### PR TITLE
Stabilize Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ARG TOPOLVM_VERSION
 COPY . /workdir
 WORKDIR /workdir
 
-RUN make build TOPOLVM_VERSION=${TOPOLVM_VERSION}
+RUN touch csi/*.go lvmd/proto/*.go docs/*.md \
+    && make build TOPOLVM_VERSION=${TOPOLVM_VERSION}
 
 # TopoLVM container
 FROM ubuntu:20.04

--- a/Dockerfile.with-sidecar
+++ b/Dockerfile.with-sidecar
@@ -7,7 +7,8 @@ ARG TOPOLVM_VERSION
 COPY . /workdir
 WORKDIR /workdir
 
-RUN make build TOPOLVM_VERSION=${TOPOLVM_VERSION}
+RUN touch csi/*.go lvmd/proto/*.go docs/*.md \
+    && make build TOPOLVM_VERSION=${TOPOLVM_VERSION}
 
 # TopoLVM container
 FROM ubuntu:20.04

--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,8 @@ csi-sidecars: ## Build sidecar images.
 
 .PHONY: image
 image: ## Build topolvm images.
-	docker build -t $(IMAGE_PREFIX)topolvm:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) .
-	docker build -t $(IMAGE_PREFIX)topolvm-with-sidecar:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) -f Dockerfile.with-sidecar .
+	docker build --no-cache -t $(IMAGE_PREFIX)topolvm:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) .
+	docker build --no-cache -t $(IMAGE_PREFIX)topolvm-with-sidecar:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) -f Dockerfile.with-sidecar .
 
 .PHONY: tag
 tag: ## Tag topolvm images.


### PR DESCRIPTION
Pre-generated files may have wrong timestamps occasionally.
`touch` them before building images for stable build process.

Also, add `--no-cache` to `docker build` for the same purpose.