### PR TITLE
Allow customization of kubeletRegistrationPath

### DIFF
--- a/charts/topolvm/Chart.yaml
+++ b/charts/topolvm/Chart.yaml
@@ -4,7 +4,7 @@ type: application
 home: https://github.com/topolvm/topolvm
 name: topolvm
 description: Topolvm
-version: 2.1.0
+version: 2.2.0
 appVersion: 0.9.0
 kubeVersion: ">=1.18.0"
 sources:

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -106,6 +106,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | lvmd.volumeMounts | list | `[{"mountPath":"/run/topolvm","name":"lvmd-socket-dir"}]` | Specify volumeMounts. |
 | lvmd.volumes | list | `[{"hostPath":{"path":"/run/topolvm","type":"DirectoryOrCreate"},"name":"lvmd-socket-dir"}]` | Specify volumes. |
 | node.lvmdSocket | string | `"/run/lvmd/lvmd.sock"` | Specify the socket to be used for communication with lvmd. |
+| node.kubeletRegistrationPath | string | `"/var/lib/kubelet/plugins/topolvm.cybozu.com/node/csi-topolvm.sock"` | Path to the CSI UNIX socket as seen by kubelet. |
 | node.metrics.annotations | object | `{"prometheus.io/port":"8080"}` | Annotations for Scrape used by Prometheus.. |
 | node.metrics.enabled | bool | `true` | If true, enable scraping of metrics by Prometheus. |
 | node.nodeSelector | object | `{}` | Specify nodeSelector. |

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
           command:
             - /csi-node-driver-registrar
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
-            - "--kubelet-registration-path=/var/lib/kubelet/plugins/topolvm.cybozu.com/node/csi-topolvm.sock"
+            - "--kubelet-registration-path={{ .Values.node.kubeletRegistrationPath }}"
           lifecycle:
             preStop:
               exec:

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -180,7 +180,7 @@ node:
   # node.lvmdSocket -- Specify the socket to be used for communication with lvmd.
   lvmdSocket: /run/lvmd/lvmd.sock
 
-  # node.kubeletRegistrationPath -- path to the CSI UNIX socket as seen by kubelet
+  # node.kubeletRegistrationPath -- Path to the CSI UNIX socket as seen by kubelet
   kubeletRegistrationPath: /var/lib/kubelet/plugins/topolvm.cybozu.com/node/csi-topolvm.sock
 
   # node.securityContext. -- Container securityContext.

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -180,6 +180,9 @@ node:
   # node.lvmdSocket -- Specify the socket to be used for communication with lvmd.
   lvmdSocket: /run/lvmd/lvmd.sock
 
+  # node.kubeletRegistrationPath -- path to the CSI UNIX socket as seen by kubelet
+  kubeletRegistrationPath: /var/lib/kubelet/plugins/topolvm.cybozu.com/node/csi-topolvm.sock
+
   # node.securityContext. -- Container securityContext.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:


### PR DESCRIPTION
Hello,

As I am installing topolvm on RKE/Fedora CoreOS, I needed to tweak the kubelet-registration-path passed to the csi-registrar container.

Reason is that kubelet runs in a container on RKE, that container uses one binding in particular to access the UNIX socket:

docker inspect kubelet:
```
...
            {
                "Type": "bind",
                "Source": "/opt/rke/var/lib/kubelet",
                "Destination": "/opt/rke/var/lib/kubelet",
                "Mode": "shared,z",
                "RW": true,
                "Propagation": "shared"
            }
...
```

No other bind is matching the default /var/lib/kubelet/plugins/topolvm.cybozu.com/node/csi-topolvm.sock path. The closest I could find is

```
            {
                "Type": "bind",
                "Source": "/var/lib/kubelet/volumeplugins",
                "Destination": "/var/lib/kubelet/volumeplugins",
                "Mode": "shared,z",
                "RW": true,
                "Propagation": "shared"
            }
```

but that's for Flex Volumes. Not sure why they have two kubelet directories...

Anyway, thanks to the new node.kubeletRegistrationPath that I introduce, I can set it to /opt/rke/var/lib/kubelet/plugins/topolvm.cybozu.com/node/csi-topolvm.sock and that let the csi-registrar succeed.

Thank for reviewing :-)

Laurent
