### PR TITLE
Update links in design doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A diagram of components is available in [docs/design.md](docs/design.md#diagram)
 This repository contains these programs:
 
 - `topolvm-controller`: CSI controller service.
-- `topolvm-scheduler`: A [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) for TopoLVM.
+- `topolvm-scheduler`: A [scheduler plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/) for TopoLVM.
 - `topolvm-node`: CSI node service.
 - `lvmd`: gRPC service to manage LVM volumes.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -151,7 +151,7 @@ When doing so, do not apply [certificates.yaml](./manifests/base/certificates.ya
 
 ### topolvm-scheduler
 
-[topolvm-scheduler][] is a [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) for `kube-scheduler`.
+[topolvm-scheduler][] is a [scheduler plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/) for `kube-scheduler`.
 It must be deployed to where `kube-scheduler` can connect.
 
 If your Kubernetes cluster runs the control plane on Nodes, `topolvm-scheduler` should be run as DaemonSet

--- a/docs/design.md
+++ b/docs/design.md
@@ -26,7 +26,7 @@ Components
 ----------
 
 - `topolvm-controller`: CSI controller service.
-- `topolvm-scheduler`: A [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) for TopoLVM.
+- `topolvm-scheduler`: A [scheduler plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/) for TopoLVM.
 - `topolvm-node`: CSI node service.
 - `lvmd`: gRPC service to manage LVM volumes.
 
@@ -65,10 +65,10 @@ dynamic volume provisioning.  Details are described in the following sections.
 a custom Kubernetes controller to implement dynamic volume provisioning and
 resource cleanups.
 
-`topolvm-scheduler` is a [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) to extend the
+`topolvm-scheduler` is a [scheduler plugin](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/) to extend the
 standard Kubernetes scheduler for TopoLVM.
 
-### How the scheduler extension works
+### How the scheduler plugin works
 
 To extend the standard scheduler, TopoLVM components work together as follows:
 


### PR DESCRIPTION
This updates some old links regarding the scheduler design proposal. I also changed `extender` -> `plugin` in the same places since this seems to be the current terminology used. However, I'm sure there are many more places where we have "extender", not sure if it is worth updating all of them since it is still easy to understand I think.

The old link goes here: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md
It links to [this archived repo](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md). But I think it makes more sense to change the link to [the scheduling framework docs](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/) (which is what I did in this PR), or to [this KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/624-scheduling-framework/README.md) (which is linked in the scheduler framework docs also).