### PR TITLE
Add test after each tests finishes  to confirm nodes are cleaned up

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1217,6 +1217,7 @@ func getNodeAnnotationMapWithPrefix(prefix string) (map[string]map[string]string
 			continue
 		}
 
+		capacities[node.Name] = make(map[string]string)
 		for k, v := range node.Annotations {
 			if !strings.HasPrefix(k, prefix) {
 				continue

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -50,10 +50,14 @@ func testE2E() {
 				}
 
 				stdout, stderr, err := kubectl("get", "node", "-o", "json")
-				Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+				if err != nil {
+					return fmt.Errorf("stdout=%s, stderr=%s", stdout, stderr)
+				}
 
 				capacitiesAfter, err := getNodeAnnotationMapWithPrefix(topolvm.CapacityKeyPrefix)
-				Expect(err).ShouldNot(HaveOccurred())
+				if err != nil {
+					return err
+				}
 				if diff := cmp.Diff(capacitiesBefore, capacitiesAfter); diff != "" {
 					return fmt.Errorf("capacities on nodes should be same before and after the test: diff=%q", diff)
 				}

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -2,8 +2,20 @@ package e2e
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/topolvm/topolvm"
 )
+
+type CleanupContext struct {
+	LvmCount            int
+	CapacityAnnotations map[string]map[string]string
+}
 
 func execAtLocal(cmd string, input []byte, args ...string) ([]byte, []byte, error) {
 	var stdout, stderr bytes.Buffer
@@ -34,4 +46,45 @@ func containString(s []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func commonBeforeEach() CleanupContext {
+	var cc CleanupContext
+	var err error
+
+	cc.LvmCount, err = countLVMs()
+	Expect(err).ShouldNot(HaveOccurred())
+
+	cc.CapacityAnnotations, err = getNodeAnnotationMapWithPrefix(topolvm.CapacityKeyPrefix)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return cc
+}
+
+func commonAfterEach(cc CleanupContext) {
+	if !CurrentGinkgoTestDescription().Failed {
+		Eventually(func() error {
+			lvmCountAfter, err := countLVMs()
+			if err != nil {
+				return err
+			}
+			if cc.LvmCount != lvmCountAfter {
+				return fmt.Errorf("lvm num mismatched. before: %d, after: %d", cc.LvmCount, lvmCountAfter)
+			}
+
+			stdout, stderr, err := kubectl("get", "node", "-o", "json")
+			if err != nil {
+				return fmt.Errorf("stdout=%s, stderr=%s", stdout, stderr)
+			}
+
+			capacitiesAfter, err := getNodeAnnotationMapWithPrefix(topolvm.CapacityKeyPrefix)
+			if err != nil {
+				return err
+			}
+			if diff := cmp.Diff(cc.CapacityAnnotations, capacitiesAfter); diff != "" {
+				return fmt.Errorf("capacities on nodes should be same before and after the test: diff=%q", diff)
+			}
+			return nil
+		}).Should(Succeed())
+	}
 }

--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -53,17 +53,17 @@ func commonBeforeEach() CleanupContext {
 	var err error
 
 	cc.LvmCount, err = countLVMs()
-	Expect(err).ShouldNot(HaveOccurred())
+	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
 
 	cc.CapacityAnnotations, err = getNodeAnnotationMapWithPrefix(topolvm.CapacityKeyPrefix)
-	Expect(err).ShouldNot(HaveOccurred())
+	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
 
 	return cc
 }
 
 func commonAfterEach(cc CleanupContext) {
 	if !CurrentGinkgoTestDescription().Failed {
-		Eventually(func() error {
+		EventuallyWithOffset(1, func() error {
 			lvmCountAfter, err := countLVMs()
 			if err != nil {
 				return err

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/golang/protobuf v1.3.4
 	github.com/google/certificate-transparency-go v1.1.0 // indirect
+	github.com/google/go-cmp v0.3.0
 	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548 // indirect
 	github.com/jmoiron/sqlx v1.2.0 // indirect
 	github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49 // indirect


### PR DESCRIPTION
The e2e test sometimes fails because it does not wait until LVs are deleted and the annotations are reverted to the original state.
This PR fixes the issue.
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>