### PR TITLE
Add support to run example on Vagrant

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -29,6 +29,7 @@ endif
 GO_FILES := $(shell find .. -path ../vendor -prune -o -path ../e2e -prune -o -name '*.go' -print)
 CA_FILES=./certs/ca.csr ./certs/ca.pem ./certs/ca-key.pem
 SERVER_CERT_FILES=./certs/server.csr ./certs/server.pem ./certs/server-key.pem
+BACKING_STORE=./build
 
 $(KUBECTL):
 	$(SUDO) curl -sfL https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl -o $(KUBECTL)
@@ -71,28 +72,28 @@ shutdown-kind:
 start-lvmd:
 	mkdir -p build /tmp/build
 	go build -o build/lvmd ../pkg/lvmd
-	if [ -f /tmp/build/backing_store* ]; then $(MAKE) stop-lvmd; fi
+	if [ -f $(BACKING_STORE)/backing_store* ]; then $(MAKE) stop-lvmd; fi
 
 	for i in $$(seq 3); do \
 		mkdir -p /tmp/topolvm/worker$$i; \
 		mkdir -p /tmp/topolvm/lvmd$$i; \
-		truncate --size=20G /tmp/build/backing_store$${i}_1; \
-		$(SUDO) losetup -f /tmp/build/backing_store$${i}_1; \
-		$(SUDO) vgcreate -y node$${i}-myvg1 $$($(SUDO) losetup -j /tmp/build/backing_store$${i}_1 | cut -d: -f1); \
+		truncate --size=20G $(BACKING_STORE)/backing_store$${i}_1; \
+		$(SUDO) losetup -f $(BACKING_STORE)/backing_store$${i}_1; \
+		$(SUDO) vgcreate -y node$${i}-myvg1 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_1 | cut -d: -f1); \
 		$(SUDO) lvcreate -y -n csi-node-test-block -L 1G node$${i}-myvg1; \
 		$(SUDO) lvcreate -y -n csi-node-test-fs -L 1G node$${i}-myvg1; \
 	done
 
 	# Create additional Volume Groups
-	truncate --size=10G /tmp/build/backing_store1_2; \
-	$(SUDO) losetup -f /tmp/build/backing_store1_2; \
-	$(SUDO) vgcreate -y node1-myvg2 $$($(SUDO) losetup -j /tmp/build/backing_store1_2 | cut -d: -f1); \
-	truncate --size=10G /tmp/build/backing_store2_2; \
-	$(SUDO) losetup -f /tmp/build/backing_store2_2; \
-	$(SUDO) vgcreate -y node2-myvg2 $$($(SUDO) losetup -j /tmp/build/backing_store2_2 | cut -d: -f1); \
-	truncate --size=10G /tmp/build/backing_store3_3; \
-	$(SUDO) losetup -f /tmp/build/backing_store3_3; \
-	$(SUDO) vgcreate -y node3-myvg3 $$($(SUDO) losetup -j /tmp/build/backing_store3_3 | cut -d: -f1); \
+	truncate --size=10G $(BACKING_STORE)/backing_store1_2; \
+	$(SUDO) losetup -f $(BACKING_STORE)/backing_store1_2; \
+	$(SUDO) vgcreate -y node1-myvg2 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store1_2 | cut -d: -f1); \
+	truncate --size=10G $(BACKING_STORE)/backing_store2_2; \
+	$(SUDO) losetup -f $(BACKING_STORE)/backing_store2_2; \
+	$(SUDO) vgcreate -y node2-myvg2 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store2_2 | cut -d: -f1); \
+	truncate --size=10G $(BACKING_STORE)/backing_store3_3; \
+	$(SUDO) losetup -f $(BACKING_STORE)/backing_store3_3; \
+	$(SUDO) vgcreate -y node3-myvg3 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store3_3 | cut -d: -f1); \
 
 	for i in $$(seq 3); do \
 		$(SUDO) systemd-run --unit=lvmd$$i.service $(shell pwd)/build/lvmd --config=$(shell pwd)/lvmd$$i.yaml; \
@@ -103,11 +104,11 @@ stop-lvmd:
 	for i in $$(seq 3); do \
 		if systemctl is-active -q lvmd$$i.service; then $(SUDO) systemctl stop lvmd$$i.service; fi; \
 		for j in $$(seq 3); do \
-			if [ -f /tmp/build/backing_store$${i}_$${j} ]; then \
+			if [ -f $(BACKING_STORE)/backing_store$${i}_$${j} ]; then \
 				$(SUDO) vgremove -ffy node$${i}-myvg$${j}; \
-				$(SUDO) pvremove -ffy $$($(SUDO) losetup -j /tmp/build/backing_store$${i}_$${j} | cut -d: -f1); \
-				$(SUDO) losetup -d $$($(SUDO) losetup -j /tmp/build/backing_store$${i}_$${j} | cut -d: -f1); \
-				rm -f /tmp/build/backing_store$${i}_$${j}; \
+				$(SUDO) pvremove -ffy $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_$${j} | cut -d: -f1); \
+				$(SUDO) losetup -d $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_$${j} | cut -d: -f1); \
+				rm -f $(BACKING_STORE)/backing_store$${i}_$${j}; \
 			fi; \
 		done; \
 	done

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -80,7 +80,7 @@ shutdown-kind:
 	for d in $$(mount | grep /lib/kubelet | cut -d ' ' -f 3); do $(SUDO) umount $$d; done
 
 start-lvmd:
-	mkdir -p build /tmp/build
+	mkdir -p build $(BACKING_STORE)
 	go build -o build/lvmd ../pkg/lvmd
 	if [ -f $(BACKING_STORE)/backing_store* ]; then $(MAKE) stop-lvmd; fi
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -144,6 +144,6 @@ setup: $(KUBECTL)
 	fi
 
 clean: stop-lvmd
-	rm -rf $(CA_FILES) $(SERVER_CERT_FILES) topolvm.img build/ /tmp/build
+	rm -rf $(CA_FILES) $(SERVER_CERT_FILES) topolvm.img build/ $(BACKING_STORE)/backing_store*
 
 .PHONY: launch-kind shutdown-kind start-lvmd stop-lvmd test setup clean

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -69,30 +69,30 @@ shutdown-kind:
 	for d in $$(mount | grep /lib/kubelet | cut -d ' ' -f 3); do $(SUDO) umount $$d; done
 
 start-lvmd:
-	mkdir -p build
+	mkdir -p build /tmp/build
 	go build -o build/lvmd ../pkg/lvmd
-	if [ -f build/backing_store* ]; then $(MAKE) stop-lvmd; fi
+	if [ -f /tmp/build/backing_store* ]; then $(MAKE) stop-lvmd; fi
 
 	for i in $$(seq 3); do \
 		mkdir -p /tmp/topolvm/worker$$i; \
 		mkdir -p /tmp/topolvm/lvmd$$i; \
-		truncate --size=20G build/backing_store$${i}_1; \
-		$(SUDO) losetup -f build/backing_store$${i}_1; \
-		$(SUDO) vgcreate -y node$${i}-myvg1 $$($(SUDO) losetup -j build/backing_store$${i}_1 | cut -d: -f1); \
+		truncate --size=20G /tmp/build/backing_store$${i}_1; \
+		$(SUDO) losetup -f /tmp/build/backing_store$${i}_1; \
+		$(SUDO) vgcreate -y node$${i}-myvg1 $$($(SUDO) losetup -j /tmp/build/backing_store$${i}_1 | cut -d: -f1); \
 		$(SUDO) lvcreate -y -n csi-node-test-block -L 1G node$${i}-myvg1; \
 		$(SUDO) lvcreate -y -n csi-node-test-fs -L 1G node$${i}-myvg1; \
 	done
 
 	# Create additional Volume Groups
-	truncate --size=10G build/backing_store1_2; \
-	$(SUDO) losetup -f build/backing_store1_2; \
-	$(SUDO) vgcreate -y node1-myvg2 $$($(SUDO) losetup -j build/backing_store1_2 | cut -d: -f1); \
-	truncate --size=10G build/backing_store2_2; \
-	$(SUDO) losetup -f build/backing_store2_2; \
-	$(SUDO) vgcreate -y node2-myvg2 $$($(SUDO) losetup -j build/backing_store2_2 | cut -d: -f1); \
-	truncate --size=10G build/backing_store3_3; \
-	$(SUDO) losetup -f build/backing_store3_3; \
-	$(SUDO) vgcreate -y node3-myvg3 $$($(SUDO) losetup -j build/backing_store3_3 | cut -d: -f1); \
+	truncate --size=10G /tmp/build/backing_store1_2; \
+	$(SUDO) losetup -f /tmp/build/backing_store1_2; \
+	$(SUDO) vgcreate -y node1-myvg2 $$($(SUDO) losetup -j /tmp/build/backing_store1_2 | cut -d: -f1); \
+	truncate --size=10G /tmp/build/backing_store2_2; \
+	$(SUDO) losetup -f /tmp/build/backing_store2_2; \
+	$(SUDO) vgcreate -y node2-myvg2 $$($(SUDO) losetup -j /tmp/build/backing_store2_2 | cut -d: -f1); \
+	truncate --size=10G /tmp/build/backing_store3_3; \
+	$(SUDO) losetup -f /tmp/build/backing_store3_3; \
+	$(SUDO) vgcreate -y node3-myvg3 $$($(SUDO) losetup -j /tmp/build/backing_store3_3 | cut -d: -f1); \
 
 	for i in $$(seq 3); do \
 		$(SUDO) systemd-run --unit=lvmd$$i.service $(shell pwd)/build/lvmd --config=$(shell pwd)/lvmd$$i.yaml; \
@@ -103,11 +103,11 @@ stop-lvmd:
 	for i in $$(seq 3); do \
 		if systemctl is-active -q lvmd$$i.service; then $(SUDO) systemctl stop lvmd$$i.service; fi; \
 		for j in $$(seq 3); do \
-			if [ -f build/backing_store$${i}_$${j} ]; then \
+			if [ -f /tmp/build/backing_store$${i}_$${j} ]; then \
 				$(SUDO) vgremove -ffy node$${i}-myvg$${j}; \
-				$(SUDO) pvremove -ffy $$($(SUDO) losetup -j build/backing_store$${i}_$${j} | cut -d: -f1); \
-				$(SUDO) losetup -d $$($(SUDO) losetup -j build/backing_store$${i}_$${j} | cut -d: -f1); \
-				rm -f build/backing_store$${i}_$${j}; \
+				$(SUDO) pvremove -ffy $$($(SUDO) losetup -j /tmp/build/backing_store$${i}_$${j} | cut -d: -f1); \
+				$(SUDO) losetup -d $$($(SUDO) losetup -j /tmp/build/backing_store$${i}_$${j} | cut -d: -f1); \
+				rm -f /tmp/build/backing_store$${i}_$${j}; \
 			fi; \
 		done; \
 	done
@@ -143,6 +143,6 @@ setup: $(KUBECTL)
 	fi
 
 clean: stop-lvmd
-	rm -rf $(CA_FILES) $(SERVER_CERT_FILES) topolvm.img build/
+	rm -rf $(CA_FILES) $(SERVER_CERT_FILES) topolvm.img build/ /tmp/build
 
 .PHONY: launch-kind shutdown-kind start-lvmd stop-lvmd test setup clean

--- a/example/Makefile
+++ b/example/Makefile
@@ -11,7 +11,7 @@ KIND_CLUSTER_NAME=topolvm-example
 GO_FILES := $(shell find .. -path ../vendor -prune -o -path ../e2e -prune -o -name '*.go' -print)
 CA_FILES=./build/certs/ca.csr ./build/certs/ca.pem ./build/certs/ca-key.pem
 SERVER_CERT_FILES=./build/certs/server.csr ./build/certs/server.pem ./build/certs/server-key.pem
-BACKING_STORE=/tmp/backing_store
+BACKING_STORE=./build
 
 $(KUBECTL):
 	$(SUDO) curl -sfL https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl -o $(KUBECTL)
@@ -70,22 +70,22 @@ shutdown-kind:
 
 start-lvmd: /tmp/topolvm/lvmd/lvmd.yaml
 	go build -o build/lvmd ../pkg/lvmd
-	if [ -f $(BACKING_STORE) ]; then $(MAKE) stop-lvmd; fi; \
+	if [ -f $(BACKING_STORE)/backing_store ]; then $(MAKE) stop-lvmd; fi; \
 	mkdir -p /tmp/topolvm/worker; \
 	mkdir -p /tmp/topolvm/lvmd; \
-	truncate --size=20G $(BACKING_STORE); \
-	$(SUDO) losetup -f $(BACKING_STORE); \
-	$(SUDO) vgcreate -f -y myvg1 $$($(SUDO) losetup -j $(BACKING_STORE) | cut -d: -f1); \
+	truncate --size=20G $(BACKING_STORE)/backing_store; \
+	$(SUDO) losetup -f $(BACKING_STORE)/backing_store; \
+	$(SUDO) vgcreate -f -y myvg1 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store | cut -d: -f1); \
 	$(SUDO) systemd-run --unit=lvmd.service $(shell pwd)/build/lvmd --config=/tmp/topolvm/lvmd/lvmd.yaml; \
 
 stop-lvmd:
 	$(MAKE) shutdown-kind
 	if systemctl is-active -q lvmd.service; then $(SUDO) systemctl stop lvmd.service; fi; \
-	if [ -f $(BACKING_STORE) ]; then \
+	if [ -f $(BACKING_STORE)/backing_store ]; then \
 		$(SUDO) vgremove -ffy myvg1; \
-		$(SUDO) pvremove -ffy $$($(SUDO) losetup -j $(BACKING_STORE) | cut -d: -f1); \
-		$(SUDO) losetup -d $$($(SUDO) losetup -j $(BACKING_STORE) | cut -d: -f1); \
-		rm -f $(BACKING_STORE); \
+		$(SUDO) pvremove -ffy $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store | cut -d: -f1); \
+		$(SUDO) losetup -d $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store | cut -d: -f1); \
+		rm -f $(BACKING_STORE)/backing_store; \
 	fi; \
 
 $(CA_FILES): ./certs/csr.json

--- a/example/Makefile
+++ b/example/Makefile
@@ -11,6 +11,7 @@ KIND_CLUSTER_NAME=topolvm-example
 GO_FILES := $(shell find .. -path ../vendor -prune -o -path ../e2e -prune -o -name '*.go' -print)
 CA_FILES=./build/certs/ca.csr ./build/certs/ca.pem ./build/certs/ca-key.pem
 SERVER_CERT_FILES=./build/certs/server.csr ./build/certs/server.pem ./build/certs/server-key.pem
+BACKING_STORE=/tmp/backing_store
 
 $(KUBECTL):
 	$(SUDO) curl -sfL https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl -o $(KUBECTL)
@@ -69,22 +70,22 @@ shutdown-kind:
 
 start-lvmd: /tmp/topolvm/lvmd/lvmd.yaml
 	go build -o build/lvmd ../pkg/lvmd
-	if [ -f build/backing_store ]; then $(MAKE) stop-lvmd; fi
+	if [ -f $(BACKING_STORE) ]; then $(MAKE) stop-lvmd; fi; \
 	mkdir -p /tmp/topolvm/worker; \
 	mkdir -p /tmp/topolvm/lvmd; \
-	truncate --size=20G build/backing_store; \
-	$(SUDO) losetup -f build/backing_store; \
-	$(SUDO) vgcreate -y myvg1 $$($(SUDO) losetup -j build/backing_store | cut -d: -f1); \
+	truncate --size=20G $(BACKING_STORE); \
+	$(SUDO) losetup -f $(BACKING_STORE); \
+	$(SUDO) vgcreate -f -y myvg1 $$($(SUDO) losetup -j $(BACKING_STORE) | cut -d: -f1); \
 	$(SUDO) systemd-run --unit=lvmd.service $(shell pwd)/build/lvmd --config=/tmp/topolvm/lvmd/lvmd.yaml; \
 
 stop-lvmd:
 	$(MAKE) shutdown-kind
 	if systemctl is-active -q lvmd.service; then $(SUDO) systemctl stop lvmd.service; fi; \
-	if [ -f build/backing_store ]; then \
+	if [ -f $(BACKING_STORE) ]; then \
 		$(SUDO) vgremove -ffy myvg1; \
-		$(SUDO) pvremove -ffy $$($(SUDO) losetup -j build/backing_store | cut -d: -f1); \
-		$(SUDO) losetup -d $$($(SUDO) losetup -j build/backing_store | cut -d: -f1); \
-		rm -f build/backing_store; \
+		$(SUDO) pvremove -ffy $$($(SUDO) losetup -j $(BACKING_STORE) | cut -d: -f1); \
+		$(SUDO) losetup -d $$($(SUDO) losetup -j $(BACKING_STORE) | cut -d: -f1); \
+		rm -f $(BACKING_STORE); \
 	fi; \
 
 $(CA_FILES): ./certs/csr.json

--- a/example/README.md
+++ b/example/README.md
@@ -33,7 +33,13 @@ To stop the demonstration environment, run:
 $ make clean
 ```
 
-If you're not on a Linux machine, we ship a _Vagrantfile_ which sets up a Linux VM using [Vagrant](https://www.vagrantup.com/). Once Vagrant is setup, bring your VM up by running:
+If you're not on a Linux machine, we ship a _Vagrantfile_ which sets up a Linux VM using [Vagrant](https://www.vagrantup.com/).
+It requires [VirtualBox](https://www.virtualbox.org/) and the [vagrant-disksize](https://github.com/sprotheroe/vagrant-disksize) plugin.
+Once Vagrant is setup, add the _vagrant-disksize_ plugin:
+```console
+$ vagrant plugin install vagrant-disksize
+```
+and bring your VM up
 ```console
 $ vagrant up
 $ vagrant ssh

--- a/example/README.md
+++ b/example/README.md
@@ -45,6 +45,12 @@ $ vagrant up
 $ vagrant ssh
 $ cd /vagrant/example
 ```
+Next, run the example as suggested. However, as Vagrant shares the host directory with the virtual machine, you need to specify where the
+your volume will be created. In order to do it, just override the `BACKING_STORE` variable. For example:
+```
+$ make setup
+$ make BACKING_STORE=/tmp run
+```
 Next, follow the steps previously highlighted. Once you're done with your demonstration environment, logout from your VM and run:
 ```console
 $ vagrant destroy

--- a/example/README.md
+++ b/example/README.md
@@ -32,3 +32,15 @@ To stop the demonstration environment, run:
 ```console
 $ make clean
 ```
+
+If you're not on a Linux machine, we ship a _Vagrantfile_ which sets up a Linux VM using [Vagrant](https://www.vagrantup.com/). Once Vagrant is setup, bring your VM up by running:
+```console
+$ vagrant up
+$ vagrant ssh
+$ cd /vagrant/example
+```
+Next, follow the steps previously highlighted. Once you're done with your demonstration environment, logout from your VM and run:
+```console
+$ vagrant destroy
+```
+to clean up your environment.

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+ config.vm.box = "ubuntu/xenial64"
+
+ config.vm.provider "virtualbox" do |vb|
+     vb.memory = (1024 * 5).to_s # make sure there's enough memory for all components
+     vb.cpus = 2
+ end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update && sudo apt-get install -y apt-transport-https curl ca-certificates curl gnupg-agent software-properties-common make gcc
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    sudo add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) \
+      stable"
+    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+    sudo echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+    sudo apt-get update
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+    systemctl daemon-reload
+    echo "Allowing docker as a non-root"
+    sudo usermod -aG docker vagrant && newgrp docker
+    wget -q https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
+      sudo tar xzf go1.13.3.linux-amd64.tar.gz -C /usr/local
+    echo "export PATH=$PATH:/usr/local/go/bin:/home/vagrant/go/bin" > /etc/profile.d/gopath.sh
+  SHELL
+end

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -2,29 +2,23 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
- config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
+  config.disksize.size = '50GB'
 
- config.vm.provider "virtualbox" do |vb|
-     vb.memory = (1024 * 5).to_s # make sure there's enough memory for all components
+  config.vm.provider "virtualbox" do |vb|
+     vb.memory = (1024 * 6).to_s # make sure there's enough memory for all components
      vb.cpus = 2
- end
-
+  end
+  
+  config.vm.synced_folder "../", "/vagrant"
   config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get update && sudo apt-get install -y apt-transport-https curl ca-certificates curl gnupg-agent software-properties-common make gcc
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    sudo add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) \
-      stable"
-    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-    sudo echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
-    sudo apt-get update
-    sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-    systemctl daemon-reload
+    apt-get update && apt-get install -y \
+       apt-transport-https curl ca-certificates \
+       curl gnupg-agent software-properties-common \
+       make gcc jq docker.io 
     echo "Allowing docker as a non-root"
-    sudo usermod -aG docker vagrant && newgrp docker
-    wget -q https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && \
-      sudo tar xzf go1.13.3.linux-amd64.tar.gz -C /usr/local
-    echo "export PATH=$PATH:/usr/local/go/bin:/home/vagrant/go/bin" > /etc/profile.d/gopath.sh
+    usermod -aG docker vagrant && newgrp docker
+    snap install --channel=1.13/stable --classic go
+    echo "export PATH=$PATH:/home/vagrant/go/bin" > /etc/profile.d/gopath.sh
   SHELL
 end


### PR DESCRIPTION
This PR adds support to run the example, e2e, using Vagrant. This is useful for those not running on Linux with no LVM support.