### PR TITLE
[helm] support `priorityClassName`

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -81,6 +81,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | controller.minReadySeconds | int | `nil` | Specify minReadySeconds. |
 | controller.nodeSelector | object | `{}` | Specify nodeSelector. |
 | controller.podDisruptionBudget.enabled | bool | `true` | Specify podDisruptionBudget enabled. |
+| controller.priorityClassName | string | `nil` | Specify priorityClassName. |
 | controller.prometheus.podMonitor.additionalLabels | object | `{}` | Additional labels that can be used so PodMonitor will be discovered by Prometheus. |
 | controller.prometheus.podMonitor.enabled | bool | `false` | Set this to `true` to create PodMonitor for Prometheus operator. |
 | controller.prometheus.podMonitor.interval | string | `""` | Scrape interval. If not set, the Prometheus default scrape interval is used. |
@@ -107,6 +108,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | lvmd.deviceClasses | list | `[{"default":true,"name":"ssd","spare-gb":10,"volume-group":"myvg1"}]` | Specify the device-class settings. |
 | lvmd.managed | bool | `true` | If true, set up lvmd service with DaemonSet. |
 | lvmd.nodeSelector | object | `{}` | Specify nodeSelector. |
+| lvmd.priorityClassName | string | `nil` | Specify priorityClassName. |
 | lvmd.psp.allowedHostPaths | list | `[{"pathPrefix":"/run/topolvm","readOnly":false}]` | Specify allowedHostPaths. |
 | lvmd.resources | object | `{}` | Specify resources. |
 | lvmd.socketName | string | `"/run/topolvm/lvmd.sock"` | Specify socketName. |
@@ -118,6 +120,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | node.metrics.annotations | object | `{"prometheus.io/port":"metrics"}` | Annotations for Scrape used by Prometheus. |
 | node.metrics.enabled | bool | `true` | If true, enable scraping of metrics by Prometheus. |
 | node.nodeSelector | object | `{}` | Specify nodeSelector. |
+| node.priorityClassName | string | `nil` | Specify priorityClassName. |
 | node.prometheus.podMonitor.additionalLabels | object | `{}` | Additional labels that can be used so PodMonitor will be discovered by Prometheus. |
 | node.prometheus.podMonitor.enabled | bool | `false` | Set this to `true` to create PodMonitor for Prometheus operator. |
 | node.prometheus.podMonitor.interval | string | `""` | Scrape interval. If not set, the Prometheus default scrape interval is used. |
@@ -144,6 +147,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | scheduler.options.listen.host | string | `"localhost"` | Host used by Probe. |
 | scheduler.options.listen.port | int | `9251` | Listen port. |
 | scheduler.podDisruptionBudget.enabled | bool | `true` | Specify podDisruptionBudget enabled. |
+| scheduler.priorityClassName | string | `nil` | Specify priorityClassName on the Deployment or DaemonSet. |
 | scheduler.resources | object | `{}` | Specify resources on the TopoLVM scheduler extender container. |
 | scheduler.schedulerOptions | object | `{}` | Tune the Node scoring. ref: https://github.com/topolvm/topolvm/blob/master/deploy/README.md |
 | scheduler.service.clusterIP | string | `nil` | Specify Service clusterIP. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -24,11 +24,11 @@ spec:
       {{- with .Values.controller.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
       {{- end }}
-      {{- with .Values.controller.affinity }}
-      affinity: {{ toYaml . | nindent 8 }}
-      {{- end }}
       {{- if .Values.controller.securityContext.enabled }}
       securityContext: {{ toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-controller
       containers:
@@ -148,6 +148,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
 
+      {{- with .Values.controller.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.controller.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -32,6 +32,9 @@ spec:
         {{- toYaml .Values.node.metrics.annotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.lvmd.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-lvmd
       hostPID: true
       containers:

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -20,6 +20,9 @@ spec:
       annotations: {{ toYaml .Values.node.metrics.annotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.node.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-node
       containers:
         - name: topolvm-node

--- a/charts/topolvm/templates/scheduler/daemonset.yaml
+++ b/charts/topolvm/templates/scheduler/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
       {{- with .Values.scheduler.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
       {{- end }}
+      {{- with .Values.scheduler.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-scheduler
       containers:
         - name: topolvm-scheduler

--- a/charts/topolvm/templates/scheduler/deployment.yaml
+++ b/charts/topolvm/templates/scheduler/deployment.yaml
@@ -28,8 +28,11 @@ spec:
       {{- with .Values.securityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.scheduler.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ .Values.scheduler.terminationGracePeriodSeconds }}
+      {{- with .Values.scheduler.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      {{- with .Values.scheduler.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-scheduler
       containers:

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -103,6 +103,9 @@ scheduler:
   #    memory: "200Mi"
   #    cpu: "200m"
 
+  # scheduler.priorityClassName -- Specify priorityClassName on the Deployment or DaemonSet.
+  priorityClassName:
+
   # scheduler.schedulerOptions -- Tune the Node scoring.
   # ref: https://github.com/topolvm/topolvm/blob/master/deploy/README.md
   schedulerOptions: {}
@@ -141,6 +144,9 @@ lvmd:
   #  limits:
   #    memory: 500Mi
   #    cpu: 500m
+
+  # lvmd.priorityClassName -- Specify priorityClassName.
+  priorityClassName:
 
   # lvmd.tolerations -- Specify tolerations.
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
@@ -245,6 +251,9 @@ node:
   #  limits:
   #    memory: 500Mi
   #    cpu: 500m
+
+  # node.priorityClassName -- Specify priorityClassName.
+  priorityClassName:
 
   # node.tolerations -- Specify tolerations.
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
@@ -364,6 +373,9 @@ controller:
   #  limits:
   #    memory: "200Mi"
   #    cpu: "200m"
+
+  # controller.priorityClassName -- Specify priorityClassName.
+  priorityClassName:
 
   # controller.updateStrategy -- Specify updateStrategy.
   updateStrategy: {}


### PR DESCRIPTION
In production deployment, we usually assign different `priorityClass` for different components, such as: `system-node-critical` for `node` and `system-cluster-critical` for `controller`.
This PR support that config.

Signed-off-by: Đặng Minh Dũng <dungdm93@live.com>