### PR TITLE
Add better error message when configured VG is not found

### DIFF
--- a/pkg/lvmd/cmd/root.go
+++ b/pkg/lvmd/cmd/root.go
@@ -79,6 +79,9 @@ func subMain() error {
 	for _, dc := range config.DeviceClasses {
 		_, err := command.FindVolumeGroup(dc.VolumeGroup)
 		if err != nil {
+			log.Error("Volume group not found:", map[string]interface{}{
+				"volume_group": dc.VolumeGroup,
+			})
 			return err
 		}
 	}


### PR DESCRIPTION
I was under the impression that I could have different names for the VG on different nodes; this is the error message that would have helped my find the error quicker.