### PR TITLE
e2e: add log for inline ephemeral volumes test

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1140,6 +1140,11 @@ func countLVMs() (int, error) {
 	if err != nil {
 		return -1, fmt.Errorf("failed to lvs. stdout %s, err %v", stdout, err)
 	}
+	/// XXX log for inline ephemeral volumes test
+	os.Stdout.WriteString("lvs command result:\n----\n")
+	os.Stdout.Write(stdout)
+	os.Stdout.WriteString("----\n")
+	///
 	return bytes.Count(stdout, []byte("\n")), nil
 }
 


### PR DESCRIPTION
The test https://github.com/topolvm/topolvm/blob/master/e2e/e2e_test.go#L781 sometimes fails. Add log to investigate this issue.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>