### PR TITLE
Add btrfs-progs pkg to use btrfs commands.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
+        btrfs-progs \
         file \
         xfsprogs \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.with-sidecar
+++ b/Dockerfile.with-sidecar
@@ -16,6 +16,7 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
+        btrfs-progs \
         file \
         xfsprogs \
     && rm -rf /var/lib/apt/lists/*

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -3,6 +3,7 @@ FROM quay.io/cybozu/ubuntu-debug:18.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
+        btrfs-progs \
         file \
         xfsprogs \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
`mounts-utils` uses btrfs command. Install the btrfs-progs package accordingly.

This PR depends #356 

Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>