### PR TITLE
change urls of placeholder images

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -32,9 +32,9 @@ Components
 
 ### Diagram
 
-- ![#FFFF00](https://placehold.it/15/FFFF00/000000?text=+) TopoLVM components
-- ![#ADD8E6](https://placehold.it/15/ADD8E6/000000?text=+) Kubernetes components
-- ![#FFC0CB](https://placehold.it/15/FFC0CB/000000?text=+) Kubernetes CSI Sidecar containers
+- ![#FFFF00](https://via.placeholder.com/15/FFFF00/000000?text=+) TopoLVM components
+- ![#ADD8E6](https://via.placeholder.com/15/ADD8E6/000000?text=+) Kubernetes components
+- ![#FFC0CB](https://via.placeholder.com/15/FFC0CB/000000?text=+) Kubernetes CSI Sidecar containers
 
 ![component diagram](http://www.plantuml.com/plantuml/svg/bPJFZjem4CRlUOfHzh8Sq0eVzr1j6tgZLGGgLRNbOE9Hi73io7RO_j6-Uvt4CIR0qhsiDZC_ZxzlFCEJiLJRfX99JOizBH7IETP2_QvGsXJ-9W3FcP9MAo5Gvw8fkTm0DP1QLIjngAP5oAPmzmE5K2_j8MCCPrXGRNgyC7nQQtNWXYk9-gTi0zHQMko6Bus6_-dAv5pkazSaaOeXV7L_PbsDxhzML08mo9sl-joSOgNa2hrefw2bUy6pKyLjrQ2rPrbGwzbUJycDrJGe0d2Q7BrljYZGUjH_EMZ1ovtz91higCNw2_E8kvM56q-CaM2Cd1aZDusHTnWZ_s-Ct3P6tZBc1oONL69_QH-0ketugJB53baZK6_Y-W2CMhgb1Y6bDJUe3wXZ1KCJikMybx1G9I-eM2lHL7ZlmfDH2_9rrfCvQkDyexGzd0dAgzH3YYtHg4ONw67bZ1txFIHdcsWIpzFac2Pj-jNr96oMGTQjbaFYBODxfI6yycHeZzUn6je4dtyvwQnTbllXmKCF9oUF44q-J9jw-W5EBC0ZV9HIMMhn57s-sue6DqozI7Uccr_7biiyIuQH3z1GDfn-V8EBrijpKIIWSRrmSQIGN313BfiXbyoGaHbopSmDCDgfCpT7z6B1PFnR2bClq0skWpADpiZ3TsgBtNLs_9hlm4d0eudtVJqhu53SxfJQZoVAw_Mb7hxLRDp-gr0IPjOpfes5_WNHRck3r3WTkdkcrhVu2ILhAl4F)
 


### PR DESCRIPTION
placehold.it seems to be obsolete. We can't show ![image](https://user-images.githubusercontent.com/6075867/117248171-75c4b180-ae7a-11eb-9396-7cadcf353b9e.png) in docs/design.md properly.