### PR TITLE
lvmd: fix #201

### DIFF
--- a/pkg/lvmd/cmd/root.go
+++ b/pkg/lvmd/cmd/root.go
@@ -141,5 +141,5 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&cfgFilePath, "config", filepath.Join("etc", "topolvm", "lvmd.yaml"), "config file")
+	rootCmd.PersistentFlags().StringVar(&cfgFilePath, "config", filepath.Join("/etc", "topolvm", "lvmd.yaml"), "config file")
 }


### PR DESCRIPTION
The default configuration file path was relative since its inception (#147).

Fix #201