### PR TITLE
Update Rancher docs to create a missing dir

### DIFF
--- a/docs/rancher.md
+++ b/docs/rancher.md
@@ -151,6 +151,7 @@ sudo mkdir -p /opt/sbin
 curl -sSLf https://github.com/topolvm/topolvm/releases/download/v${TOPOLVM_VERSION}/lvmd-${TOPOLVM_VERSION}.tar.gz | sudo tar xzf - -C /opt/sbin
 
 # Put configuration file
+sudo mkdir -p /etc/topolvm
 sudo curl -sSL -o /etc/topolvm/lvmd.yaml https://raw.githubusercontent.com/topolvm/topolvm/v${TOPOLVM_VERSION}/deploy/lvmd-config/lvmd.yaml
 
 # Register service
@@ -169,6 +170,7 @@ sudo mkdir -p /opt/sbin
 curl -sSLf https://github.com/topolvm/topolvm/releases/download/v${TOPOLVM_VERSION}/lvmd-${TOPOLVM_VERSION}.tar.gz | sudo tar xzf - -C /opt/sbin
 
 # Put configuration file
+sudo mkdir -p /etc/topolvm
 sudo curl -sSL -o /etc/topolvm/lvmd.yaml https://raw.githubusercontent.com/topolvm/topolvm/v${TOPOLVM_VERSION}/deploy/lvmd-config/lvmd.yaml
 
 # Register service


### PR DESCRIPTION
The curl command fails with `curl: (23) Failed writing body (0 != 125)`
if `/etc/topolvm` does not exist, which is not very explicit.
Let's create this directory before running the command.