### PR TITLE
helm: remove k8s version specification from Chart.yaml

### DIFF
--- a/charts/topolvm/Chart.yaml
+++ b/charts/topolvm/Chart.yaml
@@ -6,7 +6,6 @@ name: topolvm
 description: Topolvm
 version: 3.2.0
 appVersion: 0.10.3
-kubeVersion: ">=1.18.0-0"
 sources:
   - https://github.com/topolvm/topolvm
 

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -3,7 +3,6 @@
 
 ## Prerequisites
 
-* Kubernetes 1.20+
 * Configure `kube-scheduler` on the underlying nodes, ref: https://github.com/topolvm/topolvm/tree/master/deploy#configure-kube-scheduler
 * `cert-manager` version `v1.0.0+` installed. ref: https://cert-manager.io/
 * Requires at least `v3.5.0+` version of helm to support

--- a/charts/topolvm/README.md.gotmpl
+++ b/charts/topolvm/README.md.gotmpl
@@ -3,7 +3,6 @@
 
 ## Prerequisites
 
-* Kubernetes 1.20+
 * Configure `kube-scheduler` on the underlying nodes, ref: https://github.com/topolvm/topolvm/tree/master/deploy#configure-kube-scheduler
 * `cert-manager` version `v1.0.0+` installed. ref: https://cert-manager.io/
 * Requires at least `v3.5.0+` version of helm to support


### PR DESCRIPTION
Since supported Kubernetes version is specified in top level README.md file, remove it from helm Chart.yaml.