### PR TITLE
Update the link to the Scheduler Extender documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A diagram of components is available in [docs/design.md](docs/design.md#diagram)
 This repository contains these programs:
 
 - `topolvm-controller`: CSI controller service.
-- `topolvm-scheduler`: A [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) for TopoLVM.
+- `topolvm-scheduler`: A [scheduler extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md) for TopoLVM.
 - `topolvm-node`: CSI node service.
 - `lvmd`: gRPC service to manage LVM volumes.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -151,7 +151,7 @@ When doing so, do not apply [certificates.yaml](./manifests/base/certificates.ya
 
 ### topolvm-scheduler
 
-[topolvm-scheduler][] is a [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) for `kube-scheduler`.
+[topolvm-scheduler][] is a [scheduler extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md) for `kube-scheduler`.
 It must be deployed to where `kube-scheduler` can connect.
 
 If your Kubernetes cluster runs the control plane on Nodes, `topolvm-scheduler` should be run as DaemonSet

--- a/docs/design.md
+++ b/docs/design.md
@@ -26,7 +26,7 @@ Components
 ----------
 
 - `topolvm-controller`: CSI controller service.
-- `topolvm-scheduler`: A [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) for TopoLVM.
+- `topolvm-scheduler`: A [scheduler extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md) for TopoLVM.
 - `topolvm-node`: CSI node service.
 - `lvmd`: gRPC service to manage LVM volumes.
 
@@ -65,7 +65,7 @@ dynamic volume provisioning.  Details are described in the following sections.
 a custom Kubernetes controller to implement dynamic volume provisioning and
 resource cleanups.
 
-`topolvm-scheduler` is a [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) to extend the
+`topolvm-scheduler` is a [scheduler extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md) to extend the
 standard Kubernetes scheduler for TopoLVM.
 
 ### How the scheduler extension works

--- a/docs/topolvm-scheduler.md
+++ b/docs/topolvm-scheduler.md
@@ -1,7 +1,7 @@
 topolvm-scheduler
 =================
 
-`topolvm-scheduler` is a Kubernetes [scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) for TopoLVM.
+`topolvm-scheduler` is a Kubernetes [scheduler extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md) for TopoLVM.
 
 It filters and prioritizes Nodes based on the amount of free space in their volume groups.
 


### PR DESCRIPTION
The Scheduler Extender documentation we are currently referring to has been archived. Therefore, update it to the URL of the archive.

ref. #408 

Signed-off-by: Yuma Ogami <yuma-ogami@cybozu.co.jp>