### PR TITLE
force stopping kubelet to unmount lv volumes

### DIFF
--- a/e2e/cleanup_test.go
+++ b/e2e/cleanup_test.go
@@ -277,7 +277,13 @@ spec:
 
 	It("should stop undeleted container in case that the container is undeleted", func() {
 		stdout, stderr, err := execAtLocal(
-			"docker", nil, "exec", "-i", "topolvm-e2e-worker3",
+			"docker", nil, "exec", "topolvm-e2e-worker3",
+			"systemctl", "stop", "kubelet.service",
+		)
+		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+
+		stdout, stderr, err = execAtLocal(
+			"docker", nil, "exec", "topolvm-e2e-worker3",
 			"/usr/local/bin/crictl", "ps", "-o=json",
 		)
 		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
@@ -295,14 +301,12 @@ spec:
 		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s", stdout)
 
 		for _, c := range l.Containers {
-			if c.Metadata.Name == "ubuntu" {
-				stdout, stderr, err = execAtLocal(
-					"docker", nil,
-					"exec", "-i", "topolvm-e2e-worker3", "/usr/local/bin/crictl", "stop", c.ID,
-				)
-				Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
-				fmt.Printf("stop ubuntu container with id=%s\n", c.ID)
-			}
+			stdout, stderr, err = execAtLocal(
+				"docker", nil,
+				"exec", "topolvm-e2e-worker3", "/usr/local/bin/crictl", "stop", c.ID,
+			)
+			Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+			fmt.Printf("stop ubuntu container with id=%s\n", c.ID)
 		}
 	})
 


### PR DESCRIPTION
https://github.com/topolvm/topolvm/pull/242 did not fix the instability issue completely.
This PR makes the CI more stable by killing a kubelet on an undeleted node which might recover the problematic Pod after deleting it once.
Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>