### PR TITLE
Use Ubuntu 18.04 as the base image for TopoLVM container

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -20,7 +20,7 @@ jobs:
       - run: make image
   e2e-k8s:
     name: e2e-k8s
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         test_kubernetes_target: [current, prev, prev2]
@@ -38,7 +38,7 @@ jobs:
       - run: make -C e2e test
   e2e-k8s-daemonset-lvmd:
     name: e2e-k8s-daemonset-lvmd
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         test_kubernetes_target: [current, prev, prev2]
@@ -57,7 +57,7 @@ jobs:
       - run: make -C e2e daemonset-lvmd/test
   example:
     name: example
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     defaults:
       run:
         working-directory: example

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     name: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - name: Validate Release Version
         id: check_version

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN touch csi/*.go lvmd/proto/*.go docs/*.md \
     && make build TOPOLVM_VERSION=${TOPOLVM_VERSION}
 
 # TopoLVM container
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/Dockerfile.with-sidecar
+++ b/Dockerfile.with-sidecar
@@ -11,7 +11,7 @@ RUN touch csi/*.go lvmd/proto/*.go docs/*.md \
     && make build TOPOLVM_VERSION=${TOPOLVM_VERSION}
 
 # TopoLVM container
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ PROTOC_VERSION=3.15.0
 
 SUDO=sudo
 CURL=curl -Lsf
-BINDIR := $(PWD)/bin
+BINDIR := $(shell pwd)/bin
 CONTROLLER_GEN := $(BINDIR)/controller-gen
 KUSTOMIZE := $(BINDIR)/kustomize
 STATICCHECK := $(BINDIR)/staticcheck
 NILERR := $(BINDIR)/nilerr
-PROTOC := PATH=$(BINDIR):$(PATH) $(BINDIR)/protoc -I=$(PWD)/include:.
+PROTOC := PATH=$(BINDIR):$(PATH) $(BINDIR)/protoc -I=$(shell pwd)/include:.
 PACKAGES := unzip lvm2 xfsprogs
-ENVTEST_ASSETS_DIR := $(PWD)/testbin
+ENVTEST_ASSETS_DIR := $(shell pwd)/testbin
 
 GO_FILES=$(shell find -name '*.go' -not -name '*_test.go')
 GOOS := $(shell go env GOOS)

--- a/driver/node.go
+++ b/driver/node.go
@@ -32,7 +32,7 @@ const (
 	mountCmd         = "/bin/mount"
 	mountpointCmd    = "/bin/mountpoint"
 	umountCmd        = "/bin/umount"
-	findmntCmd       = "/usr/bin/findmnt"
+	findmntCmd       = "/bin/findmnt"
 	devicePermission = 0600 | unix.S_IFBLK
 	ephVolConKey     = "csi.storage.k8s.io/ephemeral"
 )

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/cybozu/ubuntu-debug:20.04
+FROM quay.io/cybozu/ubuntu-debug:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -3,26 +3,26 @@ TEST_KUBERNETES_TARGET ?= current
 TEST_SCHEDULER_MANIFEST ?= daemonset
 
 ## Dependency versions
-KIND_VERSION=0.10.0
-MINIKUBE_VERSION=v1.18.1
+KIND_VERSION := 0.10.0
+MINIKUBE_VERSION := v1.18.1
 
-BINDIR := $(shell pwd)/bin
-SUDO=sudo
-KIND_CLUSTER_NAME=topolvm-e2e
+BINDIR := $(PWD)/bin
+SUDO := sudo
+KIND_CLUSTER_NAME := topolvm-e2e
 KIND := $(BINDIR)/kind
 KUBECTL := $(BINDIR)/kubectl
 KUSTOMIZE := ../bin/kustomize
 GINKGO := ../bin/ginkgo
 
-MINIKUBE_HOME = $(BINDIR)
+MINIKUBE_HOME := $(BINDIR)
 export MINIKUBE_HOME
 
 ifeq ($(TEST_KUBERNETES_TARGET),current)
-TEST_KUBERNETES_VERSION=1.20
+TEST_KUBERNETES_VERSION := 1.20
 else ifeq ($(TEST_KUBERNETES_TARGET),prev)
-TEST_KUBERNETES_VERSION=1.19
+TEST_KUBERNETES_VERSION := 1.19
 else ifeq ($(TEST_KUBERNETES_TARGET),prev2)
-TEST_KUBERNETES_VERSION=1.18
+TEST_KUBERNETES_VERSION := 1.18
 endif
 
 export TEST_KUBERNETES_VERSION
@@ -30,27 +30,27 @@ export TEST_KUBERNETES_VERSION
 SCHEDULER_POLICY := scheduler-policy-daemonset.cfg
 KUSTOMIZE_DIR := manifests/overlays/daemonset-scheduler
 ifeq ($(TEST_SCHEDULER_MANIFEST),deployment)
-SCHEDULER_POLICY=scheduler-policy-deployment.cfg
-KUSTOMIZE_DIR=manifests/overlays/deployment-scheduler
+SCHEDULER_POLICY := scheduler-policy-deployment.cfg
+KUSTOMIZE_DIR := manifests/overlays/deployment-scheduler
 endif
 
 ifeq ($(TEST_KUBERNETES_VERSION),1.20)
-KUBERNETES_VERSION=1.20.2
-KUBEADM_APIVERSION=kubeadm.k8s.io/v1beta2
-SCHEDULER_CONFIG=scheduler-config-v1beta1-$(TEST_SCHEDULER_MANIFEST).yaml
+KUBERNETES_VERSION := 1.20.2
+KUBEADM_APIVERSION := kubeadm.k8s.io/v1beta2
+SCHEDULER_CONFIG := scheduler-config-v1beta1-$(TEST_SCHEDULER_MANIFEST).yaml
 else ifeq ($(TEST_KUBERNETES_VERSION),1.19)
-KUBERNETES_VERSION=1.19.4
-KUBEADM_APIVERSION=kubeadm.k8s.io/v1beta2
-SCHEDULER_CONFIG=scheduler-config-v1beta1-$(TEST_SCHEDULER_MANIFEST).yaml
+KUBERNETES_VERSION := 1.19.4
+KUBEADM_APIVERSION := kubeadm.k8s.io/v1beta2
+SCHEDULER_CONFIG := scheduler-config-v1beta1-$(TEST_SCHEDULER_MANIFEST).yaml
 else ifeq ($(TEST_KUBERNETES_VERSION),1.18)
-KUBERNETES_VERSION=1.18.8
-KUBEADM_APIVERSION=kubeadm.k8s.io/v1beta2
-SCHEDULER_CONFIG=scheduler-config-v1alpha1.yaml
+KUBERNETES_VERSION := 1.18.8
+KUBEADM_APIVERSION := kubeadm.k8s.io/v1beta2
+SCHEDULER_CONFIG := scheduler-config-v1alpha1.yaml
 endif
 
 GO_FILES := $(shell find .. -prune -o -path ../e2e -prune -o -name '*.go' -print)
-SERVER_CERT_FILES=./certs/cert.pem ./certs/key.pem
-BACKING_STORE=./build
+SERVER_CERT_FILES := ./certs/cert.pem ./certs/key.pem
+BACKING_STORE := ./build
 
 topolvm.img: $(GO_FILES)
 	rm -rf tmpbin
@@ -207,12 +207,12 @@ daemonset-lvmd/launch-minikube:
 		--kubernetes-version=v$(KUBERNETES_VERSION) \
 		--extra-config=kubelet.read-only-port=10255
 	$(SUDO) chown -R $$USER $$HOME/.kube $(MINIKUBE_HOME)/.minikube
-	$(SUDO) chmod -R a+r /home/runner/.kube $(MINIKUBE_HOME)/.minikube
+	$(SUDO) chmod -R a+r $$HOME/.kube $(MINIKUBE_HOME)/.minikube
 	$(SUDO) find $(MINIKUBE_HOME)/.minikube -name id_rsa -exec chmod 600 {} ';'
 
 .PHONY: daemonset-lvmd/delete-minikube
 daemonset-lvmd/delete-minikube:
-	$(BINDIR)/minikube delete || true
+	$(SUDO) $(BINDIR)/minikube delete || true
 
 # Set scheduler configs manually because minikube can't edit scheduler configs.
 .PHONY: daemonset-lvmd/update-minikube-setting

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -6,13 +6,16 @@ TEST_SCHEDULER_MANIFEST ?= daemonset
 KIND_VERSION=0.10.0
 MINIKUBE_VERSION=v1.18.1
 
-BINDIR=$(PWD)/bin
+BINDIR := $(shell pwd)/bin
 SUDO=sudo
 KIND_CLUSTER_NAME=topolvm-e2e
 KIND := $(BINDIR)/kind
 KUBECTL := $(BINDIR)/kubectl
 KUSTOMIZE := ../bin/kustomize
 GINKGO := ../bin/ginkgo
+
+MINIKUBE_HOME = $(BINDIR)
+export MINIKUBE_HOME
 
 ifeq ($(TEST_KUBERNETES_TARGET),current)
 TEST_KUBERNETES_VERSION=1.20
@@ -199,16 +202,16 @@ daemonset-lvmd/setup-minikube:
 
 .PHONY: daemonset-lvmd/launch-minikube
 daemonset-lvmd/launch-minikube:
-	ls -la ${HOME}/.kube || true
-	if [ -d ${HOME}/.kube ]; then $(SUDO) chown -R ${USER} ${HOME}/.kube; chown -R a+r ${HOME}/.kube; fi
-	$(BINDIR)/minikube start \
+	$(SUDO) $(BINDIR)/minikube start \
 		--vm-driver=none \
 		--kubernetes-version=v$(KUBERNETES_VERSION) \
 		--extra-config=kubelet.read-only-port=10255
+	$(SUDO) chown -R $$USER $$HOME/.kube $(MINIKUBE_HOME)/.minikube
+	$(SUDO) chmod -R a+r /home/runner/.kube $(MINIKUBE_HOME)/.minikube
+	$(SUDO) find $(MINIKUBE_HOME)/.minikube -name id_rsa -exec chmod 600 {} ';'
 
 .PHONY: daemonset-lvmd/delete-minikube
 daemonset-lvmd/delete-minikube:
-	if [ -d ${HOME}/.kube ]; then $(SUDO) chown -R ${USER} ${HOME}/.kube; chown -R a+r ${HOME}/.kube; fi
 	$(BINDIR)/minikube delete || true
 
 # Set scheduler configs manually because minikube can't edit scheduler configs.
@@ -221,7 +224,7 @@ daemonset-lvmd/update-minikube-setting: daemonset-lvmd/delete-minikube daemonset
 
 .PHONY: daemonset-lvmd/test
 daemonset-lvmd/test: topolvm.img $(SERVER_CERT_FILES)
-	$(KUSTOMIZE) build --load_restrictor='none' manifests/overlays/daemonset-lvmd | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build --load_restrictor='none' manifests/overlays/daemonset-lvmd | $(SUDO) $(KUBECTL) apply -f -
 	$(SUDO) -E env PATH=${PATH} E2ETEST=1 BINDIR=$(BINDIR) DAEMONSET_LVMD=true $(GINKGO) --failFast -v .
 
 .PHONY: daemonset-lvmd/clean

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -199,6 +199,8 @@ daemonset-lvmd/setup-minikube:
 
 .PHONY: daemonset-lvmd/launch-minikube
 daemonset-lvmd/launch-minikube:
+	ls -la ${HOME}/.kube || true
+	if [ -d ${HOME}/.kube ]; then $(SUDO) chown -R ${USER} ${HOME}/.kube; chown -R a+r ${HOME}/.kube; fi
 	$(BINDIR)/minikube start \
 		--vm-driver=none \
 		--kubernetes-version=v$(KUBERNETES_VERSION) \
@@ -206,6 +208,7 @@ daemonset-lvmd/launch-minikube:
 
 .PHONY: daemonset-lvmd/delete-minikube
 daemonset-lvmd/delete-minikube:
+	if [ -d ${HOME}/.kube ]; then $(SUDO) chown -R ${USER} ${HOME}/.kube; chown -R a+r ${HOME}/.kube; fi
 	$(BINDIR)/minikube delete || true
 
 # Set scheduler configs manually because minikube can't edit scheduler configs.

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -6,7 +6,7 @@ TEST_SCHEDULER_MANIFEST ?= daemonset
 KIND_VERSION := 0.10.0
 MINIKUBE_VERSION := v1.18.1
 
-BINDIR := $(PWD)/bin
+BINDIR := $(shell pwd)/bin
 SUDO := sudo
 KIND_CLUSTER_NAME := topolvm-e2e
 KIND := $(BINDIR)/kind

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -14,7 +14,7 @@ KUBECTL := $(BINDIR)/kubectl
 KUSTOMIZE := ../bin/kustomize
 GINKGO := ../bin/ginkgo
 
-MINIKUBE_HOME := $(BINDIR)
+MINIKUBE_HOME = $(BINDIR)
 export MINIKUBE_HOME
 
 ifeq ($(TEST_KUBERNETES_TARGET),current)
@@ -212,7 +212,7 @@ daemonset-lvmd/launch-minikube:
 
 .PHONY: daemonset-lvmd/delete-minikube
 daemonset-lvmd/delete-minikube:
-	$(SUDO) $(BINDIR)/minikube delete || true
+	$(BINDIR)/minikube delete || true
 
 # Set scheduler configs manually because minikube can't edit scheduler configs.
 .PHONY: daemonset-lvmd/update-minikube-setting

--- a/example/Makefile
+++ b/example/Makefile
@@ -7,7 +7,7 @@ TOPOLVM_VERSION=0.8.2
 KIND_CLUSTER_NAME=topolvm-example
 
 SUDO=sudo
-BINDIR=$(PWD)/bin
+BINDIR=$(shell pwd)/bin
 KUSTOMIZE=$(BINDIR)/kustomize
 KUBECTL=$(BINDIR)/kubectl
 


### PR DESCRIPTION
`mkfs.xfs` in Ubuntu 20.04 is too new for the Linux kernel of CentOS7.
As a temporary fix, we downgrade the base Ubuntu to 18.04 in Dockerfiles.

fix #283 
fix #257