### PR TITLE
fix to use topolvm-with-sidecar for example test

### DIFF
--- a/Dockerfile.with-sidecar
+++ b/Dockerfile.with-sidecar
@@ -16,7 +16,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
         file \
-        btrfs-progs \
         xfsprogs \
     && rm -rf /var/lib/apt/lists/*
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -25,7 +25,7 @@ $(KUBECTL):
 build/topolvm.img: $(GO_FILES)
 	$(MAKE) -C .. image IMAGE_PREFIX=quay.io/topolvm/
 	$(MAKE) -C .. tag IMAGE_PREFIX=quay.io/topolvm/ IMAGE_TAG=$(TOPOLVM_VERSION)
-	docker save -o $@ quay.io/topolvm/topolvm:$(TOPOLVM_VERSION)
+	docker save -o $@ quay.io/topolvm/topolvm-with-sidecar:$(TOPOLVM_VERSION)
 
 run: $(SERVER_CERT_FILES)
 	$(MAKE) start-lvmd


### PR DESCRIPTION
Previously, in example test, quay.io/topolvm/topolvm image is used in kind environment.
The PR fixes to use the proper image.

Signed-off-by: Toshikuni Fukaya <toshikuni-fukaya@cybozu.co.jp>