### PR TITLE
Fix tests to wait until annotaion for capacity is synced with BeforeEach/AfterEach

### DIFF
--- a/e2e/hook_test.go
+++ b/e2e/hook_test.go
@@ -26,11 +26,14 @@ func hasTopoLVMFinalizer(pvc *corev1.PersistentVolumeClaim) bool {
 }
 
 func testHook() {
+	var cc CleanupContext
 	BeforeEach(func() {
 		createNamespace(nsHookTest)
+		cc = commonBeforeEach()
 	})
 	AfterEach(func() {
 		kubectl("delete", "namespaces/"+nsHookTest)
+		commonAfterEach(cc)
 	})
 
 	It("should test hooks", func() {

--- a/e2e/metrics_test.go
+++ b/e2e/metrics_test.go
@@ -52,11 +52,14 @@ spec:
 `, nsMetricsTest, nsMetricsTest))
 
 func testMetrics() {
+	var cc CleanupContext
 	BeforeEach(func() {
 		createNamespace(nsMetricsTest)
+		cc = commonBeforeEach()
 	})
 	AfterEach(func() {
 		kubectl("delete", "namespaces/"+nsMetricsTest)
+		commonAfterEach(cc)
 	})
 
 	It("should export volume metrics", func() {

--- a/e2e/node_test.go
+++ b/e2e/node_test.go
@@ -16,6 +16,14 @@ import (
 )
 
 func testNode() {
+	var cc CleanupContext
+	BeforeEach(func() {
+		cc = commonBeforeEach()
+	})
+	AfterEach(func() {
+		commonAfterEach(cc)
+	})
+
 	It("should be deployed", func() {
 		Eventually(func() error {
 			result, stderr, err := kubectl("get", "-n=topolvm-system", "pods", "--selector=app.kubernetes.io/name=node", "-o=json")

--- a/e2e/scheduler_test.go
+++ b/e2e/scheduler_test.go
@@ -11,6 +11,14 @@ import (
 )
 
 func testScheduler() {
+	var cc CleanupContext
+	BeforeEach(func() {
+		cc = commonBeforeEach()
+	})
+	AfterEach(func() {
+		commonAfterEach(cc)
+	})
+
 	testNamespacePrefix := "scheduler-test"
 
 	It("should be deployed topolvm-scheduler pod", func() {


### PR DESCRIPTION
CI gets to fail often with the following errors:
- https://github.com/topolvm/topolvm/runs/1694271458?check_suite_focus=true
- https://github.com/topolvm/topolvm/runs/1694271531?check_suite_focus=true

This is caused by not waiting for the capacity annotation to be synced after each "It" block is done.
This PR fix tests to wait until annotaion for capacity is synced in "AfterEach".
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>