### PR TITLE
Support build with dockerx in Makefile

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.13
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
       - run: make setup
       - run: make check-uncommitted
       - run: make test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,19 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.13
+      - run: make setup
+      - run: make check-uncommitted
+      - run: make test
+      - run: sudo -E env PATH=${PATH} go test -mod=vendor -race -v ./lvmd ./driver ./filesystem
+      - run: make image
+  build-multiarch:
+    name: build mulch architecture images
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - run: make setup

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - run: make check-uncommitted
       - run: make test
       - run: sudo -E env PATH=${PATH} go test -mod=vendor -race -v ./lvmd ./driver ./filesystem
-      - run: make image
+      - run: make image-multiarch
   e2e-k8s:
     name: e2e-k8s
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
       - run: sudo -E env PATH=${PATH} go test -mod=vendor -race -v ./lvmd ./driver ./filesystem
       - run: make image
   build-multiarch:
-    name: build mulch architecture images
+    name: build multi architecture images
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ steps.check_version.outputs.prerelease == 'false' }}
         run: |
           BRANCH=$(echo ${{ steps.check_version.outputs.version }} | cut -d "." -f 1-2)
-          make tag push IMAGE_TAG=$BRANCH
+          make image-multiarch-push TOPOLVM_VERSION=${{ steps.check_version.outputs.version }} IMAGE_TAG=$BRANCH
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.13
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
       - run: make setup
       - run: make build/lvmd TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
       - run: tar czf lvmd-${{ steps.check_version.outputs.version }}.tar.gz -C ./build lvmd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,7 @@ jobs:
       - run: make setup
       - run: make build/lvmd TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
       - run: tar czf lvmd-${{ steps.check_version.outputs.version }}.tar.gz -C ./build lvmd
-      - run: make image TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
-      - run: make tag push IMAGE_TAG=${{ steps.check_version.outputs.version }}
+      - run: make image-multiarch-push TOPOLVM_VERSION=${{ steps.check_version.outputs.version }} IMAGE_TAG=${{ steps.check_version.outputs.version }}
       - name: Push branch tag
         if: ${{ steps.check_version.outputs.prerelease == 'false' }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,21 @@ csi-sidecars:
 image:
 	docker build -t $(IMAGE_PREFIX)topolvm:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) .
 
+.PHONY: image-multiarch-push
+image-multiarch-push:
+	# We have to use `docker buildx` command with --push flag to
+	# pushing build result to registry.
+	#
+	# You can't use `docker tag` and `docker push` command to image release because 
+	# local dockerd can't store another architecture images and built image by `image-multiarch` not stored to local dockerd. Only build cache remains.
+	docker buildx build -t $(IMAGE_PREFIX)topolvm:$(IMAGE_TAG) --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --platform linux/amd64,linux/arm64,linux/ppc64le --push .
+
+.PHONY: image-multiarch
+image-multiarch:
+	# Built result isn't stored to docker images. Built result only remain in the build cache.
+	# `push-image-multi` can use cache which made by `image-multiarch`.
+	docker buildx build -t $(IMAGE_PREFIX)topolvm:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --platform linux/amd64,linux/arm64,linux/ppc64le .
+
 .PHONY: tag
 tag:
 	docker tag $(IMAGE_PREFIX)topolvm:devel $(IMAGE_PREFIX)topolvm:$(IMAGE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -112,13 +112,13 @@ image-multiarch-push:
 	#
 	# We can't use `docker tag` and `docker push` command to image release because 
 	# local dockerd can't store another architecture images and built image by `image-multiarch` not stored to local dockerd. Only build cache remains.
-	docker buildx build -t $(IMAGE_PREFIX)topolvm:$(IMAGE_TAG) --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --platform linux/amd64,linux/arm64,linux/ppc64le --push .
+	docker buildx build -t $(IMAGE_PREFIX)topolvm:$(IMAGE_TAG) --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --platform linux/amd64,linux/arm64 --push .
 
 .PHONY: image-multiarch
 image-multiarch:
 	# Built result isn't stored to docker images. Built result only remain in the build cache.
 	# `push-image-multi` can use cache which made by `image-multiarch`.
-	docker buildx build -t $(IMAGE_PREFIX)topolvm:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --platform linux/amd64,linux/arm64,linux/ppc64le .
+	docker buildx build -t $(IMAGE_PREFIX)topolvm:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --platform linux/amd64,linux/arm64 .
 
 .PHONY: tag
 tag:

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ image-multiarch-push:
 	# We have to use `docker buildx` command with --push flag to
 	# pushing build result to registry.
 	#
-	# You can't use `docker tag` and `docker push` command to image release because 
+	# We can't use `docker tag` and `docker push` command to image release because 
 	# local dockerd can't store another architecture images and built image by `image-multiarch` not stored to local dockerd. Only build cache remains.
 	docker buildx build -t $(IMAGE_PREFIX)topolvm:$(IMAGE_TAG) --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --platform linux/amd64,linux/arm64,linux/ppc64le --push .
 


### PR DESCRIPTION
# What

This PR supports building multi architecture docker image.
Docker buildx command is **experimenal**. Your topolvm developers have a choice to whether merge or no.

For your information:
- https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408
- https://www.docker.com/blog/multi-arch-images/

# How to build (for example)

Before this, docker experimental flag and target QEMU command (userland mode) are needed.

```
docker buildx create --name mybuilder
docker buildx use mybuilder
make image-multiarch
```

Image example: https://hub.docker.com/repository/docker/onokatio2/topolvm/tags

# Status

Supported:
- amd64
- arm64
- powerpc 64

No supported:
- arm v7
- 386

(Because 32bit architectures are not supported in `driver/node.go` )

# Depends
#215 