### PR TITLE
Make kubelet work directory overridable via single chart parameter

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -114,14 +114,15 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | lvmd.managed | bool | `true` | If true, set up lvmd service with DaemonSet. |
 | lvmd.nodeSelector | object | `{}` | Specify nodeSelector. |
 | lvmd.priorityClassName | string | `nil` | Specify priorityClassName. |
-| lvmd.psp.allowedHostPaths | list | `[{"pathPrefix":"/run/topolvm","readOnly":false}]` | Specify allowedHostPaths. |
+| lvmd.psp.allowedHostPaths | list | `[]` | Specify allowedHostPaths. |
 | lvmd.resources | object | `{}` | Specify resources. |
 | lvmd.socketName | string | `"/run/topolvm/lvmd.sock"` | Specify socketName. |
 | lvmd.tolerations | list | `[]` | Specify tolerations. |
 | lvmd.updateStrategy | object | `{}` | Specify updateStrategy. |
-| lvmd.volumeMounts | list | `[{"mountPath":"/run/topolvm","name":"lvmd-socket-dir"}]` | Specify volumeMounts. |
-| lvmd.volumes | list | `[{"hostPath":{"path":"/run/topolvm","type":"DirectoryOrCreate"},"name":"lvmd-socket-dir"}]` | Specify volumes. |
-| node.lvmdSocket | string | `"/run/lvmd/lvmd.sock"` | Specify the socket to be used for communication with lvmd. |
+| lvmd.volumeMounts | list | `[]` | Specify volumeMounts. |
+| lvmd.volumes | list | `[]` | Specify volumes. |
+| node.kubeletWorkDirectory | string | `"/var/lib/kubelet"` | Specify the work directory of Kubelet on the host. For example, on microk8s it needs to be set to `/var/snap/microk8s/common/var/lib/kubelet` |
+| node.lvmdSocket | string | `"/run/topolvm/lvmd.sock"` | Specify the socket to be used for communication with lvmd. |
 | node.metrics.annotations | object | `{"prometheus.io/port":"metrics"}` | Annotations for Scrape used by Prometheus. |
 | node.metrics.enabled | bool | `true` | If true, enable scraping of metrics by Prometheus. |
 | node.nodeSelector | object | `{}` | Specify nodeSelector. |
@@ -133,13 +134,13 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | node.prometheus.podMonitor.namespace | string | `""` | Optional namespace in which to create PodMonitor. |
 | node.prometheus.podMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping. |
 | node.prometheus.podMonitor.scrapeTimeout | string | `""` | Scrape timeout. If not set, the Prometheus default scrape timeout is used. |
-| node.psp.allowedHostPaths | list | `[{"pathPrefix":"/var/lib/kubelet","readOnly":false},{"pathPrefix":"/run/topolvm","readOnly":false}]` | Specify allowedHostPaths. |
+| node.psp.allowedHostPaths | list | `[]` | Specify volumes. |
 | node.resources | object | `{}` | Specify resources. |
 | node.securityContext.privileged | bool | `true` |  |
 | node.tolerations | list | `[]` | Specify tolerations. |
 | node.updateStrategy | object | `{}` | Specify updateStrategy. |
-| node.volumeMounts.topolvmNode | list | `[{"mountPath":"/run/topolvm","name":"node-plugin-dir"},{"mountPath":"/run/lvmd","name":"lvmd-socket-dir"},{"mountPath":"/var/lib/kubelet/pods","mountPropagation":"Bidirectional","name":"pod-volumes-dir"},{"mountPath":"/var/lib/kubelet/plugins/kubernetes.io/csi","mountPropagation":"Bidirectional","name":"csi-plugin-dir"}]` | Specify volumeMounts for topolvm-node container. |
-| node.volumes | list | `[{"hostPath":{"path":"/var/lib/kubelet/plugins_registry/","type":"Directory"},"name":"registration-dir"},{"hostPath":{"path":"/var/lib/kubelet/plugins/topolvm.cybozu.com/node","type":"DirectoryOrCreate"},"name":"node-plugin-dir"},{"hostPath":{"path":"/var/lib/kubelet/plugins/kubernetes.io/csi","type":"DirectoryOrCreate"},"name":"csi-plugin-dir"},{"hostPath":{"path":"/var/lib/kubelet/pods/","type":"DirectoryOrCreate"},"name":"pod-volumes-dir"},{"hostPath":{"path":"/run/topolvm","type":"Directory"},"name":"lvmd-socket-dir"}]` | Specify volumes. |
+| node.volumeMounts.topolvmNode | list | `[]` | Specify volumes. |
+| node.volumes | list | `[]` | Specify volumes. |
 | podSecurityPolicy.create | bool | `true` | Enable pod security policy. |
 | priorityClass.enabled | bool | `true` | Install priorityClass. |
 | priorityClass.name | string | `"topolvm"` | Specify priorityClass resource name. |

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -51,15 +51,23 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/topolvm
-            {{- with .Values.lvmd.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- if .Values.lvmd.volumeMounts }}
+            {{- toYaml .Values.lvmd.volumeMounts | nindent 12 }}
+            {{- else}}
+            - name: lvmd-socket-dir
+              mountPath: {{ dir .Values.lvmd.socketName }}
+            {{- end}}
       volumes:
         - name: config
           configMap:
             name: {{ template "topolvm.fullname" . }}-lvmd-{{ $lvmdidx }}
-        {{- with .Values.lvmd.volumes }}
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.lvmd.volumes }}
+        {{- toYaml .Values.lvmd.volumes | nindent 8 }}
+        {{- else }}
+        - name: lvmd-socket-dir
+          hostPath:
+            path: {{ dir .Values.lvmd.socketName }}
+            type: DirectoryOrCreate
         {{- end }}
       {{- with $lvmd.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}

--- a/charts/topolvm/templates/lvmd/psp.yaml
+++ b/charts/topolvm/templates/lvmd/psp.yaml
@@ -14,9 +14,13 @@ spec:
     - 'emptyDir'
     - 'hostPath'
     - 'secret'
-  {{- with .Values.lvmd.psp.allowedHostPaths }}
-  allowedHostPaths: {{ toYaml . | nindent 2 }}
-  {{- end }}
+  allowedHostPaths:
+    {{- if .Values.lvmd.psp.allowedHostPaths }}
+    {{- toYaml .Values.lvmd.psp.allowedHostPaths | nindent 4 }}
+    {{- else }}
+    - pathPrefix: {{ dir .Values.lvmd.socketName }}
+      readOnly: false
+    {{- end }}
   runAsUser:
     rule: 'RunAsAny'
   seLinux:

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -35,6 +35,7 @@ spec:
           {{- end }}
           command:
             - /topolvm-node
+            - --csi-socket={{ .Values.node.kubeletWorkDirectory }}/plugins/topolvm.cybozu.com/node/csi-topolvm.sock
             - --lvmd-socket={{ .Values.node.lvmdSocket }}
           ports:
             - name: healthz
@@ -59,9 +60,21 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          {{- with .Values.node.volumeMounts.topolvmNode }}
-          volumeMounts: {{ toYaml . | nindent 12 }}
-          {{- end }}
+          volumeMounts:
+            {{- if .Values.node.volumeMounts.topolvmNode }}
+            {{- toYaml .Values.node.volumeMounts.topolvmNode | nindent 12 }}
+            {{- else }}
+            - name: node-plugin-dir
+              mountPath: {{ .Values.node.kubeletWorkDirectory }}/plugins/topolvm.cybozu.com/node/
+            - name: lvmd-socket-dir
+              mountPath: {{ dir .Values.node.lvmdSocket }}
+            - name: pod-volumes-dir
+              mountPath: {{ .Values.node.kubeletWorkDirectory }}/pods
+              mountPropagation: "Bidirectional"
+            - name: csi-plugin-dir
+              mountPath: {{ .Values.node.kubeletWorkDirectory }}/plugins/kubernetes.io/csi
+              mountPropagation: "Bidirectional"
+            {{- end }}
 
         - name: csi-registrar
           {{- if .Values.image.csi.nodeDriverRegistrar }}
@@ -74,13 +87,13 @@ spec:
           {{- end }}
           command:
             - /csi-node-driver-registrar
-            - --csi-address=/run/topolvm/csi-topolvm.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/topolvm.cybozu.com/node/csi-topolvm.sock
+            - --csi-address={{ .Values.node.kubeletWorkDirectory }}/plugins/topolvm.cybozu.com/node/csi-topolvm.sock
+            - --kubelet-registration-path={{ .Values.node.kubeletWorkDirectory }}/plugins/topolvm.cybozu.com/node/csi-topolvm.sock
           livenessProbe:
             exec:
               command:
               - /csi-node-driver-registrar
-              - --kubelet-registration-path=/var/lib/kubelet/plugins/topolvm.cybozu.com/node/csi-topolvm.sock
+              - --kubelet-registration-path={{ .Values.node.kubeletWorkDirectory }}/plugins/topolvm.cybozu.com/node/csi-topolvm.sock
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
           lifecycle:
@@ -92,7 +105,7 @@ spec:
                 - rm -rf /registration/topolvm.cybozu.com /registration/topolvm.cybozu.com-reg.sock
           volumeMounts:
             - name: node-plugin-dir
-              mountPath: /run/topolvm
+              mountPath: {{ .Values.node.kubeletWorkDirectory }}/plugins/topolvm.cybozu.com/node/
             - name: registration-dir
               mountPath: /registration
 
@@ -107,14 +120,36 @@ spec:
           {{- end }}
           command:
             - /livenessprobe
-            - --csi-address=/run/topolvm/csi-topolvm.sock
+            - --csi-address={{ .Values.node.kubeletWorkDirectory }}/plugins/topolvm.cybozu.com/node/csi-topolvm.sock
           volumeMounts:
             - name: node-plugin-dir
-              mountPath: /run/topolvm
+              mountPath: {{ .Values.node.kubeletWorkDirectory }}/plugins/topolvm.cybozu.com/node/
 
-      {{- with .Values.node.volumes }}
-      volumes: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      volumes:
+        {{- if .Values.node.volumes }}
+        {{- toYaml .Values.node.volumes | nindent 8 }}
+        {{- else }}
+        - name: registration-dir
+          hostPath:
+            path: {{ .Values.node.kubeletWorkDirectory }}/plugins_registry/
+            type: Directory
+        - name: node-plugin-dir
+          hostPath:
+            path: {{ .Values.node.kubeletWorkDirectory }}/plugins/topolvm.cybozu.com/node
+            type: DirectoryOrCreate
+        - name: csi-plugin-dir
+          hostPath:
+            path: {{ .Values.node.kubeletWorkDirectory }}/plugins/kubernetes.io/csi
+            type: DirectoryOrCreate
+        - name: pod-volumes-dir
+          hostPath:
+            path: {{ .Values.node.kubeletWorkDirectory }}/pods/
+            type: DirectoryOrCreate
+        - name: lvmd-socket-dir
+          hostPath:
+            path: {{ dir .Values.node.lvmdSocket }}
+            type: Directory
+        {{- end }}
 
       {{- with .Values.node.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}

--- a/charts/topolvm/templates/node/psp.yaml
+++ b/charts/topolvm/templates/node/psp.yaml
@@ -14,9 +14,15 @@ spec:
     - 'emptyDir'
     - 'secret'
     - 'hostPath'
-  {{- with .Values.node.psp.allowedHostPaths }}
-  allowedHostPaths: {{ toYaml . | nindent 2 }}
-  {{- end }}
+  allowedHostPaths:
+    {{- if .Values.node.psp.allowedHostPaths }}
+    {{- toYaml .Values.node.psp.allowedHostPaths | nindent 4 }}
+    {{- else }}
+    - pathPrefix: {{ .Values.node.kubeletWorkDirectory }}
+      readOnly: false
+    - pathPrefix: {{ dir .Values.node.lvmdSocket }}
+      readOnly: false
+    {{- end }}
   hostNetwork: false
   runAsUser:
     rule: 'RunAsAny'

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -157,16 +157,16 @@ lvmd:
   nodeSelector: {}
 
   # lvmd.volumes -- Specify volumes.
-  volumes:
-    - name: lvmd-socket-dir
-      hostPath:
-        path: /run/topolvm
-        type: DirectoryOrCreate
+  volumes: []
+  #  - name: lvmd-socket-dir
+  #    hostPath:
+  #      path: /run/topolvm
+  #      type: DirectoryOrCreate
 
   # lvmd.volumeMounts -- Specify volumeMounts.
-  volumeMounts:
-    - name: lvmd-socket-dir
-      mountPath: /run/topolvm
+  volumeMounts: []
+  #  - name: lvmd-socket-dir
+  #    mountPath: /run/topolvm
 
   # lvmd.additionalConfigs -- Define additional LVM Daemon configs if you have additional types of nodes.
   # Please ensure nodeSelectors are non overlapping.
@@ -181,9 +181,9 @@ lvmd:
 
   psp:
     # lvmd.psp.allowedHostPaths -- Specify allowedHostPaths.
-    allowedHostPaths:
-      - pathPrefix: "/run/topolvm"
-        readOnly: false
+    allowedHostPaths: []
+    #  - pathPrefix: "/run/topolvm"
+    #    readOnly: false
 
   # lvmd.updateStrategy -- Specify updateStrategy.
   updateStrategy: {}
@@ -195,7 +195,10 @@ lvmd:
 # CSI node service
 node:
   # node.lvmdSocket -- Specify the socket to be used for communication with lvmd.
-  lvmdSocket: /run/lvmd/lvmd.sock
+  lvmdSocket: /run/topolvm/lvmd.sock
+  # node.kubeletWorkDirectory -- Specify the work directory of Kubelet on the host.
+  # For example, on microk8s it needs to be set to `/var/snap/microk8s/common/var/lib/kubelet`
+  kubeletWorkDirectory: /var/lib/kubelet
 
   # node.securityContext. -- Container securityContext.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -264,49 +267,49 @@ node:
   nodeSelector: {}
 
   # node.volumes -- Specify volumes.
-  volumes:
-    - name: registration-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins_registry/
-        type: Directory
-    - name: node-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/topolvm.cybozu.com/node
-        type: DirectoryOrCreate
-    - name: csi-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/kubernetes.io/csi
-        type: DirectoryOrCreate
-    - name: pod-volumes-dir
-      hostPath:
-        path: /var/lib/kubelet/pods/
-        type: DirectoryOrCreate
-    - name: lvmd-socket-dir
-      hostPath:
-        path: /run/topolvm
-        type: Directory
+  volumes: []
+  #  - name: registration-dir
+  #    hostPath:
+  #      path: /var/lib/kubelet/plugins_registry/
+  #      type: Directory
+  #  - name: node-plugin-dir
+  #    hostPath:
+  #      path: /var/lib/kubelet/plugins/topolvm.cybozu.com/node
+  #      type: DirectoryOrCreate
+  #  - name: csi-plugin-dir
+  #    hostPath:
+  #      path: /var/lib/kubelet/plugins/kubernetes.io/csi
+  #      type: DirectoryOrCreate
+  #  - name: pod-volumes-dir
+  #    hostPath:
+  #      path: /var/lib/kubelet/pods/
+  #      type: DirectoryOrCreate
+  #  - name: lvmd-socket-dir
+  #    hostPath:
+  #      path: /run/topolvm
+  #      type: Directory
 
   volumeMounts:
-    # node.volumeMounts.topolvmNode -- Specify volumeMounts for topolvm-node container.
-    topolvmNode:
-      - name: node-plugin-dir
-        mountPath: /run/topolvm
-      - name: lvmd-socket-dir
-        mountPath: /run/lvmd
-      - name: pod-volumes-dir
-        mountPath: /var/lib/kubelet/pods
-        mountPropagation: "Bidirectional"
-      - name: csi-plugin-dir
-        mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
-        mountPropagation: "Bidirectional"
+    # node.volumeMounts.topolvmNode -- Specify volumes.
+    topolvmNode: []
+    # - name: node-plugin-dir
+    #   mountPath: /var/lib/kubelet/plugins/topolvm.cybozu.com/node
+    # - name: csi-plugin-dir
+    #   mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+    #   mountPropagation: "Bidirectional"
+    # - name: pod-volumes-dir
+    #   mountPath: /var/lib/kubelet/pods
+    #   mountPropagation: "Bidirectional"
+    # - name: lvmd-socket-dir
+    #   mountPath: /run/topolvm
 
   psp:
-    # node.psp.allowedHostPaths -- Specify allowedHostPaths.
-    allowedHostPaths:
-      - pathPrefix: "/var/lib/kubelet"
-        readOnly: false
-      - pathPrefix: "/run/topolvm"
-        readOnly: false
+    # node.psp.allowedHostPaths -- Specify volumes.
+    allowedHostPaths: []
+    # - pathPrefix: "/var/lib/kubelet"
+    #   readOnly: false
+    # - pathPrefix: "/run/topolvm"
+    #   readOnly: false
 
   # node.updateStrategy -- Specify updateStrategy.
   updateStrategy: {}

--- a/e2e/manifests/values/daemonset-lvmd-storage-capacity.yaml
+++ b/e2e/manifests/values/daemonset-lvmd-storage-capacity.yaml
@@ -32,59 +32,9 @@ lvmd:
     - name: "hdd2"
       volume-group: "node-myvg3"
       spare-gb: 1
-  volumes:
-    - name: lvmd-socket-dir
-      hostPath:
-        path: /tmp/topolvm/daemonset_lvmd
-        type: DirectoryOrCreate
-  volumeMounts:
-    - name: lvmd-socket-dir
-      mountPath: /tmp/topolvm/daemonset_lvmd
-  psp:
-    allowedHostPaths:
-      - pathPrefix: "/tmp/topolvm/daemonset_lvmd"
-        readOnly: false
 
 node:
-  volumeMounts:
-    topolvmNode:
-      - name: node-plugin-dir
-        mountPath: /run/topolvm
-      - name: lvmd-socket-dir
-        mountPath: /run/lvmd
-      - name: pod-volumes-dir
-        mountPath: /var/lib/kubelet/pods
-        mountPropagation: "Bidirectional"
-      - name: csi-plugin-dir
-        mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
-        mountPropagation: "Bidirectional"
-      - name: device-dir
-        mountPath: /dev
-  volumes:
-    - name: registration-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins_registry/
-        type: Directory
-    - name: node-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/topolvm.cybozu.com/node
-        type: DirectoryOrCreate
-    - name: csi-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/kubernetes.io/csi
-        type: DirectoryOrCreate
-    - name: pod-volumes-dir
-      hostPath:
-        path: /var/lib/kubelet/pods/
-        type: DirectoryOrCreate
-    - name: lvmd-socket-dir
-      hostPath:
-        path: /tmp/topolvm/daemonset_lvmd
-        type: Directory
-    - name: device-dir
-      hostPath:
-        path: /dev
-        type: Directory
+  lvmdSocket: /tmp/topolvm/daemonset_lvmd/lvmd.sock
 
 storageClasses:
   - name: topolvm-provisioner

--- a/e2e/manifests/values/daemonset-lvmd.yaml
+++ b/e2e/manifests/values/daemonset-lvmd.yaml
@@ -40,61 +40,9 @@ lvmd:
     - name: "hdd2"
       volume-group: "node-myvg3"
       spare-gb: 1
-  volumes:
-    - name: lvmd-socket-dir
-      hostPath:
-        path: /tmp/topolvm/daemonset_lvmd
-        type: DirectoryOrCreate
-  volumeMounts:
-    - name: lvmd-socket-dir
-      mountPath: /tmp/topolvm/daemonset_lvmd
-    - name: lvmd-socket-dir
-      mountPath: /run/topolvm
-  psp:
-    allowedHostPaths:
-      - pathPrefix: "/tmp/topolvm/daemonset_lvmd"
-        readOnly: false
 
 node:
-  volumeMounts:
-    topolvmNode:
-      - name: node-plugin-dir
-        mountPath: /run/topolvm
-      - name: lvmd-socket-dir
-        mountPath: /run/lvmd
-      - name: pod-volumes-dir
-        mountPath: /var/lib/kubelet/pods
-        mountPropagation: "Bidirectional"
-      - name: csi-plugin-dir
-        mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
-        mountPropagation: "Bidirectional"
-      - name: device-dir
-        mountPath: /dev
-  volumes:
-    - name: registration-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins_registry/
-        type: Directory
-    - name: node-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/topolvm.cybozu.com/node
-        type: DirectoryOrCreate
-    - name: csi-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/kubernetes.io/csi
-        type: DirectoryOrCreate
-    - name: pod-volumes-dir
-      hostPath:
-        path: /var/lib/kubelet/pods/
-        type: DirectoryOrCreate
-    - name: lvmd-socket-dir
-      hostPath:
-        path: /tmp/topolvm/daemonset_lvmd
-        type: Directory
-    - name: device-dir
-      hostPath:
-        path: /dev
-        type: Directory
+  lvmdSocket: /tmp/topolvm/daemonset_lvmd/lvmd.sock
 
 storageClasses:
   - name: topolvm-provisioner

--- a/e2e/manifests/values/daemonset-scheduler.yaml
+++ b/e2e/manifests/values/daemonset-scheduler.yaml
@@ -23,45 +23,7 @@ lvmd:
   managed: false
 
 node:
-  volumeMounts:
-    topolvmNode:
-      - name: node-plugin-dir
-        mountPath: /run/topolvm
-      - name: lvmd-socket-dir
-        mountPath: /run/lvmd
-      - name: pod-volumes-dir
-        mountPath: /var/lib/kubelet/pods
-        mountPropagation: "Bidirectional"
-      - name: csi-plugin-dir
-        mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
-        mountPropagation: "Bidirectional"
-      - name: device-dir
-        mountPath: /dev
-  volumes:
-    - name: registration-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins_registry/
-        type: Directory
-    - name: node-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/topolvm.cybozu.com/node
-        type: DirectoryOrCreate
-    - name: csi-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/kubernetes.io/csi
-        type: DirectoryOrCreate
-    - name: pod-volumes-dir
-      hostPath:
-        path: /var/lib/kubelet/pods/
-        type: DirectoryOrCreate
-    - name: lvmd-socket-dir
-      hostPath:
-        path: /tmp/topolvm
-        type: Directory
-    - name: device-dir
-      hostPath:
-        path: /dev
-        type: Directory
+  lvmdSocket: /tmp/topolvm/lvmd.sock
 
 storageClasses:
   - name: topolvm-provisioner

--- a/e2e/manifests/values/deployment-scheduler.yaml
+++ b/e2e/manifests/values/deployment-scheduler.yaml
@@ -33,45 +33,7 @@ lvmd:
   managed: false
 
 node:
-  volumeMounts:
-    topolvmNode:
-      - name: node-plugin-dir
-        mountPath: /run/topolvm
-      - name: lvmd-socket-dir
-        mountPath: /run/lvmd
-      - name: pod-volumes-dir
-        mountPath: /var/lib/kubelet/pods
-        mountPropagation: "Bidirectional"
-      - name: csi-plugin-dir
-        mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
-        mountPropagation: "Bidirectional"
-      - name: device-dir
-        mountPath: /dev
-  volumes:
-    - name: registration-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins_registry/
-        type: Directory
-    - name: node-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/topolvm.cybozu.com/node
-        type: DirectoryOrCreate
-    - name: csi-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/kubernetes.io/csi
-        type: DirectoryOrCreate
-    - name: pod-volumes-dir
-      hostPath:
-        path: /var/lib/kubelet/pods/
-        type: DirectoryOrCreate
-    - name: lvmd-socket-dir
-      hostPath:
-        path: /tmp/topolvm
-        type: Directory
-    - name: device-dir
-      hostPath:
-        path: /dev
-        type: Directory
+  lvmdSocket: /tmp/topolvm/lvmd.sock
 
 storageClasses:
   - name: topolvm-provisioner

--- a/e2e/manifests/values/storage-capacity.yaml
+++ b/e2e/manifests/values/storage-capacity.yaml
@@ -25,45 +25,7 @@ lvmd:
   managed: false
 
 node:
-  volumeMounts:
-    topolvmNode:
-      - name: node-plugin-dir
-        mountPath: /run/topolvm
-      - name: lvmd-socket-dir
-        mountPath: /run/lvmd
-      - name: pod-volumes-dir
-        mountPath: /var/lib/kubelet/pods
-        mountPropagation: "Bidirectional"
-      - name: csi-plugin-dir
-        mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
-        mountPropagation: "Bidirectional"
-      - name: device-dir
-        mountPath: /dev
-  volumes:
-    - name: registration-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins_registry/
-        type: Directory
-    - name: node-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/topolvm.cybozu.com/node
-        type: DirectoryOrCreate
-    - name: csi-plugin-dir
-      hostPath:
-        path: /var/lib/kubelet/plugins/kubernetes.io/csi
-        type: DirectoryOrCreate
-    - name: pod-volumes-dir
-      hostPath:
-        path: /var/lib/kubelet/pods/
-        type: DirectoryOrCreate
-    - name: lvmd-socket-dir
-      hostPath:
-        path: /tmp/topolvm
-        type: Directory
-    - name: device-dir
-      hostPath:
-        path: /dev
-        type: Directory
+  lvmdSocket: /tmp/topolvm/lvmd.sock
 
 storageClasses:
   - name: topolvm-provisioner


### PR DESCRIPTION
/var/lib/kubelet directory appears multiple times in node component
configuration. node.kubeletWorkDirectory parameter allows overriding
them all in concert, which is useful for deplyment on microk8s where
/var/snap/microk8s/common/var/lib/kubelet directory needs to be used
instead.

This is an alternative to #407. Either one can be used to solve the problem of deployment on microk8s cluster described in #406. This PR is larger but provides more streamlined user experience: only 1 string property to override instead of 4, 3 of which require structured values.