### PR TITLE
Add support for creating security context contraints via helm

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -159,6 +159,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | scheduler.updateStrategy | object | `{}` | Specify updateStrategy on the Deployment or DaemonSet. |
 | securityContext.runAsGroup | int | `10000` | Specify runAsGroup. |
 | securityContext.runAsUser | int | `10000` | Specify runAsUser. |
+| securityContextConstraint.create | bool | `false` | Create Openshift Security Context Constraints. |
 | storageClasses | list | `[{"name":"topolvm-provisioner","storageClass":{"additionalParameters":{},"allowVolumeExpansion":true,"annotations":{},"fsType":"xfs","isDefaultClass":false,"reclaimPolicy":null,"volumeBindingMode":"WaitForFirstConsumer"}}]` | Whether to create storageclass(s) ref: https://kubernetes.io/docs/concepts/storage/storage-classes/ |
 | webhook.caBundle | string | `nil` | Specify the certificate to be used for AdmissionWebhook. |
 | webhook.existingCertManagerIssuer | object | `{}` | Specify the cert-manager issuer to be used for AdmissionWebhook. |

--- a/charts/topolvm/templates/controller/scc.yaml
+++ b/charts/topolvm/templates/controller/scc.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.securityContextConstraint.create }}
+---
+# scc for the topolvm deployment and daemonsets
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: {{ template "topolvm.fullname" . }}-controller
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+priority:
+allowHostNetwork: false
+allowHostPorts: false
+allowedCapabilities: []
+allowHostPID: false
+allowHostIPC: false
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+defaultAddCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - emptyDir
+  - hostPath
+  - secret
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ template "topolvm.fullname" . }}-controller
+---
+{{- end }}

--- a/charts/topolvm/templates/lvmd/scc.yaml
+++ b/charts/topolvm/templates/lvmd/scc.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.securityContextConstraint.create .Values.lvmd.managed }}
+---
+# scc for the topolvm deployment and daemonsets
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: {{ template "topolvm.fullname" . }}-lvmd
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+priority:
+allowHostNetwork: false
+allowHostPorts: false
+allowedCapabilities: []
+allowHostPID: true
+allowHostIPC: true
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+defaultAddCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - emptyDir
+  - hostPath
+  - secret
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ template "topolvm.fullname" . }}-lvmd
+---
+{{- end }}

--- a/charts/topolvm/templates/node/scc.yaml
+++ b/charts/topolvm/templates/node/scc.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.securityContextConstraint.create }}
+---
+# scc for the topolvm deployment and daemonsets
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: {{ template "topolvm.fullname" . }}-node
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+priority:
+allowHostNetwork: false
+allowHostPorts: false
+allowedCapabilities: []
+allowHostPID: true
+allowHostIPC: true
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+defaultAddCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - emptyDir
+  - hostPath
+  - secret
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ template "topolvm.fullname" . }}-node
+---
+{{- end }}

--- a/charts/topolvm/templates/scheduler/scc.yaml
+++ b/charts/topolvm/templates/scheduler/scc.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.securityContextConstraint.create  .Values.scheduler.enabled }}
+---
+# scc for the topolvm deployment and daemonsets
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: {{ template "topolvm.fullname" . }}-scheduler
+allowPrivilegedContainer: false
+allowHostDirVolumePlugin: false
+priority:
+allowHostNetwork: true
+allowHostPorts: false
+allowedCapabilities: []
+allowHostPID: false
+allowHostIPC: false
+readOnlyRootFilesystem: true
+requiredDropCapabilities: []
+defaultAddCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - emptyDir
+  - secret
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ template "topolvm.fullname" . }}-scheduler
+---
+{{- end }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -466,6 +466,11 @@ podSecurityPolicy:
   ## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
   create: true
 
+securityContextConstraint:
+  # securityContextConstraint.create -- Create Openshift Security Context Constraints.
+  ## ref: https://docs.okd.io/latest/authentication/managing-security-context-constraints.html
+  create: false
+
 cert-manager:
   # cert-manager.enabled -- Install cert-manager together.
   ## ref: https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm


### PR DESCRIPTION
fixes: #387 

Testing:

```
$ oc version                                  
Client Version: 4.9.0
Server Version: 4.9.0
Kubernetes Version: v1.22.0-rc.0+894a78b

```
1. With K8s Storage Capacity:
```
# sapillai @ localhost in ~/go/src/github.com/topolvm/charts/topolvm on git:scc x [17:16:08] 
$ oc get pods 
NAME                                              READY   STATUS    RESTARTS   AGE
my-pod                                            1/1     Running   0          161m
my-pod-2                                          1/1     Running   0          161m
my-pod-3                                          1/1     Running   0          161m
my-pod-4                                          1/1     Running   0          87s
my-pod-5                                          1/1     Running   0          10s
topolvm-cert-manager-cainjector-97768874c-8qt74   1/1     Running   0          4m22s
topolvm-cert-manager-d746b79b-wlkr2               1/1     Running   0          4m22s
topolvm-cert-manager-webhook-559ff4fb5d-nkws6     1/1     Running   0          4m22s
topolvm-controller-7f4dcbb55b-gnpdx               4/4     Running   0          4m19s
topolvm-controller-7f4dcbb55b-mxm5v               4/4     Running   0          4m19s
topolvm-lvmd-0-2v7z9                              1/1     Running   0          4m19s
topolvm-lvmd-0-6vb6j                              1/1     Running   0          4m19s
topolvm-lvmd-0-f9nqk                              1/1     Running   0          4m19s
topolvm-node-27l95                                3/3     Running   0          4m19s
topolvm-node-hndkt                                3/3     Running   0          4m19s
topolvm-node-m2rpn                                3/3     Running   0          4m19s

# sapillai @ localhost in ~/go/src/github.com/topolvm/charts/topolvm on git:scc x [17:16:10] 
$ oc get pvc  
NAME            STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS          AGE
topolvm-pvc     Bound    pvc-c2d31e4e-aa8d-4c43-97cf-3aec7212eed4   5Gi        RWO            topolvm-provisioner   162m
topolvm-pvc-2   Bound    pvc-1c617e63-3cd1-4e43-9b8b-37df84d2bb2e   10Gi       RWO            topolvm-provisioner   161m
topolvm-pvc-3   Bound    pvc-33a4223e-4e6e-448f-be47-0a24aabe98fe   50Gi       RWO            topolvm-provisioner   161m
topolvm-pvc-4   Bound    pvc-31fd0d41-e7ff-4446-a572-363c997821df   50Gi       RWO            topolvm-provisioner   91s
topolvm-pvc-5   Bound    pvc-c2b30f26-2776-426d-8dc2-985cbfefff21   2Gi        RWO            topolvm-provisioner   15s

# sapillai @ localhost in ~/go/src/github.com/topolvm/charts/topolvm on git:scc x [17:16:14] 
$ oc get scc | grep topo
topolvm-controller                true    []           MustRunAs   RunAsAny           MustRunAs   RunAsAny    <no value>   false            ["configMap","emptyDir","hostPath","secret"]
topolvm-lvmd                      true    []           MustRunAs   RunAsAny           MustRunAs   RunAsAny    <no value>   false            ["configMap","emptyDir","hostPath","secret"]
topolvm-node                      true    []           MustRunAs   RunAsAny           MustRunAs   RunAsAny    <no value>   false            ["configMap","emptyDir","hostPath","secret"]
```

2. With Scheduler Extension:

``` 
# sapillai @ localhost in ~/go/src/github.com/topolvm/example on git:scc x [18:29:29] 
$ oc get pods                         
NAME                                              READY   STATUS    RESTARTS   AGE
my-pod-10                                         1/1     Running   0          98s
my-pod-11                                         1/1     Running   0          51s
topolvm-cert-manager-cainjector-97768874c-7jct2   1/1     Running   0          9m5s
topolvm-cert-manager-d746b79b-sthjx               1/1     Running   0          9m5s
topolvm-cert-manager-webhook-dc6f8b9b4-87mft      1/1     Running   0          9m5s
topolvm-controller-7cc7f8b6b-2sl4n                4/4     Running   0          9m2s
topolvm-controller-7cc7f8b6b-qsb6l                4/4     Running   0          9m2s
topolvm-lvmd-0-gtw4l                              1/1     Running   0          9m2s
topolvm-lvmd-0-k5w7f                              1/1     Running   0          9m2s
topolvm-lvmd-0-m62bt                              1/1     Running   0          9m2s
topolvm-node-pkh9v                                3/3     Running   0          9m2s
topolvm-node-skf4q                                3/3     Running   0          9m2s
topolvm-node-z2d5f                                3/3     Running   0          9m2s
topolvm-scheduler-dgxnd                           1/1     Running   0          9m2s
topolvm-scheduler-g2pzl                           1/1     Running   0          9m3s
topolvm-scheduler-pxmdd                           1/1     Running   0          9m2s

# sapillai @ localhost in ~/go/src/github.com/topolvm/example on git:scc x [18:30:18] 
$ oc get pv   
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                            STORAGECLASS          REASON   AGE
pvc-d00ccd25-ff0f-4ae2-a852-e00e3a05ecfe   25Gi       RWO            Delete           Bound    topolvm-system2/topolvm-pvc-11   topolvm-provisioner            55s
pvc-e053b76e-0cd9-4e10-8505-bc82ddcd0a61   15Gi       RWO            Delete           Bound    topolvm-system2/topolvm-pvc-10   topolvm-provisioner            103s


# sapillai @ localhost in ~/go/src/github.com/topolvm/example on git:scc x [18:30:33] 
$ oc get scc               
NAME                              PRIV    CAPS         SELINUX     RUNASUSER          FSGROUP     SUPGROUP    PRIORITY     READONLYROOTFS   VOLUMES
...
topolvm-controller                true    []           MustRunAs   RunAsAny           MustRunAs   RunAsAny    <no value>   false            ["configMap","emptyDir","hostPath","secret"]
topolvm-lvmd                      true    []           MustRunAs   RunAsAny           MustRunAs   RunAsAny    <no value>   false            ["configMap","emptyDir","hostPath","secret"]
topolvm-node                      true    []           MustRunAs   RunAsAny           MustRunAs   RunAsAny    <no value>   false            ["configMap","emptyDir","hostPath","secret"]
topolvm-scheduler                 false   []           MustRunAs   RunAsAny           MustRunAs   RunAsAny    <no value>   true             ["configMap","emptyDir","secret"]
```
Signed-off-by: Santosh Pillai <sapillai@redhat.com>