### PR TITLE
Use MayRunAs instead of MustRunAs to avoid recursive chown

### DIFF
--- a/deploy/manifests/base/psp.yaml
+++ b/deploy/manifests/base/psp.yaml
@@ -48,7 +48,7 @@ spec:
     - min: 1
       max: 65535
   fsGroup:
-    rule: 'MustRunAs'
+    rule: 'MayRunAs'
     ranges:
     - min: 1
       max: 65535


### PR DESCRIPTION
Related to https://github.com/cybozu-go/neco/issues/1018
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>