### PR TITLE
Fix flaky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ check-uncommitted: ## Check if latest generated artifacts are committed.
 
 .PHONY: lint
 lint: ## Run lint
-	test -z "$$(gofmt -s -l . | grep -v '^vendor' | tee /dev/stderr)"
+	test -z "$$(gofmt -s -l . | grep -vE '^vendor|^api/v1/zz_generated.deepcopy.go' | tee /dev/stderr)"
 	$(STATICCHECK) ./...
 	test -z "$$($(NILERR) ./... 2>&1 | tee /dev/stderr)"
 	go vet ./...

--- a/driver/k8s/logicalvolume_service.go
+++ b/driver/k8s/logicalvolume_service.go
@@ -103,7 +103,7 @@ func NewLogicalVolumeService(mgr manager.Manager) (*LogicalVolumeService, error)
 	return &LogicalVolumeService{
 		writer:       mgr.GetClient(),
 		getter:       getter.NewRetryMissingGetter(mgr.GetClient(), mgr.GetAPIReader()),
-		volumeGetter: &volumeGetter{mgr.GetClient(), mgr.GetAPIReader()},
+		volumeGetter: &volumeGetter{cacheReader: mgr.GetClient(), apiReader: mgr.GetAPIReader()},
 	}, nil
 }
 

--- a/driver/k8s/node_service.go
+++ b/driver/k8s/node_service.go
@@ -23,7 +23,7 @@ type NodeService struct {
 
 // NewNodeService returns NodeService.
 func NewNodeService(mgr manager.Manager) *NodeService {
-	return &NodeService{mgr.GetClient()}
+	return &NodeService{reader: mgr.GetClient()}
 }
 
 func (s NodeService) getNodes(ctx context.Context) (*corev1.NodeList, error) {

--- a/driver/k8s/node_service.go
+++ b/driver/k8s/node_service.go
@@ -17,17 +17,17 @@ var ErrDeviceClassNotFound = errors.New("device class not found")
 
 // NodeService represents node service.
 type NodeService struct {
-	client.Client
+	client client.Client
 }
 
 // NewNodeService returns NodeService.
 func NewNodeService(mgr manager.Manager) *NodeService {
-	return &NodeService{Client: mgr.GetClient()}
+	return &NodeService{client: mgr.GetClient()}
 }
 
 func (s NodeService) getNodes(ctx context.Context) (*corev1.NodeList, error) {
 	nl := new(corev1.NodeList)
-	err := s.List(ctx, nl)
+	err := s.client.List(ctx, nl)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (s NodeService) extractCapacityFromAnnotation(node *corev1.Node, deviceClas
 // GetCapacityByName returns VG capacity of specified node by name.
 func (s NodeService) GetCapacityByName(ctx context.Context, name, deviceClass string) (int64, error) {
 	n := new(corev1.Node)
-	err := s.Get(ctx, client.ObjectKey{Name: name}, n)
+	err := s.client.Get(ctx, client.ObjectKey{Name: name}, n)
 	if err != nil {
 		return 0, err
 	}

--- a/driver/k8s/node_service.go
+++ b/driver/k8s/node_service.go
@@ -17,17 +17,18 @@ var ErrDeviceClassNotFound = errors.New("device class not found")
 
 // NodeService represents node service.
 type NodeService struct {
-	client client.Client
+	// it is safe to use cache reader because updating node annotations is periodic.
+	reader client.Reader
 }
 
 // NewNodeService returns NodeService.
 func NewNodeService(mgr manager.Manager) *NodeService {
-	return &NodeService{client: mgr.GetClient()}
+	return &NodeService{mgr.GetClient()}
 }
 
 func (s NodeService) getNodes(ctx context.Context) (*corev1.NodeList, error) {
 	nl := new(corev1.NodeList)
-	err := s.client.List(ctx, nl)
+	err := s.reader.List(ctx, nl)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +49,7 @@ func (s NodeService) extractCapacityFromAnnotation(node *corev1.Node, deviceClas
 // GetCapacityByName returns VG capacity of specified node by name.
 func (s NodeService) GetCapacityByName(ctx context.Context, name, deviceClass string) (int64, error) {
 	n := new(corev1.Node)
-	err := s.client.Get(ctx, client.ObjectKey{Name: name}, n)
+	err := s.reader.Get(ctx, client.ObjectKey{Name: name}, n)
 	if err != nil {
 		return 0, err
 	}

--- a/getter/getter.go
+++ b/getter/getter.go
@@ -1,0 +1,35 @@
+package getter
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Unlike reconciler, webhook or CSI gRPC are one shot API, so they needs read-after-create consistency.
+// This provides us such semantics by reading api-server directly if the object is missing on the cache reader.
+type RetryMissingGetter struct {
+	cacheReader client.Reader
+	apiReader   client.Reader
+}
+
+// NewRetryMissingGetter creates a RetryMissingGetter instance.
+func NewRetryMissingGetter(cacheReader client.Reader, apiReader client.Reader) *RetryMissingGetter {
+	return &RetryMissingGetter{
+		cacheReader: cacheReader,
+		apiReader:   apiReader,
+	}
+}
+
+// Get tries cache reader, then if it returns NotFound error, retry direct reader.
+func (r *RetryMissingGetter) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	err := r.cacheReader.Get(ctx, key, obj)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+	return r.apiReader.Get(ctx, key, obj)
+}

--- a/hook/mutate_persistentvolumeclaim.go
+++ b/hook/mutate_persistentvolumeclaim.go
@@ -26,7 +26,7 @@ type persistentVolumeClaimMutator struct {
 func PVCMutator(r client.Reader, apiReader client.Reader, dec *admission.Decoder) http.Handler {
 	return &webhook.Admission{
 		Handler: &persistentVolumeClaimMutator{
-			getter: getter.NewRetryMissingGetter(r, apiReader),
+			getter:  getter.NewRetryMissingGetter(r, apiReader),
 			decoder: dec,
 		},
 	}

--- a/hook/mutate_persistentvolumeclaim.go
+++ b/hook/mutate_persistentvolumeclaim.go
@@ -24,7 +24,12 @@ type persistentVolumeClaimMutator struct {
 
 // PVCMutator creates a mutating webhook for PVCs.
 func PVCMutator(r client.Reader, apiReader client.Reader, dec *admission.Decoder) http.Handler {
-	return &webhook.Admission{Handler: &persistentVolumeClaimMutator{getter.NewRetryMissingGetter(r, apiReader), dec}}
+	return &webhook.Admission{
+		Handler: &persistentVolumeClaimMutator{
+			getter: getter.NewRetryMissingGetter(r, apiReader),
+			decoder: dec,
+		},
+	}
 }
 
 //+kubebuilder:webhook:failurePolicy=fail,matchPolicy=equivalent,groups=core,resources=persistentvolumeclaims,verbs=create,versions=v1,name=pvc-hook.topolvm.cybozu.com,path=/pvc/mutate,mutating=true,sideEffects=none,admissionReviewVersions={v1,v1beta1}

--- a/hook/mutate_pod.go
+++ b/hook/mutate_pod.go
@@ -33,7 +33,12 @@ type podMutator struct {
 
 // PodMutator creates a mutating webhook for Pods.
 func PodMutator(r client.Reader, apiReader client.Reader, dec *admission.Decoder) http.Handler {
-	return &webhook.Admission{Handler: &podMutator{getter.NewRetryMissingGetter(r, apiReader), dec}}
+	return &webhook.Admission{
+		Handler: &podMutator{
+			getter: getter.NewRetryMissingGetter(r, apiReader),
+			decoder: dec,
+		},
+	}
 }
 
 // Handle implements admission.Handler interface.

--- a/hook/mutate_pod.go
+++ b/hook/mutate_pod.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/topolvm/topolvm"
+	"github.com/topolvm/topolvm/getter"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -26,17 +27,17 @@ var pmLogger = ctrl.Log.WithName("pod-mutator")
 
 // podMutator mutates pods using PVC for TopoLVM.
 type podMutator struct {
-	client  client.Client
+	getter  *getter.RetryMissingGetter
 	decoder *admission.Decoder
 }
 
 // PodMutator creates a mutating webhook for Pods.
-func PodMutator(c client.Client, dec *admission.Decoder) http.Handler {
-	return &webhook.Admission{Handler: podMutator{c, dec}}
+func PodMutator(r client.Reader, apiReader client.Reader, dec *admission.Decoder) http.Handler {
+	return &webhook.Admission{Handler: &podMutator{getter.NewRetryMissingGetter(r, apiReader), dec}}
 }
 
 // Handle implements admission.Handler interface.
-func (m podMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+func (m *podMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	pod := &corev1.Pod{}
 	err := m.decoder.Decode(req, pod)
 	if err != nil {
@@ -58,13 +59,7 @@ func (m podMutator) Handle(ctx context.Context, req admission.Request) admission
 		pod.Namespace = req.Namespace
 	}
 
-	targets, err := m.targetStorageClasses(ctx)
-	if err != nil {
-		pmLogger.Error(err, "targetStorageClasses failed")
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
-
-	pvcCapacities, err := m.requestedPVCCapacity(ctx, pod, targets)
+	pvcCapacities, err := m.requestedPVCCapacity(ctx, pod)
 	if err != nil {
 		pmLogger.Error(err, "requestedPVCCapacity failed")
 		return admission.Errored(http.StatusInternalServerError, err)
@@ -113,23 +108,35 @@ func (m podMutator) Handle(ctx context.Context, req admission.Request) admission
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 }
 
-func (m podMutator) targetStorageClasses(ctx context.Context) (map[string]storagev1.StorageClass, error) {
-	var scl storagev1.StorageClassList
-	if err := m.client.List(ctx, &scl); err != nil {
-		return nil, err
-	}
-
-	targets := make(map[string]storagev1.StorageClass)
-	for _, sc := range scl.Items {
-		if sc.Provisioner != topolvm.PluginName {
-			continue
-		}
-		targets[sc.Name] = sc
-	}
-	return targets, nil
+type targetSC struct {
+	getter *getter.RetryMissingGetter
+	cache  map[string]*storagev1.StorageClass
 }
 
-func (m podMutator) requestedPVCCapacity(ctx context.Context, pod *corev1.Pod, targets map[string]storagev1.StorageClass) (map[string]int64, error) {
+func (t *targetSC) Get(ctx context.Context, name string) (*storagev1.StorageClass, error) {
+	if sc, ok := t.cache[name]; ok {
+		return sc, nil
+	}
+
+	var sc storagev1.StorageClass
+	err := t.getter.Get(ctx, types.NamespacedName{Name: name}, &sc)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			t.cache[name] = nil
+			return nil, nil
+		}
+		return nil, err
+	}
+	if sc.Provisioner != topolvm.PluginName {
+		t.cache[name] = nil
+		return nil, nil
+	}
+	t.cache[name] = &sc
+	return &sc, nil
+}
+
+func (m *podMutator) requestedPVCCapacity(ctx context.Context, pod *corev1.Pod) (map[string]int64, error) {
+	targetSC := targetSC{m.getter, map[string]*storagev1.StorageClass{}}
 	capacities := make(map[string]int64)
 	for _, vol := range pod.Spec.Volumes {
 		if vol.PersistentVolumeClaim == nil {
@@ -145,7 +152,7 @@ func (m podMutator) requestedPVCCapacity(ctx context.Context, pod *corev1.Pod, t
 		}
 
 		var pvc corev1.PersistentVolumeClaim
-		if err := m.client.Get(ctx, name, &pvc); err != nil {
+		if err := m.getter.Get(ctx, name, &pvc); err != nil {
 			if !apierrs.IsNotFound(err) {
 				pmLogger.Error(err, "failed to get pvc",
 					"pod", pod.Name,
@@ -165,8 +172,11 @@ func (m podMutator) requestedPVCCapacity(ctx context.Context, pod *corev1.Pod, t
 			// https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
 			continue
 		}
-		sc, ok := targets[*pvc.Spec.StorageClassName]
-		if !ok {
+		sc, err := targetSC.Get(ctx, *pvc.Spec.StorageClassName)
+		if err != nil {
+			return nil, err
+		}
+		if sc == nil {
 			continue
 		}
 
@@ -192,7 +202,7 @@ func (m podMutator) requestedPVCCapacity(ctx context.Context, pod *corev1.Pod, t
 	return capacities, nil
 }
 
-func (m podMutator) requestedEphemeralCapacity(pod *corev1.Pod) (int64, error) {
+func (m *podMutator) requestedEphemeralCapacity(pod *corev1.Pod) (int64, error) {
 	var total int64
 	for _, vol := range pod.Spec.Volumes {
 		if vol.CSI == nil {

--- a/hook/mutate_pod.go
+++ b/hook/mutate_pod.go
@@ -35,7 +35,7 @@ type podMutator struct {
 func PodMutator(r client.Reader, apiReader client.Reader, dec *admission.Decoder) http.Handler {
 	return &webhook.Admission{
 		Handler: &podMutator{
-			getter: getter.NewRetryMissingGetter(r, apiReader),
+			getter:  getter.NewRetryMissingGetter(r, apiReader),
 			decoder: dec,
 		},
 	}

--- a/hook/run_test.go
+++ b/hook/run_test.go
@@ -8,7 +8,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	// +kubebuilder:scaffold:imports
 )
@@ -32,8 +31,8 @@ func run(ctx context.Context, cfg *rest.Config, scheme *runtime.Scheme, opts *en
 
 	dec, _ := admission.NewDecoder(scheme)
 	wh := mgr.GetWebhookServer()
-	wh.Register(podMutatingWebhookPath, &webhook.Admission{Handler: podMutator{mgr.GetClient(), dec}})
-	wh.Register(pvcMutatingWebhookPath, &webhook.Admission{Handler: persistentVolumeClaimMutator{mgr.GetClient(), dec}})
+	wh.Register(podMutatingWebhookPath, PodMutator(mgr.GetClient(), mgr.GetAPIReader(), dec))
+	wh.Register(pvcMutatingWebhookPath, PVCMutator(mgr.GetClient(), mgr.GetAPIReader(), dec))
 
 	if err := mgr.Start(ctx); err != nil {
 		return err

--- a/pkg/topolvm-controller/cmd/run.go
+++ b/pkg/topolvm-controller/cmd/run.go
@@ -74,8 +74,8 @@ func subMain() error {
 	// admissoin.NewDecoder never returns non-nil error
 	dec, _ := admission.NewDecoder(scheme)
 	wh := mgr.GetWebhookServer()
-	wh.Register("/pod/mutate", hook.PodMutator(mgr.GetClient(), dec))
-	wh.Register("/pvc/mutate", hook.PVCMutator(mgr.GetClient(), dec))
+	wh.Register("/pod/mutate", hook.PodMutator(mgr.GetClient(), mgr.GetAPIReader(), dec))
+	wh.Register("/pvc/mutate", hook.PVCMutator(mgr.GetClient(), mgr.GetAPIReader(), dec))
 
 	// register controllers
 	nodecontroller := &controllers.NodeReconciler{

--- a/runners/metrics_exporter.go
+++ b/runners/metrics_exporter.go
@@ -31,7 +31,7 @@ type NodeMetrics struct {
 }
 
 type metricsExporter struct {
-	client.Client
+	client         client.Client
 	nodeName       string
 	vgService      proto.VGServiceClient
 	availableBytes *prometheus.GaugeVec
@@ -62,7 +62,7 @@ func NewMetricsExporter(conn *grpc.ClientConn, mgr manager.Manager, nodeName str
 	metrics.Registry.MustRegister(sizeBytes)
 
 	return &metricsExporter{
-		Client:         mgr.GetClient(),
+		client:         mgr.GetClient(),
 		nodeName:       nodeName,
 		vgService:      proto.NewVGServiceClient(conn),
 		availableBytes: availableBytes,
@@ -119,7 +119,7 @@ func (m *metricsExporter) updateNode(ctx context.Context, wc proto.VGService_Wat
 		}
 
 		var node corev1.Node
-		if err := m.Get(ctx, types.NamespacedName{Name: m.nodeName}, &node); err != nil {
+		if err := m.client.Get(ctx, types.NamespacedName{Name: m.nodeName}, &node); err != nil {
 			return err
 		}
 
@@ -145,7 +145,7 @@ func (m *metricsExporter) updateNode(ctx context.Context, wc proto.VGService_Wat
 		for _, item := range res.Items {
 			node2.Annotations[topolvm.CapacityKeyPrefix+item.DeviceClass] = strconv.FormatUint(item.FreeBytes, 10)
 		}
-		if err := m.Patch(ctx, node2, client.MergeFrom(&node)); err != nil {
+		if err := m.client.Patch(ctx, node2, client.MergeFrom(&node)); err != nil {
 			return err
 		}
 	}

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package topolvm


### PR DESCRIPTION
I found some test flakiness comes from no read-after-create consistency provided by the cache reader. This PR introduces a new getter to retry Get if no objects are found.

fix #313