### PR TITLE
fix PodSecurityPolicy for Daemonset of lvmd

### DIFF
--- a/deploy/manifests/lvmd/lvmd.yaml
+++ b/deploy/manifests/lvmd/lvmd.yaml
@@ -14,7 +14,9 @@ spec:
   hostPID: true
   volumes:
     - 'configMap'
+    - 'emptyDir'
     - 'hostPath'
+    - 'secret'
   allowedHostPaths:
   - pathPrefix: "/run/topolvm"
     readOnly: false


### PR DESCRIPTION
Add required permissions to use `lvmd` pod.

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>