### PR TITLE
Make event handler be invoked on create event.

### DIFF
--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -196,7 +196,7 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	pred := predicate.Funcs{
-		CreateFunc:  func(event.CreateEvent) bool { return false },
+		CreateFunc:  func(event.CreateEvent) bool { return true },
 		DeleteFunc:  func(event.DeleteEvent) bool { return false },
 		UpdateFunc:  func(event.UpdateEvent) bool { return true },
 		GenericFunc: func(event.GenericEvent) bool { return false },

--- a/controllers/persistentvolumeclaim_controller.go
+++ b/controllers/persistentvolumeclaim_controller.go
@@ -114,7 +114,7 @@ OUTER:
 // SetupWithManager sets up Reconciler with Manager.
 func (r *PersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	pred := predicate.Funcs{
-		CreateFunc:  func(event.CreateEvent) bool { return false },
+		CreateFunc:  func(event.CreateEvent) bool { return true },
 		DeleteFunc:  func(event.DeleteEvent) bool { return false },
 		UpdateFunc:  func(event.UpdateEvent) bool { return true },
 		GenericFunc: func(event.GenericEvent) bool { return false },


### PR DESCRIPTION
If pvc or node resources are created before topolvm-controller is started,
controller-runtime notifies it as a create event, so the predicate
function should returns true.

Signed-off-by: Toshikuni Fukaya <toshikuni-fukaya@cybozu.co.jp>

Fixes #278 