### PR TITLE
add readinessProbe for scheduler

### DIFF
--- a/charts/topolvm/templates/scheduler/daemonset.yaml
+++ b/charts/topolvm/templates/scheduler/daemonset.yaml
@@ -48,6 +48,11 @@ spec:
               host: {{ .Values.scheduler.options.listen.host }}
               port: {{ .Values.scheduler.options.listen.port }}
               path: /status
+          readinessProbe:
+            httpGet:
+              host: {{ .Values.scheduler.options.listen.host }}
+              port: {{ .Values.scheduler.options.listen.port }}
+              path: /status
           volumeMounts:
             - mountPath: /etc/topolvm
               name: {{ template "topolvm.fullname" . }}-scheduler-options

--- a/charts/topolvm/templates/scheduler/deployment.yaml
+++ b/charts/topolvm/templates/scheduler/deployment.yaml
@@ -48,6 +48,10 @@ spec:
             httpGet:
               port: {{ .Values.scheduler.options.listen.port }}
               path: /status
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.scheduler.options.listen.port }}
+              path: /status
           volumeMounts:
             - mountPath: /etc/topolvm
               name: {{ template "topolvm.fullname" . }}-scheduler-options


### PR DESCRIPTION
In scheduler-test, we wait topolvm-scheduler ready, but readinessProbe
is not set now, it may introduce flakiness. If it is not related to the
flakiness, it is better to set it up.