### PR TITLE
duplicate label causes YAML parsing errors

### DIFF
--- a/charts/topolvm/templates/mutatingwebhooks.yaml
+++ b/charts/topolvm/templates/mutatingwebhooks.yaml
@@ -8,7 +8,6 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "topolvm.fullname" . }}-mutatingwebhook
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
-    app.kubernetes.io/name: {{ template "topolvm.fullname" . }}-hook
 webhooks:
   {{- if .Values.webhook.pvcMutatingWebhook.enabled }}
   - name: pvc-hook.topolvm.cybozu.com


### PR DESCRIPTION
`{{- include "topolvm.labels" . | nindent 4 }}` also includes the `app.kubernetes.io/name` label, and the duplication causes YAML parsing errors