### PR TITLE
Add maintenance.md for supported Kubernetes upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ clean:
 
 .PHONY: tools
 tools:
-	cd /tmp; env GO111MODULE=on go get golang.org/x/tools/cmd/goimports	
+	cd /tmp; env GO111MODULE=on go get golang.org/x/tools/cmd/goimports
 	cd /tmp; env GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck
 	cd /tmp; env GO111MODULE=on go get github.com/gordonklaus/ineffassign
 	cd /tmp; env GO111MODULE=on go get github.com/gostaticanalysis/nilerr/cmd/nilerr

--- a/csi/csi_grpc.pb.go
+++ b/csi/csi_grpc.pb.go
@@ -26,7 +26,7 @@ type identityClient struct {
 	cc grpc.ClientConnInterface
 }
 
-func NewIdentityClient(cc grpc.ClientConnInterface) IdentityClient {
+func NewIdentityClient(cc grpc.ClientConnInterface) IdentityClientIdentityClient {
 	return &identityClient{cc}
 }
 

--- a/csi/csi_grpc.pb.go
+++ b/csi/csi_grpc.pb.go
@@ -26,7 +26,7 @@ type identityClient struct {
 	cc grpc.ClientConnInterface
 }
 
-func NewIdentityClient(cc grpc.ClientConnInterface) IdentityClientIdentityClient {
+func NewIdentityClient(cc grpc.ClientConnInterface) IdentityClient {
 	return &identityClient{cc}
 }
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -10,32 +10,30 @@ so checking them together with this guide is recommended when you do this task.
 
 First of all, we should have a look at the release notes in the order below.
 
-Please clarify on the issue on GitHub what kinds of changes we find in the release note and what we are going to do and NOT going to do to address the changes.
-The format is up to you, but this is very important to keep track of what changes are made in this task, so please do not forget to do it.
-
-Basically, we should pay attention for breaking changes and security fixes first.
-If we find some interesting features added in new versions, please consider if we actually use them and make an GitHub issue to incorporate them after the upgrading task is done.
-
 1. Kubernetes
   - Choose the next version and check the [release note](https://kubernetes.io/docs/setup/release/notes/). e.g. 1.17, 1.18, 1.19 -> 1.18, 1.19, 1.20
 2. controller-runtime
   - Read the [release note](https://github.com/kubernetes-sigs/controller-runtime/releases), and check which version is compatible with the Kubernetes versions.
 3. CSI spec
   - Read the [release note](https://github.com/container-storage-interface/spec/blob/master/spec.md) and check all the changes from the current version to the latest.
-  - Basically, CSI spec should NOT be upgraded progressively in this task.
-    Upgrade the CSI version only if new features we should cover are introduced in newer versions or we have to upgrade it because Kubernetes does not support the current CSI version.
+  - Basically, CSI spec should NOT be upgraded aggressively in this task.
+    Upgrade the CSI version only if new features we should cover are introduced in newer versions, or the Kubernetes versions TopoLVM is going to support does not support the current CSI version.
 4. CSI sidecars
   - TopoLVM does not use all the sidecars listed [here](https://kubernetes-csi.github.io/docs/sidecar-containers.html).
-    Have a look at `csi-sidecars.mk` first and check what sidecars are actually used.
+    Have a look at `csi-sidecars.mk` first and understand what sidecars are actually being used.
   - Check the release pages of the sidecars under [kubernetes-csi](https://github.com/kubernetes-csi) one by one and choose the latest version for each sidecar which satisfies both "Minimal Kubernetes version" and "Supported CSI spec versions".
-    DO NOT follow the version compatibility tables in this [page](https://kubernetes-csi.github.io/docs/sidecar-containers.html) and the README.md files of the sidecar repositories because they are sometimes not updated properly.
+    DO NOT follow the version compatibility tables in this [page](https://kubernetes-csi.github.io/docs/sidecar-containers.html) and the README.md files in the sidecar repositories because they are sometimes not updated properly.
   - Read the change logs which are linked from the release pages.
+
+Please write down to the Github issue of this task what kinds of changes we find in the release note and what we are going to do and NOT going to do to address the changes.
+The format is up to you, but this is very important to keep track of what changes are made in this task, so please do not forget to do it.
+
+Basically, we should pay attention to breaking changes and security fixes first.
+If we find some interesting features added in new versions, please consider if we are going to use them or not and make a GitHub issue to incorporate them after the upgrading task is done.
 
 ## Update written versions
 
 Once we decide the versions we are going to upgrade, we should update the versions written in the following files manually.
-`git grep 1.18`, `git grep image:`, and `git grep VERSION` might help us avoid overlooking necessary changes.
-Please update the versions in the code and docs with great care.
 
 - `README.md`: Documentation which indicates what versions are supported by TopoLVM
 - `deploy/README.md`: Documentation which instructs how to deploy TopoLVM on various versions of Kubernetes
@@ -45,6 +43,9 @@ Please update the versions in the code and docs with great care.
 - `example/Makefile`: Makefile for running example
 - `deploy/manifests/overlays/daemonset-scheduler/kustomization.yaml`: Kustomization for overwriting the TopoLVM image version
 - `deploy/manifests/overlays/deployment-scheduler/kustomization.yaml`: Kustomization for overwriting the TopoLVM image version
+
+`git grep 1.18`, `git grep image:`, and `git grep VERSION` might help us avoid overlooking necessary changes.
+Please update the versions in the code and docs with great care.
 
 ## Update CSI spec
 
@@ -62,9 +63,10 @@ make csi/csi_grpc.pb.go
 ## Update dependencies
 
 Next, we should update `go.mod` by the following commands.
+Please note that Kubernetes v1 corresponds with v0 for the release tags. For example, v1.17.2 corresponds with the `v0.17.2` tag.
 
 ```bash
-VERSION=<upgrading Kubernetes version>
+VERSION=<upgrading Kubernetes release version>
 go get k8s.io/api@v${VERSION} k8s.io/apimachinery@v${VERSION} k8s.io/client-go@v${VERSION}
 ```
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,91 @@
+How to upgrade supported Kubernetes version
+===========================================
+
+TopoLVM depends on some Kubernetes repositories like `k8s.io/client-go` and should support 3 consecutive Kubernets versions at a time.
+Here is the guide for how to upgrade the supported versions.
+Issues and PRs related to the last upgrade task also help you understand how to upgrade the supported versions,
+so checking them besides this guide is recommended when we do this task.
+
+## Check release notes
+
+First of all, we should have a look at the release notes in the order below.
+
+Please clarify on the issue on GitHub what kinds of changes we find in the release note and what we are going to do and NOT going to do address the changes.
+The format is up to you, but this is a very important step to keep track of what changes are made, so please do not forget to do it.
+
+Basically, we should pay attention for breaking changes and security fixes first.
+If we find some interesting features added in new versions, please consider and make an GitHub issue to deal with it after the upgrading task is over.
+
+1. Kubernetes
+  - Choose the next version and check the [release note](https://kubernetes.io/docs/setup/release/notes/). e.g. 1.17, 1.18, 1.19 -> 1.18, 1.19, 1.20
+2. controller-runtime
+  - Read the [release note](https://github.com/kubernetes-sigs/controller-runtime/releases), and check which version is compatible with the Kubernetes versions.
+3. CSI spec
+  - Read the [release note](https://github.com/container-storage-interface/spec/blob/master/spec.md) and check all the changes from the current version to the latest.
+  - Basically, CSI spec should NOT be upgraded progressively in this task.
+    Upgrade the CSI version only if new features we should cover are introduced in newer versions or we have to upgrade it because Kubernetes does not support the current CSI version.
+4. CSI sidecars
+  - TopoLVM does not use all the sidecars listed [here](https://kubernetes-csi.github.io/docs/sidecar-containers.html).
+    Have a look at `csi-sidecars.mk` first and check what sidecars are actually used.
+  - Check the release pages of the sidecars under [kubernetes-csi](https://github.com/kubernetes-csi) one by one under and choose the latest versions which satisfy the minimal Kubernetes version.
+    DO NOT follow the version compatibility tables in this [page](https://kubernetes-csi.github.io/docs/sidecar-containers.html) and the README.md files of the sidecar repositories    because they are sometimes not updated properly.
+
+## Update written versions
+
+Once we decide the versions you are going to upgrade, we should update the versions written in the following files manually.
+`git grep 1.18`, `git grep image:`, and `git grep VERSION` might help you avoid overlooking the target versions.
+Please update the versions in the code and docs with great care.
+
+- `README.md`: Documentation which indicates what versions are supported by TopoLVM
+- `deploy/README.md`: Documentation which instructs how to deploy TopoLVM on various versions of Kubernetes
+- `csi-sidecars.mk`: Makefile for building CSI sidecars
+- `Makefile`: Makefile for running e2e tests
+- `e2e/Makefile`: Makefile for running e2e tests
+- `example/Makefile`: Makefile for running example
+- `deploy/manifests/overlays/daemonset-scheduler/kustomization.yaml`: Kustomization for overwriting the TopoLVM image version
+- `deploy/manifests/overlays/deployment-scheduler/kustomization.yaml`: Kustomization for overwriting the TopoLVM image version
+
+## Update CSI spec
+
+In case we update the version of the CSI spec written in `Makefile`, we should regenerate the gRPC schema with the protobuf file corresponding to the CSI spec version.
+First, we might have to upgrade the `protoc` version defined in `Makefile` with checking the Go section in [release note](https://github.com/protocolbuffers/protobuf/releases).
+Then, please execute the following commands to update the Go code.
+
+```bash
+cd ${GOPATH}/src/github.com/topolvm/topolvm
+make setup
+make csi/csi.pb.go
+make csi/csi_grpc.pb.go
+```
+
+## Update dependencies
+
+Next, we should update `go.mod` by the following commands.
+
+```bash
+VERSION=<upgrading Kubernetes version>
+go get k8s.io/api@v${VERSION} k8s.io/apimachinery@v${VERSION} k8s.io/client-go@v${VERSION}
+```
+
+If we need to upgrade the `controller-runtime` version, do the following as well.
+
+```bash
+VERSION=<upgrading controller-runtime version>
+go get sigs.k8s.io/controller-runtime@v${VERSION}
+```
+
+Then, please tidy up the dependencies.
+
+```bash
+go mod tidy
+```
+
+These are minimal changes for the Kubernetes upgrade, but if there are some breaking changes found in the release notes, you have to handle them as well in this step.
+
+## Release the changes
+
+We should follow [RELEASE.md](../RELEASE.md) and upgrade the minor version.
+
+## Prepare for the next upgrade
+
+We should create an issue for the next upgrade. Besides, Please update this document if you find something to be updated.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -16,19 +16,19 @@ so checking them together with this guide is recommended when you do this task.
 First of all, we should have a look at the release notes in the order below.
 
 1. Kubernetes
-  - Choose the next version and check the [release note](https://kubernetes.io/docs/setup/release/notes/). e.g. 1.17, 1.18, 1.19 -> 1.18, 1.19, 1.20
+    - Choose the next version and check the [release note](https://kubernetes.io/docs/setup/release/notes/). e.g. 1.17, 1.18, 1.19 -> 1.18, 1.19, 1.20
 2. controller-runtime
-  - Read the [release note](https://github.com/kubernetes-sigs/controller-runtime/releases), and check which version is compatible with the Kubernetes versions.
+    - Read the [release note](https://github.com/kubernetes-sigs/controller-runtime/releases), and check which version is compatible with the Kubernetes versions.
 3. CSI spec
-  - Read the [release note](https://github.com/container-storage-interface/spec/blob/master/spec.md) and check all the changes from the current version to the latest.
-  - Basically, CSI spec should NOT be upgraded aggressively in this task.
+    - Read the [release note](https://github.com/container-storage-interface/spec/releases) and check all the changes from the current version to the latest.
+    - Basically, CSI spec should NOT be upgraded aggressively in this task.
     Upgrade the CSI version only if new features we should cover are introduced in newer versions, or the Kubernetes versions TopoLVM is going to support does not support the current CSI version.
 4. CSI sidecars
-  - TopoLVM does not use all the sidecars listed [here](https://kubernetes-csi.github.io/docs/sidecar-containers.html).
-    Have a look at `csi-sidecars.mk` first and understand what sidecars are actually being used.
-  - Check the release pages of the sidecars under [kubernetes-csi](https://github.com/kubernetes-csi) one by one and choose the latest version for each sidecar which satisfies both "Minimal Kubernetes version" and "Supported CSI spec versions".
-    DO NOT follow the version compatibility tables in this [page](https://kubernetes-csi.github.io/docs/sidecar-containers.html) and the README.md files in the sidecar repositories because they are sometimes not updated properly.
-  - Read the change logs which are linked from the release pages.
+    - TopoLVM does not use all the sidecars listed [here](https://kubernetes-csi.github.io/docs/sidecar-containers.html).
+      Have a look at `csi-sidecars.mk` first and understand what sidecars are actually being used.
+    - Check the release pages of the sidecars under [kubernetes-csi](https://github.com/kubernetes-csi) one by one and choose the latest version for each sidecar which satisfies both "Minimal Kubernetes version" and "Supported CSI spec versions".
+      DO NOT follow the "Status and Releases" tables in this [page](https://kubernetes-csi.github.io/docs/sidecar-containers.html) and the README.md files in the sidecar repositories because they are sometimes not updated properly.
+    - Read the change logs which are linked from the release pages.
 
 Please write down to the Github issue of this task what kinds of changes we find in the release note and what we are going to do and NOT going to do to address the changes.
 The format is up to you, but this is very important to keep track of what changes are made in this task, so please do not forget to do it.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -54,15 +54,11 @@ Please update the versions in the code and docs with great care.
 
 ### Update CSI spec
 
-In case we update the version of the CSI spec written in `Makefile`, we should regenerate the gRPC schema with the protobuf file corresponding to the CSI spec version.
-First, we might have to upgrade the `protoc` version defined in `Makefile` with checking the Go section in [release note](https://github.com/protocolbuffers/protobuf/releases).
-Then, please execute the following commands to update the Go code.
+To update the CSI version, we need to update `CSI_VERSION` in `Makefile`, and run the following commands.
 
 ```bash
-cd ${GOPATH}/src/github.com/topolvm/topolvm
-make setup
-make csi/csi.pb.go
-make csi/csi_grpc.pb.go
+$ make csi.proto
+$ make generate
 ```
 
 ### Update dependencies
@@ -71,21 +67,21 @@ Next, we should update `go.mod` by the following commands.
 Please note that Kubernetes v1 corresponds with v0 for the release tags. For example, v1.17.2 corresponds with the `v0.17.2` tag.
 
 ```bash
-VERSION=<upgrading Kubernetes release version>
-go get k8s.io/api@v${VERSION} k8s.io/apimachinery@v${VERSION} k8s.io/client-go@v${VERSION}
+$ VERSION=<upgrading Kubernetes release version>
+$ go get k8s.io/api@v${VERSION} k8s.io/apimachinery@v${VERSION} k8s.io/client-go@v${VERSION}
 ```
 
 If we need to upgrade the `controller-runtime` version, do the following as well.
 
 ```bash
-VERSION=<upgrading controller-runtime version>
-go get sigs.k8s.io/controller-runtime@v${VERSION}
+$ VERSION=<upgrading controller-runtime version>
+$ go get sigs.k8s.io/controller-runtime@v${VERSION}
 ```
 
 Then, please tidy up the dependencies.
 
 ```bash
-go mod tidy
+$ go mod tidy
 ```
 
 These are minimal changes for the Kubernetes upgrade, but if there are some breaking changes found in the release notes, you have to handle them as well in this step.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,17 +4,17 @@ How to upgrade supported Kubernetes version
 TopoLVM depends on some Kubernetes repositories like `k8s.io/client-go` and should support 3 consecutive Kubernets versions at a time.
 Here is the guide for how to upgrade the supported versions.
 Issues and PRs related to the last upgrade task also help you understand how to upgrade the supported versions,
-so checking them besides this guide is recommended when we do this task.
+so checking them together with this guide is recommended when you do this task.
 
 ## Check release notes
 
 First of all, we should have a look at the release notes in the order below.
 
-Please clarify on the issue on GitHub what kinds of changes we find in the release note and what we are going to do and NOT going to do address the changes.
-The format is up to you, but this is a very important step to keep track of what changes are made, so please do not forget to do it.
+Please clarify on the issue on GitHub what kinds of changes we find in the release note and what we are going to do and NOT going to do to address the changes.
+The format is up to you, but this is very important to keep track of what changes are made in this task, so please do not forget to do it.
 
 Basically, we should pay attention for breaking changes and security fixes first.
-If we find some interesting features added in new versions, please consider and make an GitHub issue to deal with it after the upgrading task is over.
+If we find some interesting features added in new versions, please consider if we actually use them and make an GitHub issue to incorporate them after the upgrading task is done.
 
 1. Kubernetes
   - Choose the next version and check the [release note](https://kubernetes.io/docs/setup/release/notes/). e.g. 1.17, 1.18, 1.19 -> 1.18, 1.19, 1.20
@@ -27,13 +27,14 @@ If we find some interesting features added in new versions, please consider and 
 4. CSI sidecars
   - TopoLVM does not use all the sidecars listed [here](https://kubernetes-csi.github.io/docs/sidecar-containers.html).
     Have a look at `csi-sidecars.mk` first and check what sidecars are actually used.
-  - Check the release pages of the sidecars under [kubernetes-csi](https://github.com/kubernetes-csi) one by one under and choose the latest versions which satisfy the minimal Kubernetes version.
-    DO NOT follow the version compatibility tables in this [page](https://kubernetes-csi.github.io/docs/sidecar-containers.html) and the README.md files of the sidecar repositories    because they are sometimes not updated properly.
+  - Check the release pages of the sidecars under [kubernetes-csi](https://github.com/kubernetes-csi) one by one and choose the latest version for each sidecar which satisfies both "Minimal Kubernetes version" and "Supported CSI spec versions".
+    DO NOT follow the version compatibility tables in this [page](https://kubernetes-csi.github.io/docs/sidecar-containers.html) and the README.md files of the sidecar repositories because they are sometimes not updated properly.
+  - Read the change logs which are linked from the release pages.
 
 ## Update written versions
 
-Once we decide the versions you are going to upgrade, we should update the versions written in the following files manually.
-`git grep 1.18`, `git grep image:`, and `git grep VERSION` might help you avoid overlooking the target versions.
+Once we decide the versions we are going to upgrade, we should update the versions written in the following files manually.
+`git grep 1.18`, `git grep image:`, and `git grep VERSION` might help us avoid overlooking necessary changes.
 Please update the versions in the code and docs with great care.
 
 - `README.md`: Documentation which indicates what versions are supported by TopoLVM
@@ -88,4 +89,4 @@ We should follow [RELEASE.md](../RELEASE.md) and upgrade the minor version.
 
 ## Prepare for the next upgrade
 
-We should create an issue for the next upgrade. Besides, Please update this document if you find something to be updated.
+We should create an issue for the next upgrade. Besides, Please update this document if we find something to be updated.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,12 +1,17 @@
+Maintenance guide
+=================
+
+This is the maintenance guide for TopoLVM.
+
 How to upgrade supported Kubernetes version
-===========================================
+-------------------------------------------
 
 TopoLVM depends on some Kubernetes repositories like `k8s.io/client-go` and should support 3 consecutive Kubernets versions at a time.
 Here is the guide for how to upgrade the supported versions.
 Issues and PRs related to the last upgrade task also help you understand how to upgrade the supported versions,
 so checking them together with this guide is recommended when you do this task.
 
-## Check release notes
+### Check release notes
 
 First of all, we should have a look at the release notes in the order below.
 
@@ -31,7 +36,7 @@ The format is up to you, but this is very important to keep track of what change
 Basically, we should pay attention to breaking changes and security fixes first.
 If we find some interesting features added in new versions, please consider if we are going to use them or not and make a GitHub issue to incorporate them after the upgrading task is done.
 
-## Update written versions
+### Update written versions
 
 Once we decide the versions we are going to upgrade, we should update the versions written in the following files manually.
 
@@ -47,7 +52,7 @@ Once we decide the versions we are going to upgrade, we should update the versio
 `git grep 1.18`, `git grep image:`, and `git grep VERSION` might help us avoid overlooking necessary changes.
 Please update the versions in the code and docs with great care.
 
-## Update CSI spec
+### Update CSI spec
 
 In case we update the version of the CSI spec written in `Makefile`, we should regenerate the gRPC schema with the protobuf file corresponding to the CSI spec version.
 First, we might have to upgrade the `protoc` version defined in `Makefile` with checking the Go section in [release note](https://github.com/protocolbuffers/protobuf/releases).
@@ -60,7 +65,7 @@ make csi/csi.pb.go
 make csi/csi_grpc.pb.go
 ```
 
-## Update dependencies
+### Update dependencies
 
 Next, we should update `go.mod` by the following commands.
 Please note that Kubernetes v1 corresponds with v0 for the release tags. For example, v1.17.2 corresponds with the `v0.17.2` tag.
@@ -85,10 +90,10 @@ go mod tidy
 
 These are minimal changes for the Kubernetes upgrade, but if there are some breaking changes found in the release notes, you have to handle them as well in this step.
 
-## Release the changes
+### Release the changes
 
 We should follow [RELEASE.md](../RELEASE.md) and upgrade the minor version.
 
-## Prepare for the next upgrade
+### Prepare for the next upgrade
 
 We should create an issue for the next upgrade. Besides, Please update this document if we find something to be updated.


### PR DESCRIPTION
We need some special knowledge for upgrading the supported Kubernetes versions.
This PR adds a document to decrease the knowledge gap between maintainers about how to upgrade the versions.
Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>