### PR TITLE
change slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It can be considered as a specific implementation of [local persistent volumes](
 
 The team presented the motivation and implementation of TopoLVM at KubeCon Europe 2020: https://kccnceu20.sched.com/event/ZerD
 
-Join our community on Slack: [Invitation form](https://docs.google.com/forms/d/e/1FAIpQLSd2zZhqZUDTs8YUfhvKmSI_xb_iiPnz3-Hy6S7ehmHHmiifEg/viewform?embedded=true)
+Join our community on Slack: [Invitation link](https://join.slack.com/t/topolvm/shared_invite/zt-zz8dmk6a-OxQO3ovgC_zlUD3WHmMHLw)
 
 - **Project Status**: Testing for production
 - **Conformed CSI version**: [1.5.0](https://github.com/container-storage-interface/spec/blob/v1.5.0/spec.md)


### PR DESCRIPTION
Because the old form uses legacy API, I replace it with slack official invitation link