### PR TITLE
Change e2e test names 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        test_kubernetes_version: [1.17, 1.16, 1.15]
+        test_kubernetes_target: [current, prev, prev2]
     env:
-      TEST_KUBERNETES_VERSION: ${{ matrix.test_kubernetes_version }}
+      TEST_KUBERNETES_TARGET: ${{ matrix.test_kubernetes_target }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -11,6 +11,7 @@ KIND_CLUSTER_NAME=topolvm-e2e
 # If you want to change the Kubernetes version for e2e test, specify this variable from command line.
 # e.g. $ make TEST_KUBERNETES_VERSION=1.17 setup test
 TEST_KUBERNETES_VERSION?=1.17
+export TEST_KUBERNETES_VERSION
 
 ifeq ($(TEST_KUBERNETES_VERSION),1.17)
 KUBERNETES_VERSION=1.17.2

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -8,9 +8,18 @@ KUSTOMIZE_VERSION=3.5.4
 KUSTOMIZE=/usr/local/bin/kustomize
 KIND_CLUSTER_NAME=topolvm-e2e
 
+ifeq ($(TEST_KUBERNETES_TARGET),current)
+TEST_KUBERNETES_VERSION=1.17
+else ifeq ($(TEST_KUBERNETES_TARGET),prev)
+TEST_KUBERNETES_VERSION=1.16
+else ifeq ($(TEST_KUBERNETES_TARGET),prev2)
+TEST_KUBERNETES_VERSION=1.15
+else
 # If you want to change the Kubernetes version for e2e test, specify this variable from command line.
 # e.g. $ make TEST_KUBERNETES_VERSION=1.17 setup test
 TEST_KUBERNETES_VERSION?=1.17
+endif
+
 export TEST_KUBERNETES_VERSION
 
 ifeq ($(TEST_KUBERNETES_VERSION),1.17)


### PR DESCRIPTION
This PR solves two issues on e2e test.

- In https://github.com/topolvm/topolvm/blob/73aa20d57d582aba4c041d23e7d56210c2796af9/e2e/hook_test.go#L167 , `TEST_KUBERNETES_VERSION` is used as environment variable. Makefile defines `TEST_KUBERNETES_VERSION` with default value if it doesn't exist, but doesn't export it. It is incomplete.

- Required tests to merge are named as `build`, `e2e-k8s (1.17)`, `e2e-k8s (1.16)`, `e2e-k8s (1.15)`. Since this requires change of project settings on every k8s version update, this PR makes use of fixed test names.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>