### PR TITLE
✨ Add lvcreate-options

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -10,7 +10,7 @@ because CSI volumes can be referenced only via PersistentVolumeClaims.
 Ref: https://kubernetes.io/docs/concepts/storage/volumes/#csi
 
 > The `csi` volume type does not support direct reference from Pod and may
-> only be referenced in a Pod via a `PersistentVolumeClaim` object. 
+> only be referenced in a Pod via a `PersistentVolumeClaim` object.
 
 Pod without PVC
 ---------------
@@ -36,3 +36,49 @@ CSI ephemeral volumes may leave orphaned logical volumes
 
 The logical volume created by CSI ephemeral volumes may be left behind by restarting the node.
 This problem is because the kubelet on the restarted node may fail to remove the logical volume through the CSI driver when pods are removed.
+
+Use lvcreate-options at your own risk
+-------------------------------------------
+
+TopoLVM does not check the `lvcreate-options` that can optionally be added to a device-class.
+Therefore it cannot take them into consideration when scheduling, or do sanity checks for them.
+It is up to the user to make sure that these arguments make sense and work with the VG in question.
+For example, with `--type=raid1`, the VG must have at least 2 PVs to be able to create any LVs.
+
+Note also that the options may affect the "actual" available capacity.
+With `--type=raid1`, each LV will take up twice the normal space.
+You may want to tweak the `spare-gb` setting to avoid some issues with this.
+
+**Example**
+
+There is one VG `raid-vg` with two PVs (`disk1` and `disk2`).
+Then we create the following lvmd config:
+
+```yaml
+device-classes:
+  - name: "raid1"
+    volume-group: "raid-vg"
+    spare-gb: 100
+    lvcreate-options:
+      - "--type=raid1"
+```
+
+If we now ask for a volume with this device class it will be created using `lvcreate` with `--type=raid1`.
+This means that the data will be mirrored on the two disks.
+Notice the following:
+
+1. The VG *must* have at least two PVs in it with enough capacity or volume creation will fail.
+   This is a requirement coming from the RAID configuration and is up to the user to take into account when creating the VG and device-class.
+2. Since the data is mirrored on the two disks, it takes up twice as much space.
+   If we ask for a volume with 1 GB capacity, it will use 1 GB on each disk, i.e. 2 GB total of the VG.
+   TopoLVM does not know about this so it will not be considered when doing scheduling decisions.
+
+To help with the scheduling we can set `spare-gb` to the size of one disk.
+For example, if `disk1` and `disk2` are 100 GB each, we can set `spare-gb` to 100 GB so that the reported capacity from TopoLVM would be 100 GB.
+This is the "real" capacity that is available when all LVs are created with `--type=raid1`.
+However, this will not be correct once we create some volumes, since they use up some capacity.
+For example, we ask for a 50 GB volume.
+This volume will use 100 GB in total since it is of type RAID1.
+The VG has 200 GB total and 100 GB spare configured so TopoLVM will now consider this VG full.
+
+For more details please see [this proposal](./proposals/lvcreate-options.md).

--- a/docs/lvmd.md
+++ b/docs/lvmd.md
@@ -33,6 +33,10 @@ device-classes:
     spare-gb: 10
     stripe: 2
     stripe-size: "64"
+  - name: raid
+    volume-group: raid-vg
+    lvcreate-options:
+      - --type=raid1
 ```
 
 | Name             | Type                     | Default                  | Description                         |
@@ -42,14 +46,24 @@ device-classes:
 
 The device-class settings can be specified in the following fields:
 
-| Name           | Type   | Default | Description                                                                        |
-| -------------- | ------ | ------- | ---------------------------------------------------------------------------------- |
-| `name`         | string | -       | The name of a device-class.                                                        |
-| `volume-group` | string | -       | The group where this device-class creates the logical volumes.                     |
-| `spare-gb`     | uint64 | `10`    | Storage capacity in GiB to be spared.                                              |
-| `default`      | bool   | `false` | A flag to indicate that this device-class is used by default.                      |
-| `stripe`       | uint   | -       | The number of stripes in the logical volume.                                       |
-| `stripe-size`  | string | -       | The amount of data that is written to one device before moving to the next device. |
+| Name                | Type     | Default | Description                                                                        |
+| ------------------- | ------   | ------- | ---------------------------------------------------------------------------------- |
+| `name`              | string   | -       | The name of a device-class.                                                        |
+| `volume-group`      | string   | -       | The group where this device-class creates the logical volumes.                     |
+| `spare-gb`          | uint64   | `10`    | Storage capacity in GiB to be spared.                                              |
+| `default`           | bool     | `false` | A flag to indicate that this device-class is used by default.                      |
+| `stripe`            | uint     | -       | The number of stripes in the logical volume.                                       |
+| `stripe-size`       | string   | -       | The amount of data that is written to one device before moving to the next device. |
+| `lvcreate-options`  | []string | -       | Extra arguments to pass to `lvcreate`, e.g. `["--type=raid1"]`.                    |
+
+Note that striping can be configured both using the dedicated options (`stripe` and `stripe-size`) and `lvcreate-options`.
+Either one can be used but not together since this would lead to duplicate arguments to `lvcreate`.
+This means that you should never set `lvcreate-options: ["--stripes=n"]` and `stripe: n` at the same time.
+It is fine to use both as long as `lvcreate-options` are not used for striping however:
+```
+stripe: 2
+lvcreate-options: ["--mirrors=1"]
+```
 
 Spare capacity
 --------------

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -119,15 +119,23 @@ start-lvmd:
 	done
 
 	# Create additional Volume Groups
-	truncate --size=10G $(BACKING_STORE)/backing_store1_2; \
-	$(SUDO) losetup -f $(BACKING_STORE)/backing_store1_2; \
-	$(SUDO) vgcreate -y node1-myvg2 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store1_2 | cut -d: -f1); \
-	truncate --size=10G $(BACKING_STORE)/backing_store2_2; \
-	$(SUDO) losetup -f $(BACKING_STORE)/backing_store2_2; \
-	$(SUDO) vgcreate -y node2-myvg2 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store2_2 | cut -d: -f1); \
-	truncate --size=10G $(BACKING_STORE)/backing_store3_3; \
-	$(SUDO) losetup -f $(BACKING_STORE)/backing_store3_3; \
-	$(SUDO) vgcreate -y node3-myvg3 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store3_3 | cut -d: -f1); \
+	for i in $$(seq 3); do \
+		truncate --size=10G $(BACKING_STORE)/backing_store$${i}_2; \
+		$(SUDO) losetup -f $(BACKING_STORE)/backing_store$${i}_2; \
+		$(SUDO) vgcreate -y node$${i}-myvg2 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_2 | cut -d: -f1); \
+	done
+
+	# Create Volume Group for testing raid1 volumes.
+	# This requires 2 PVs in each VG.
+	# node{i}-myvg3: backing_store{i}_3, backing_store{i}_4
+	for i in $$(seq 3); do \
+		truncate --size=3G $(BACKING_STORE)/backing_store$${i}_3; \
+		truncate --size=3G $(BACKING_STORE)/backing_store$${i}_4; \
+		$(SUDO) losetup -f $(BACKING_STORE)/backing_store$${i}_3; \
+		$(SUDO) losetup -f $(BACKING_STORE)/backing_store$${i}_4; \
+		$(SUDO) vgcreate -y node$${i}-myvg3 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_3 | cut -d: -f1) \
+			$$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_4 | cut -d: -f1); \
+	done
 
 	for i in $$(seq 3); do \
 		$(SUDO) systemd-run --unit=lvmd$$i.service $(shell pwd)/build/lvmd --config=$(shell pwd)/lvmd$$i.yaml; \
@@ -138,13 +146,16 @@ stop-lvmd:
 	$(MAKE) shutdown-kind
 	for i in $$(seq 3); do \
 		if systemctl is-active -q lvmd$$i.service; then $(SUDO) systemctl stop lvmd$$i.service; fi; \
-		for j in $$(seq 3); do \
-			if [ -f $(BACKING_STORE)/backing_store$${i}_$${j} ]; then \
+		for j in $$(seq 4); do \
+			# We have only 3 VGs per node, but 4 PVs, since node{i}-myvg3 uses both \
+			# backing_store{i}_3 and backing_store{i}_4. \
+			# I.e. there is no node{i}-myvg4. \
+			if [ "$${j}" -ne 4 ]; then \
 				$(SUDO) vgremove -ffy node$${i}-myvg$${j}; \
-				$(SUDO) pvremove -ffy $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_$${j} | cut -d: -f1); \
-				$(SUDO) losetup -d $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_$${j} | cut -d: -f1); \
-				rm -f $(BACKING_STORE)/backing_store$${i}_$${j}; \
 			fi; \
+			$(SUDO) pvremove -ffy $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_$${j} | cut -d: -f1); \
+			$(SUDO) losetup -d $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$${i}_$${j} | cut -d: -f1); \
+			rm -f $(BACKING_STORE)/backing_store$${i}_$${j}; \
 		done; \
 	done
 
@@ -195,10 +206,24 @@ daemonset-lvmd/create-vg:
 		$(SUDO) lvcreate -y -n csi-node-test-fs -L 1G node-myvg$${i}; \
 	done
 
+	# Create Volume Group for testing raid1 volumes.
+	# This requires 2 PVs in each VG.
+	truncate --size=3G $(BACKING_STORE)/backing_store_lvmd_4
+	truncate --size=3G $(BACKING_STORE)/backing_store_lvmd_5
+	$(SUDO) losetup -f $(BACKING_STORE)/backing_store_lvmd_4
+	$(SUDO) losetup -f $(BACKING_STORE)/backing_store_lvmd_5
+	$(SUDO) vgcreate -y node-myvg4 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store_lvmd_4 | cut -d: -f1) \
+		$$($(SUDO) losetup -j $(BACKING_STORE)/backing_store_lvmd_5 | cut -d: -f1)
+
 .PHONY: daemonset-lvmd/remove-vg
 daemonset-lvmd/remove-vg:
-	for i in $$(seq 3); do \
-		$(SUDO) vgremove -ffy node-myvg$${i}; \
+	for i in $$(seq 5); do \
+		# We have only 4 VGs, but 5 PVs, since node-myvg4 uses both \
+		# backing_store_lvmd_4 and backing_store_lvmd_5. \
+		# I.e. there is no node-myvg5. \
+		if [ "$${i}" -ne 5 ]; then \
+			$(SUDO) vgremove -ffy node-myvg$${i}; \
+		fi; \
 		$(SUDO) pvremove -ffy $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store_lvmd_$${i} | cut -d: -f1); \
 		$(SUDO) losetup -d $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store_lvmd_$${i} | cut -d: -f1); \
 		rm -f $(BACKING_STORE)/backing_store_lvmd_$${i}; \

--- a/e2e/lvcreate_options_test.go
+++ b/e2e/lvcreate_options_test.go
@@ -1,0 +1,68 @@
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func testLVCreateOptions() {
+	testNamespacePrefix := "lvcreate-options-"
+	var ns string
+	var cc CleanupContext
+
+	BeforeEach(func() {
+		cc = commonBeforeEach()
+
+		ns = testNamespacePrefix + randomString(10)
+		createNamespace(ns)
+	})
+
+	AfterEach(func() {
+		// When a test fails, I want to investigate the cause. So please don't remove the namespace!
+		if !CurrentGinkgoTestDescription().Failed {
+			kubectl("delete", "namespaces/"+ns)
+		}
+
+		commonAfterEach(cc)
+	})
+
+	It("should use lvcreate-options when creating LV", func() {
+		By("creating Pod with PVC using raid device-class")
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1, "topolvm-provisioner-raid"))
+		podYaml := []byte(fmt.Sprintf(podVolumeMountTemplateYAML, "ubuntu", "topo-pvc"))
+
+		stdout, stderr, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+		stdout, stderr, err = kubectlWithInput(podYaml, "apply", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+
+		By("finding the corresponding LV")
+
+		var lvName string
+		Eventually(func() error {
+			stdout, stderr, err = kubectl("get", "pvc", "-n", ns, "topo-pvc", "-o=template", "--template={{.spec.volumeName}}")
+			if err != nil {
+				return fmt.Errorf("failed to get PVC. stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			}
+			volumeName := strings.TrimSpace(string(stdout))
+
+			stdout, stderr, err = kubectl("get", "logicalvolume", "-n", "topolvm-system", volumeName, "-o=template", "--template={{.metadata.uid}}")
+			if err != nil {
+				return fmt.Errorf("failed to get logicalvolume. stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+			}
+			lvName = strings.TrimSpace(string(stdout))
+			return nil
+		}).Should(Succeed())
+
+		By("checking that the LV is of type raid")
+		stdout, err = exec.Command("sudo", "lvs", "-o", "lv_attr", "--noheadings", "--select", "lv_name="+lvName).Output()
+		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+		attribute_bit1 := string(strings.TrimSpace(string(stdout))[0])
+		// lv_attr bit 1 represents the volume type, where 'r' is for raid
+		Expect(attribute_bit1).To(Equal("r"))
+	})
+}

--- a/e2e/lvmd1.yaml
+++ b/e2e/lvmd1.yaml
@@ -7,3 +7,8 @@ device-classes:
   - name: "hdd1"
     volume-group: "node1-myvg2"
     spare-gb: 1
+  - name: "raid"
+    volume-group: "node1-myvg3"
+    spare-gb: 1
+    lvcreate-options:
+      - "--type=raid1"

--- a/e2e/lvmd2.yaml
+++ b/e2e/lvmd2.yaml
@@ -7,3 +7,8 @@ device-classes:
   - name: "hdd1"
     volume-group: "node2-myvg2"
     spare-gb: 1
+  - name: "raid"
+    volume-group: "node2-myvg3"
+    spare-gb: 1
+    lvcreate-options:
+      - "--type=raid1"

--- a/e2e/lvmd3.yaml
+++ b/e2e/lvmd3.yaml
@@ -5,5 +5,10 @@ device-classes:
     default: true
     spare-gb: 1
   - name: "hdd2"
+    volume-group: "node3-myvg2"
+    spare-gb: 1
+  - name: "raid"
     volume-group: "node3-myvg3"
     spare-gb: 1
+    lvcreate-options:
+      - "--type=raid1"

--- a/e2e/manifests/common/provisioner.yaml
+++ b/e2e/manifests/common/provisioner.yaml
@@ -62,6 +62,14 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 ---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: topolvm-provisioner-raid
+provisioner: topolvm.cybozu.com
+parameters:
+  "topolvm.cybozu.com/device-class": "raid"
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/e2e/manifests/values/daemonset-lvmd-storage-capacity.yaml
+++ b/e2e/manifests/values/daemonset-lvmd-storage-capacity.yaml
@@ -32,6 +32,11 @@ lvmd:
     - name: "hdd2"
       volume-group: "node-myvg3"
       spare-gb: 1
+    - name: "raid"
+      volume-group: "node-myvg4"
+      spare-gb: 1
+      lvcreate-options:
+        - "--type=raid1"
 
 node:
   lvmdSocket: /tmp/topolvm/daemonset_lvmd/lvmd.sock

--- a/e2e/manifests/values/daemonset-lvmd.yaml
+++ b/e2e/manifests/values/daemonset-lvmd.yaml
@@ -40,6 +40,11 @@ lvmd:
     - name: "hdd2"
       volume-group: "node-myvg3"
       spare-gb: 1
+    - name: "raid"
+      volume-group: "node-myvg4"
+      spare-gb: 1
+      lvcreate-options:
+        - "--type=raid1"
 
 node:
   lvmdSocket: /tmp/topolvm/daemonset_lvmd/lvmd.sock

--- a/e2e/multiple_vg_test.go
+++ b/e2e/multiple_vg_test.go
@@ -66,7 +66,7 @@ func testMultipleVolumeGroups() {
 			return err
 		}).Should(Succeed())
 
-		vgName := "node3-myvg3"
+		vgName := "node3-myvg2"
 		if isDaemonsetLvmdEnvSet() {
 			vgName = "node-myvg3"
 		}

--- a/e2e/node_test.go
+++ b/e2e/node_test.go
@@ -142,9 +142,9 @@ func testNode() {
 			}
 			found = true
 
-			length := 2
+			length := 3
 			if isDaemonsetLvmdEnvSet() {
-				length = 3
+				length = 4
 			}
 			Expect(family.Metric).Should(HaveLen(length))
 

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -143,6 +143,7 @@ var _ = Describe("TopoLVM", func() {
 	Context("ReadWriteOncePod", testReadWriteOncePod)
 	Context("e2e", testE2E)
 	Context("multiple-vg", testMultipleVolumeGroups)
+	Context("lvcreate-options", testLVCreateOptions)
 	Context("cleanup", testCleanup)
 	Context("CSI sanity", testSanity)
 })

--- a/lvmd/command/lvm.go
+++ b/lvmd/command/lvm.go
@@ -279,7 +279,9 @@ func (g *VolumeGroup) ListVolumes() ([]*LogicalVolume, error) {
 // CreateVolume creates logical volume in this volume group.
 // name is a name of creating volume. size is volume size in bytes. volTags is a
 // list of tags to add to the volume.
-func (g *VolumeGroup) CreateVolume(name string, size uint64, tags []string, stripe uint, stripeSize string) (*LogicalVolume, error) {
+// lvcreateOptions are additional arguments to pass to lvcreate.
+func (g *VolumeGroup) CreateVolume(name string, size uint64, tags []string, stripe uint, stripeSize string,
+	lvcreateOptions []string) (*LogicalVolume, error) {
 	lvcreateArgs := []string{"-n", name, "-L", fmt.Sprintf("%vg", size>>30), "-W", "y", "-y"}
 	for _, tag := range tags {
 		lvcreateArgs = append(lvcreateArgs, "--addtag")
@@ -292,6 +294,7 @@ func (g *VolumeGroup) CreateVolume(name string, size uint64, tags []string, stri
 			lvcreateArgs = append(lvcreateArgs, "-I", stripeSize)
 		}
 	}
+	lvcreateArgs = append(lvcreateArgs, lvcreateOptions...)
 	lvcreateArgs = append(lvcreateArgs, g.Name())
 
 	if err := CallLVM("lvcreate", lvcreateArgs...); err != nil {

--- a/lvmd/device_class_manager.go
+++ b/lvmd/device_class_manager.go
@@ -34,6 +34,8 @@ type DeviceClass struct {
 	Stripe *uint `json:"stripe"`
 	// StripeSize is the amount of data that is written to one device before moving to the next device
 	StripeSize string `json:"stripe-size"`
+	// LVCreateOptions are extra arguments to pass to lvcreate
+	LVCreateOptions []string `json:"lvcreate-options"`
 }
 
 // GetSpare returns spare in bytes for the device-class

--- a/lvmd/lvservice.go
+++ b/lvmd/lvservice.go
@@ -61,8 +61,12 @@ func (s *lvService) CreateLV(_ context.Context, req *proto.CreateLVRequest) (*pr
 	if dc.Stripe != nil {
 		stripe = *dc.Stripe
 	}
+	var lvcreateOptions []string
+	if dc.LVCreateOptions != nil {
+		lvcreateOptions = dc.LVCreateOptions
+	}
 
-	lv, err := vg.CreateVolume(req.GetName(), requested, req.GetTags(), stripe, dc.StripeSize)
+	lv, err := vg.CreateVolume(req.GetName(), requested, req.GetTags(), stripe, dc.StripeSize, lvcreateOptions)
 	if err != nil {
 		log.Error("failed to create volume", map[string]interface{}{
 			"name":      req.GetName(),

--- a/lvmd/vgservice_test.go
+++ b/lvmd/vgservice_test.go
@@ -124,7 +124,7 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 		t.Errorf("numVolumes must be 0: %d", numVols1)
 	}
 	testtag := "testtag"
-	_, err = vg.CreateVolume("test1", 1<<30, []string{testtag}, 0, "")
+	_, err = vg.CreateVolume("test1", 1<<30, []string{testtag}, 0, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 		t.Errorf(`Volume.Tags[0] != %s: %v`, testtag, vol.GetTags())
 	}
 
-	_, err = vg.CreateVolume("test2", 1<<30, nil, 0, "")
+	_, err = vg.CreateVolume("test2", 1<<30, nil, 0, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,12 +183,21 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 		t.Errorf("Free bytes mismatch: %d, expected: %d, freeBytes: %d", res2.GetFreeBytes(), expected, freeBytes)
 	}
 
-	_, err = vg.CreateVolume("test3", 1<<30, nil, 2, "4k")
+	test3Vol, err := vg.CreateVolume("test3", 1<<30, nil, 2, "4k", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = vg.CreateVolume("test4", 1<<30, nil, 2, "4M")
+	test4Vol, err := vg.CreateVolume("test4", 1<<30, nil, 2, "4M", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove volumes to make room for a raid volume
+	test3Vol.Remove()
+	test4Vol.Remove()
+
+	_, err = vg.CreateVolume("test5", 1<<30, nil, 0, "", []string{"--type=raid1"})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is the implementation of the [lvcreate-options](https://github.com/topolvm/topolvm/blob/main/docs/proposals/lvcreate-options.md) proposal.

This PR adds a new field in the `device-class` settings, namely `lvcreate-options`. It takes a list of additional arguments to pass to `lvcreate`. This can be used to create RAID volumes for example.

Please let me know if there are things I can improve!