### PR TITLE
Make allowedHostPaths property of node's PSP configurable

### DIFF
--- a/charts/topolvm/Chart.yaml
+++ b/charts/topolvm/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 home: https://github.com/topolvm/topolvm
 name: topolvm
 description: Topolvm
-version: 2.0.2
+version: 2.1.0
 appVersion: 0.8.3
 kubeVersion: ">=1.18.0"
 sources:

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -109,6 +109,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | node.metrics.annotations | object | `{"prometheus.io/port":"8080"}` | Annotations for Scrape used by Prometheus.. |
 | node.metrics.enabled | bool | `true` | If true, enable scraping of metrics by Prometheus. |
 | node.nodeSelector | object | `{}` | Specify nodeSelector. |
+| node.psp.allowedHostPaths | list | `[{"pathPrefix":"/var/lib/kubelet","readOnly":false},{"pathPrefix":"/run/topolvm","readOnly":false}]` | Specify allowedHostPaths. |
 | node.resources | object | `{}` | Specify resources. |
 | node.securityContext.privileged | bool | `true` |  |
 | node.tolerations | list | `[]` | Specify tolerations. |

--- a/charts/topolvm/templates/node/psp.yaml
+++ b/charts/topolvm/templates/node/psp.yaml
@@ -14,11 +14,9 @@ spec:
     - 'emptyDir'
     - 'secret'
     - 'hostPath'
-  allowedHostPaths:
-    - pathPrefix: "/var/lib/kubelet"
-      readOnly: false
-    - pathPrefix: "/run/topolvm"
-      readOnly: false
+  {{- with .Values.node.psp.allowedHostPaths }}
+  allowedHostPaths: {{ toYaml . | nindent 2 }}
+  {{- end }}
   hostNetwork: false
   runAsUser:
     rule: 'RunAsAny'

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -245,6 +245,14 @@ node:
         mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
         mountPropagation: "Bidirectional"
 
+  psp:
+    # node.psp.allowedHostPaths -- Specify allowedHostPaths.
+    allowedHostPaths:
+      - pathPrefix: "/var/lib/kubelet"
+        readOnly: false
+      - pathPrefix: "/run/topolvm"
+        readOnly: false
+
 # CSI controller service
 controller:
   # controller.replicaCount -- Number of replicas for CSI controller service.


### PR DESCRIPTION
Hello,

While installing TopoLVM on RKE, I noticed that the node DaemonSet's list of allowedHostPaths could not be tweaked via the values.yaml of the Chart. That's a problem because my kubelet directory is `/var/opt/rke/var/lib/kubelet` instead of `/var/lib/kubelet`.

It's already possible to customize the allowedHostPaths of the lvmd DeamonSet, so I mostly did it the exact same way.

This is my first PR, apologies if you missed something :-)

PS: I'm also good with the change of MIT license to Apache License 2.0 for this and future contributions.

Kind regard,
Laurent