### PR TITLE
cast Statfs_t.Frsize to int64 for s390x arch

### DIFF
--- a/driver/node.go
+++ b/driver/node.go
@@ -453,9 +453,9 @@ func (s *nodeService) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 	if sfs.Blocks > 0 {
 		usage = append(usage, &csi.VolumeUsage{
 			Unit:      csi.VolumeUsage_BYTES,
-			Total:     int64(sfs.Blocks) * sfs.Frsize,
-			Used:      int64(sfs.Blocks-sfs.Bfree) * sfs.Frsize,
-			Available: int64(sfs.Bavail) * sfs.Frsize,
+			Total:     int64(sfs.Blocks) * int64(sfs.Frsize),
+			Used:      int64(sfs.Blocks-sfs.Bfree) * int64(sfs.Frsize),
+			Available: int64(sfs.Bavail) * int64(sfs.Frsize),
 		})
 	}
 	if sfs.Files > 0 {


### PR DESCRIPTION
topolvm build on s390x arch fails due to mismatched types int64 and uint32
This PR casts `Frsize` to int64.

fixes: #424 

Signed-off-by: Santosh Pillai <sapillai@redhat.com>