### PR TITLE
Fix YAML example in deploy/README.md

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -243,7 +243,7 @@ you need set the `controller.storageCapacityTracking.enabled=true` and `schedule
     <snip>
     controller:
       storageCapacityTracking:
-        enabled: false
+        enabled: true
     <snip>
     scheduler:
       enabled: false


### PR DESCRIPTION
I think `controller.storageCapacityTracking.enabled` should be `true` in this YAML example.

> If you want to use Storage Capacity Tracking instead of using topolvm-scheduler, you need set the controller.storageCapacityTracking.enabled=true and scheduler.enabled=false in the Helm Chart values.
>
> https://github.com/topolvm/topolvm/blob/main/deploy/README.md