### PR TITLE
kustomize: replace imageTags with images

### DIFF
--- a/deploy/manifests/overlays/daemonset-scheduler/kustomization.yaml
+++ b/deploy/manifests/overlays/daemonset-scheduler/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - scheduler.yaml
-imageTags:
+images:
   - name: quay.io/topolvm/topolvm
     newTag: 0.5.3

--- a/deploy/manifests/overlays/deployment-scheduler/kustomization.yaml
+++ b/deploy/manifests/overlays/deployment-scheduler/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - scheduler.yaml
-imageTags:
+images:
   - name: quay.io/topolvm/topolvm
     newTag: 0.5.3


### PR DESCRIPTION
because imageTags was replaced with images as of kustomize 2.0.0.

https://kubernetes-sigs.github.io/kustomize/blog/2019/02/05/v2.0.0/#imagetags