### PR TITLE
[helm] support `existingCertManagerIssuer`

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -136,6 +136,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | securityContext.runAsUser | int | `10000` | Specify runAsUser. |
 | storageClasses | list | `[{"name":"topolvm-provisioner","storageClass":{"additionalParameters":{},"allowVolumeExpansion":true,"annotations":{},"fsType":"xfs","isDefaultClass":false,"reclaimPolicy":null,"volumeBindingMode":"WaitForFirstConsumer"}}]` | Whether to create storageclass(s) ref: https://kubernetes.io/docs/concepts/storage/storage-classes/ |
 | webhook.caBundle | string | `nil` | Specify the certificate to be used for AdmissionWebhook. |
+| webhook.existingCertManagerIssuer | object | `{}` | Specify the cert-manager issuer to be used for AdmissionWebhook. |
 | webhook.podMutatingWebhook.enabled | bool | `true` | Enable Pod MutatingWebhook. |
 | webhook.pvcMutatingWebhook.enabled | bool | `true` | Enable PVC MutatingWebhook. |
 

--- a/charts/topolvm/templates/certificates/certificates.yaml
+++ b/charts/topolvm/templates/certificates/certificates.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.webhook.existingCertManagerIssuer }}
 # Generate a CA Certificate used to sign certificates for the webhook
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -8,15 +9,18 @@ metadata:
     {{- include "topolvm.labels" . | nindent 4 }}
 spec:
   secretName: {{ template "topolvm.fullname" . }}-webhook-ca
-  duration: 87600h0m0s # 10y
+  duration: 87600h # 10y
   issuerRef:
+    group: cert-manager.io
+    kind: Issuer
     name: {{ template "topolvm.fullname" . }}-webhook-selfsign
-  commonName: "ca.webhook.topolvm"
+  commonName: ca.webhook.topolvm
   isCA: true
   usages:
     - digital signature
     - key encipherment
     - cert sign
+{{- end }}
 ---
 # Finally, generate a serving certificate for the webhook to use
 apiVersion: cert-manager.io/v1
@@ -28,9 +32,15 @@ metadata:
     {{- include "topolvm.labels" . | nindent 4 }}
 spec:
   secretName: {{ template "topolvm.fullname" . }}-mutatingwebhook
-  duration: 8760h0m0s # 1y
+  duration: 8760h # 1y
   issuerRef:
+    {{- with .Values.webhook.existingCertManagerIssuer }}
+    {{- toYaml . | nindent 4 -}}
+    {{- else }}
+    group: cert-manager.io
+    kind: Issuer
     name: {{ template "topolvm.fullname" . }}-webhook-ca
+    {{- end }}
   dnsNames:
     - {{ template "topolvm.fullname" . }}-controller
     - {{ template "topolvm.fullname" . }}-controller.{{ .Release.Namespace }}

--- a/charts/topolvm/templates/certificates/issuers.yaml
+++ b/charts/topolvm/templates/certificates/issuers.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.webhook.existingCertManagerIssuer }}
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
 apiVersion: cert-manager.io/v1
@@ -21,3 +22,4 @@ metadata:
 spec:
   ca:
     secretName: {{ template "topolvm.fullname" . }}-webhook-ca
+{{- end }}

--- a/charts/topolvm/templates/mutatingwebhooks.yaml
+++ b/charts/topolvm/templates/mutatingwebhooks.yaml
@@ -5,7 +5,9 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "topolvm.fullname" . }}-hook
   annotations:
+    {{- if not .Values.webhook.caBundle }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "topolvm.fullname" . }}-mutatingwebhook
+    {{- end }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
 webhooks:

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -341,6 +341,11 @@ storageClasses:
 webhook:
   # webhook.caBundle -- Specify the certificate to be used for AdmissionWebhook.
   caBundle:  # Base64-encoded, PEM-encoded CA certificate that signs the server certificate.
+  # webhook.existingCertManagerIssuer -- Specify the cert-manager issuer to be used for AdmissionWebhook.
+  existingCertManagerIssuer: {}
+    # group: cert-manager.io
+    # kind: Issuer
+    # name: webhook-issuer
   podMutatingWebhook:
     # webhook.podMutatingWebhook.enabled -- Enable Pod MutatingWebhook.
     enabled: true


### PR DESCRIPTION
Support user specify cert-manager issuer.

Currently, `topolvm` helm chart only support managed CA issuer, which is unsatisfactory in some org that has very strict policy of (internal) certificates. So, it's nice to provide an option to end-user provide there own cert-manager issuer instead of helm default.