### PR TITLE
Use lvmd.socketName value when lvmd.additionalConfigs[n].socketName is not set

### DIFF
--- a/charts/topolvm/templates/lvmd/configmap.yaml
+++ b/charts/topolvm/templates/lvmd/configmap.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "topolvm.labels" . | nindent 4 }}
 data:
   lvmd.yaml: |
-    socket-name: {{ $lvmd.socketName }}
+    socket-name: {{ default .Values.lvmd.socketName $lvmd.socketName }}
     {{- if $lvmd.deviceClasses }}
     device-classes: {{ toYaml $lvmd.deviceClasses | nindent 6 }}
     {{- end }}


### PR DESCRIPTION
Here's something that I noticed when setting up a cluster two repurposed machines, that had different LVM setups. Consider the following chart values override:
```
lvmd:
  nodeSelector:
    kubernetes.io/hostname: mimosa
  deviceClasses:
    - name: ssd
      volume-group: ubuntu-vg
      spare-gb: 800
      default: true
  additionalConfigs:
    - nodeSelector:
        kubernetes.io/hostname: tectona
      deviceClasses:
        - name: ssd
          volume-group: vg1
          spare-gb: 250
          default: true
```
This results in generating the following `ConfigMap`s:
```
---
# Source: topolvm/templates/lvmd/configmap.yaml
---
kind: ConfigMap
metadata:
  name: topolvm-lvmd-0
  namespace: topolvm-system
  labels:
    idx: "0"
    helm.sh/chart: topolvm-3.2.0
    app.kubernetes.io/name: topolvm
    app.kubernetes.io/instance: topolvm
    app.kubernetes.io/version: "0.10.3"
    app.kubernetes.io/managed-by: Helm
data:
  lvmd.yaml: |
    socket-name: /run/topolvm/lvmd.sock
    device-classes: 
      - name: ssd
        volume-group: ubuntu-vg
        spare-gb: 800
        default: true
---
# Source: topolvm/templates/lvmd/configmap.yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: topolvm-lvmd-1
  namespace: topolvm-system
  labels:
    idx: "1"
    helm.sh/chart: topolvm-3.2.0
    app.kubernetes.io/name: topolvm
    app.kubernetes.io/instance: topolvm
    app.kubernetes.io/version: "0.10.3"
    app.kubernetes.io/managed-by: Helm
data:
  lvmd.yaml: |
    socket-name: 
    device-classes: 
      - name: ssd
        volume-group: vg1
        spare-gb: 250
        default: true
```
Notice that in the `topolvm-lvmd-1` ConfigMap `socket-name` is empty.

This can be mitigated by adding `socketName` setting:
```
lvmd:
  nodeSelector:
    kubernetes.io/hostname: mimosa
  deviceClasses:
    - name: ssd
      volume-group: ubuntu-vg
      spare-gb: 800
      default: true
  additionalConfigs:
    - socketName: /run/topolvm/lvmd.sock
      nodeSelector:
        kubernetes.io/hostname: tectona
      deviceClasses:
        - name: ssd
          volume-group: vg1
          spare-gb: 250
          default: true
```
But I believe this should not be necessary, especially it the user's intent is to _not_ override the defaults.

I'm proposing a change to use `lvmd.socketName` by default bu allow overriding it in the individual `additionalConfig`s. However, it could be argued that this kind of flexibility is not needed and lvmd socket path should be consistent across cluster. This is in fact what `node` `DaemonSet` assumes.