### PR TITLE
Add topolvm-controller CLI flag to skip node finalize

### DIFF
--- a/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
@@ -12,10 +12,12 @@ jobs:
       matrix:
         test_kubernetes_target: [current, prev, prev2]
         storage_capacity: ["false", "true"]
+        skip_node_finalize: ["false", "true"]
     env:
       TEST_KUBERNETES_TARGET: ${{ matrix.test_kubernetes_target }}
       TEST_SCHEDULER_MANIFEST: deployment
       STORAGE_CAPACITY: ${{ matrix.storage_capacity }}
+      SKIP_NODE_FINALIZE: ${{ matrix.skip_node_finalize }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -13,10 +13,12 @@ jobs:
         test_kubernetes_target: [current, prev, prev2]
         test_scheduler_manifest: [daemonset, deployment]
         storage_capacity: ["false", "true"]
+        skip_node_finalize: ["false", "true"]
     env:
       TEST_KUBERNETES_TARGET: ${{ matrix.test_kubernetes_target }}
       TEST_SCHEDULER_MANIFEST: ${{ matrix.test_scheduler_manifest }}
       STORAGE_CAPACITY: ${{ matrix.storage_capacity }}
+      SKIP_NODE_FINALIZE: ${{ matrix.skip_node_finalize }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -84,6 +84,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | cert-manager.enabled | bool | `false` | Install cert-manager together. |
 | controller.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["topolvm-controller"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Specify affinity. |
 | controller.minReadySeconds | int | `nil` | Specify minReadySeconds. |
+| controller.nodeFinalize.skipped | bool | `false` | Skip automatic cleanup of PhysicalVolumeClaims when a Node is deleted. |
 | controller.nodeSelector | object | `{}` | Specify nodeSelector. |
 | controller.podDisruptionBudget.enabled | bool | `true` | Specify podDisruptionBudget enabled. |
 | controller.priorityClassName | string | `nil` | Specify priorityClassName. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -37,6 +37,9 @@ spec:
           command:
             - /topolvm-controller
             - --cert-dir=/certs
+            {{- if .Values.controller.nodeFinalize.skipped }}
+            - --skip-node-finalize
+            {{- end }}
           ports:
             - containerPort: 9443
               name: webhook

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -328,6 +328,10 @@ controller:
     # controller.securityContext.enabled -- Enable securityContext.
     enabled: true
 
+  nodeFinalize:
+    # controller.nodeFinalize.skipped -- Skip automatic cleanup of PhysicalVolumeClaims when a Node is deleted.
+    skipped: false
+
   prometheus:
     podMonitor:
       # controller.prometheus.podMonitor.enabled -- Set this to `true` to create PodMonitor for Prometheus operator.

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -19,6 +19,7 @@ import (
 // NodeReconciler reconciles a Node object
 type NodeReconciler struct {
 	client.Client
+	SkipNodeFinalize bool
 }
 
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
@@ -95,6 +96,11 @@ func (r *NodeReconciler) targetStorageClasses(ctx context.Context) (map[string]b
 }
 
 func (r *NodeReconciler) doFinalize(ctx context.Context, log logr.Logger, node *corev1.Node) (ctrl.Result, error) {
+	if r.SkipNodeFinalize {
+		log.Info("skipping node finalize")
+		return ctrl.Result{}, nil
+	}
+
 	scs, err := r.targetStorageClasses(ctx)
 	if err != nil {
 		log.Error(err, "unable to fetch StorageClass")

--- a/docs/topolvm-controller.md
+++ b/docs/topolvm-controller.md
@@ -159,7 +159,11 @@ Controllers
 `topolvm-metrics` adds `topolvm.cybozu.com/node` finalizer.
 
 When a Node is being deleted, the controller deletes all PVCs and LogicalVolumes for TopoLVM
-on the deleting node.
+on the deleting node. 
+
+This node finalize procedure may be skipped with the `--skip-node-finalize` flag. 
+When this is true, the PVCs and the LogicalVolume CRs from a deleted node must be
+deleted manually by a cluster administrator.
 
 ### PVC finalizer
 
@@ -171,10 +175,11 @@ the deleted PVC, if any.
 Command-line flags
 ------------------
 
-| Name                   | Type   | Default                                 | Description                                   |
-| ---------------------- | ------ | --------------------------------------- | --------------------------------------------- |
-| `cert-dir`             | string | `/tmp/k8s-webhook-server/serving-certs` | Directory for `tls.crt` and `tls.key` files.  |
-| `csi-socket`           | string | `/run/topolvm/csi-topolvm.sock`         | UNIX domain socket of `topolvm-controller`.   |
-| `metrics-bind-address` | string | `:8080`                                 | Listen address for Prometheus metrics.        |
-| `leader-election-id`   | string | `topolvm`                               | ID for leader election by controller-runtime. |
-| `webhook-addr`         | string | `:9443`                                 | Listen address for the webhook endpoint.      |
+| Name                      | Type   | Default                                 | Description                                                                  |
+| ------------------------- | ------ | --------------------------------------- | ---------------------------------------------------------------------------- |
+| `cert-dir`                | string | `/tmp/k8s-webhook-server/serving-certs` | Directory for `tls.crt` and `tls.key` files.                                 |
+| `csi-socket`              | string | `/run/topolvm/csi-topolvm.sock`         | UNIX domain socket of `topolvm-controller`.                                  |
+| `metrics-bind-address`    | string | `:8080`                                 | Listen address for Prometheus metrics.                                       |
+| `leader-election-id`      | string | `topolvm`                               | ID for leader election by controller-runtime.                                |
+| `webhook-addr`            | string | `:9443`                                 | Listen address for the webhook endpoint.                                     |
+| `skip-node-finalize`      | bool   | `false`                                 | When true, skips automatic cleanup of PhysicalVolumeClaims on Node deletion. |

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -2,6 +2,7 @@
 TEST_KUBERNETES_TARGET ?= current
 TEST_SCHEDULER_MANIFEST ?= daemonset
 STORAGE_CAPACITY ?= false
+SKIP_NODE_FINALIZE ?= false
 
 ## Dependency versions
 MINIKUBE_VERSION := v1.23.2
@@ -57,6 +58,12 @@ endif
 
 else
 HELM_VALUES_FILE_LVMD := manifests/values/daemonset-lvmd.yaml
+endif
+
+ifeq ($(SKIP_NODE_FINALIZE),true)
+HELM_SKIP_NODE_FINALIZE_FLAG := --set controller.nodeFinalize.skipped=true
+else
+HELM_SKIP_NODE_FINALIZE_FLAG :=
 endif
 
 SCHEDULER_CONFIG := scheduler-config-v1beta1-$(TEST_SCHEDULER_MANIFEST).yaml
@@ -154,9 +161,9 @@ ifneq ($(HELM_VALUES_FILE),"")
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo update
 	$(HELM) dependency build ../charts/topolvm/
-	$(HELM) install --namespace=topolvm-system topolvm ../charts/topolvm/ -f $(HELM_VALUES_FILE)
+	$(HELM) install --namespace=topolvm-system topolvm ../charts/topolvm/ -f $(HELM_VALUES_FILE) $(HELM_SKIP_NODE_FINALIZE_FLAG)
 	$(KUBECTL) apply -f manifests/common/
-	$(SUDO) -E env PATH=${PATH} E2ETEST=1 BINDIR=$(BINDIR) STORAGE_CAPACITY=$(STORAGE_CAPACITY) READ_WRITE_ONCE_POD=$(READ_WRITE_ONCE_POD) GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn $(GINKGO) --failFast -v .
+	$(SUDO) -E env PATH=${PATH} E2ETEST=1 BINDIR=$(BINDIR) STORAGE_CAPACITY=$(STORAGE_CAPACITY) SKIP_NODE_FINALIZE=$(SKIP_NODE_FINALIZE) READ_WRITE_ONCE_POD=$(READ_WRITE_ONCE_POD) GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn $(GINKGO) --failFast -v .
 endif
 
 .PHONY: clean
@@ -238,9 +245,9 @@ ifneq ($(HELM_VALUES_FILE_LVMD),"")
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo update
 	$(HELM) dependency build ../charts/topolvm/
-	$(HELM) install --create-namespace --namespace=topolvm-system topolvm ../charts/topolvm/ -f $(HELM_VALUES_FILE_LVMD)
+	$(HELM) install --create-namespace --namespace=topolvm-system topolvm ../charts/topolvm/ -f $(HELM_VALUES_FILE_LVMD) $(HELM_SKIP_NODE_FINALIZE_FLAG)
 	$(KUBECTL) apply -f manifests/common/
-	$(SUDO) -E env PATH=${PATH} E2ETEST=1 BINDIR=$(BINDIR) STORAGE_CAPACITY=$(STORAGE_CAPACITY) READ_WRITE_ONCE_POD=$(READ_WRITE_ONCE_POD) DAEMONSET_LVMD=true GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn $(GINKGO) --failFast -v .
+	$(SUDO) -E env PATH=${PATH} E2ETEST=1 BINDIR=$(BINDIR) STORAGE_CAPACITY=$(STORAGE_CAPACITY) SKIP_NODE_FINALIZE=$(SKIP_NODE_FINALIZE) READ_WRITE_ONCE_POD=$(READ_WRITE_ONCE_POD) DAEMONSET_LVMD=true GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn $(GINKGO) --failFast -v .
 endif
 
 .PHONY: daemonset-lvmd/clean

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -78,6 +78,10 @@ func isStorageCapacity() bool {
 	return os.Getenv("STORAGE_CAPACITY") == "true"
 }
 
+func isNodeFinalizeSkipped() bool {
+	return os.Getenv("SKIP_NODE_FINALIZE") == "true"
+}
+
 func skipIfDaemonsetLvmd() {
 	if isDaemonsetLvmdEnvSet() {
 		Skip("skip because current environment is daemonset lvmd")

--- a/pkg/topolvm-controller/cmd/root.go
+++ b/pkg/topolvm-controller/cmd/root.go
@@ -17,6 +17,7 @@ var config struct {
 	webhookAddr      string
 	certDir          string
 	leaderElectionID string
+	skipNodeFinalize bool
 	zapOpts          zap.Options
 }
 
@@ -49,6 +50,7 @@ func init() {
 	fs.StringVar(&config.webhookAddr, "webhook-addr", ":9443", "Listen address for the webhook endpoint")
 	fs.StringVar(&config.certDir, "cert-dir", "", "certificate directory")
 	fs.StringVar(&config.leaderElectionID, "leader-election-id", "topolvm", "ID for leader election by controller-runtime")
+	fs.BoolVar(&config.skipNodeFinalize, "skip-node-finalize", false, "skips automatic cleanup of PhysicalVolumeClaims when a Node is deleted")
 
 	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(goflags)

--- a/pkg/topolvm-controller/cmd/run.go
+++ b/pkg/topolvm-controller/cmd/run.go
@@ -79,7 +79,8 @@ func subMain() error {
 
 	// register controllers
 	nodecontroller := &controllers.NodeReconciler{
-		Client: mgr.GetClient(),
+		Client:           mgr.GetClient(),
+		SkipNodeFinalize: config.skipNodeFinalize,
 	}
 	if err := nodecontroller.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Node")


### PR DESCRIPTION
Adds a flag `--skip-node-finalize` to the topolvm-controller, which skips the doFinalize function in the node controller. When the flag is enabled, PersistentVolumeClaims are not automatically cleaned up when a Node is deleted. An administrator for the Kubernetes cluster should clear up the PVCs/LogicalVolumes manually.

The Helm value controller.nodeFinalize.skipped has been added to support the new flag from the Helm chart.

The e2e tests and documentation are updated as well, along with a new entry in the matrix for the GitHub action, which deploys the chart with the flag turned on/off. The cleanup checks have been amended to cover both cases.

Fixes #397