### PR TITLE
Helm Chart: Support custom clusterIP for scheduler deployment

### DIFF
--- a/charts/topolvm/Chart.yaml
+++ b/charts/topolvm/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 home: https://github.com/topolvm/topolvm
 name: topolvm
 description: Topolvm
-version: 2.0.2
+version: 2.0.3
 appVersion: 0.8.3
 kubeVersion: ">=1.18.0"
 sources:

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -124,6 +124,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | scheduler.options.listen.port | int | `9251` | Listen port. |
 | scheduler.resources | object | `{}` | Specify resources on the TopoLVM scheduler extender container. |
 | scheduler.schedulerOptions | object | `{}` | Tune the Node scoring. ref: https://github.com/topolvm/topolvm/blob/master/deploy/README.md |
+| scheduler.service.clusterIP | string | `nil` | Specify Service clusterIP. |
 | scheduler.service.nodePort | int | `nil` | Specify nodePort. |
 | scheduler.service.type | string | `"LoadBalancer"` | Specify Service type. |
 | scheduler.terminationGracePeriodSeconds | int | `nil` | Specify terminationGracePeriodSeconds on the Deployment or DaemonSet. |

--- a/charts/topolvm/templates/scheduler/deployment-service.yaml
+++ b/charts/topolvm/templates/scheduler/deployment-service.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- include "topolvm.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.scheduler.service.type }}
+  {{- with .Values.scheduler.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "topolvm.fullname" . }}-scheduler
   ports:

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -45,6 +45,8 @@ scheduler:
   service:
     # scheduler.service.type -- Specify Service type.
     type: LoadBalancer
+    # scheduler.service.clusterIP -- Specify Service clusterIP.
+    clusterIP:  # None
     # scheduler.service.nodePort -- (int) Specify nodePort.
     nodePort:  # 30251
 


### PR DESCRIPTION
This PR allows the Helm chart to configure Service `spec.clusterIP` for the scheduler.

## Background and use-case

I'm setting up topolvm for a cluster whose control plane has no access to the service network but the pod network. 
I want to set `clusterIP` `None` for the scheduler service to make it headless but it's currently not exposed by the chart.

## Note for reviewers

I only made sure to update the chart README by running `bin/helm-docs` and tested if my change renders as expected by `helm template ./charts/topolvm`. Please guide me through any necessary steps, if any, to make this reviewable.


