### PR TITLE
Multi architecture support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-*
-!build
-!LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Container
 FROM golang:buster AS build-env
 
-ADD . /workdir
+COPY . /workdir
 WORKDIR /workdir
 
 RUN make build
@@ -25,11 +25,11 @@ RUN ln -s hypertopolvm /lvmd \
     && ln -s hypertopolvm /topolvm-controller
 
 # CSI sidecar
-COPY build/csi-provisioner /csi-provisioner
-COPY build/csi-node-driver-registrar /csi-node-driver-registrar
-COPY build/csi-attacher /csi-attacher
-COPY build/csi-resizer /csi-resizer
-COPY build/livenessprobe /livenessprobe
-COPY LICENSE /LICENSE
+COPY --from=build-env /workdir/build/csi-provisioner /csi-provisioner
+COPY --from=build-env /workdir/build/csi-node-driver-registrar /csi-node-driver-registrar
+COPY --from=build-env /workdir/build/csi-attacher /csi-attacher
+COPY --from=build-env /workdir/build/csi-resizer /csi-resizer
+COPY --from=build-env /workdir/build/livenessprobe /livenessprobe
+COPY --from=build-env /workdir/LICENSE /LICENSE
 
 ENTRYPOINT ["/hypertopolvm"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+# Build Container
+FROM golang:buster AS build-env
+
+ADD . /workdir
+WORKDIR /workdir
+
+RUN make build
+
 # TopoLVM container
 FROM ubuntu:18.04
 
@@ -9,7 +17,8 @@ RUN apt-get update \
         xfsprogs \
     && rm -rf /var/lib/apt/lists/*
 
-COPY build/hypertopolvm /hypertopolvm
+COPY --from=build-env /workdir/build/hypertopolvm /hypertopolvm
+
 RUN ln -s hypertopolvm /lvmd \
     && ln -s hypertopolvm /topolvm-scheduler \
     && ln -s hypertopolvm /topolvm-node \

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ export GO111MODULE GOFLAGS KUBEBUILDER_ASSETS
 BUILD_TARGET=hypertopolvm
 TOPOLVM_VERSION ?= devel
 IMAGE_TAG ?= latest
+DOCKER_USER ?= PLEASE_SPECIFY_DOCKER_USER
 
 csi.proto:
 	$(CURL) -o $@ https://raw.githubusercontent.com/container-storage-interface/spec/v$(CSI_VERSION)/csi.proto
@@ -104,6 +105,11 @@ csi-sidecars:
 .PHONY: image
 image:
 	docker build -t $(IMAGE_PREFIX)topolvm:devel .
+
+.PHONY: image-multiarch
+image-multiarch:
+	# You have to --push flag to pushing build to registry because local dockerd can't store another architecture images and built image not stored to local dockerd.
+	docker buildx build -t $(DOCKER_USER)/topolvm:0.0.1 --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7 --push .
 
 .PHONY: tag
 tag:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ export GO111MODULE GOFLAGS KUBEBUILDER_ASSETS
 BUILD_TARGET=hypertopolvm
 TOPOLVM_VERSION ?= devel
 IMAGE_TAG ?= latest
-DOCKER_USER ?= PLEASE_SPECIFY_DOCKER_USER
 
 csi.proto:
 	$(CURL) -o $@ https://raw.githubusercontent.com/container-storage-interface/spec/v$(CSI_VERSION)/csi.proto
@@ -108,8 +107,8 @@ image:
 
 .PHONY: image-multiarch
 image-multiarch:
-	# You have to --push flag to pushing build to registry because local dockerd can't store another architecture images and built image not stored to local dockerd.
-	docker buildx build -t $(DOCKER_USER)/topolvm:0.0.1 --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7 --push .
+	# You have to use --push flag to push build to registry because local dockerd can't store another architecture images and built image not stored to local dockerd.
+	docker buildx build -t $(IMAGE_PREFIX)/topolvm:$(IMAGE_TAG) --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7 --push .
 
 .PHONY: tag
 tag:


### PR DESCRIPTION
# What

Support bulding multi architecture docker image with docker buildx.

# Build(e.x.)

```
docker buildx create --name mybuilder
docker buildx use mybuilder
IMAGE_PREFIX=onokatio2 IMAGE_TAG=0.6.0 make image-multiarch
```

https://hub.docker.com/repository/docker/onokatio2/topolvm/

# Status

Architecture:
- amd64
- arm64
- arm v7
- powerpc 64

# Depends
#215 