### PR TITLE
Add Tiltfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bin
 /build
 /e2e/build
 /e2e/tmpbin
+/tilt_modules
 /include
 /testbin
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -6,7 +6,7 @@ def get_all_go_files():
 all_go_files = get_all_go_files()
 ignores=["e2e/tmpbin", "e2e/bin", "e2e/build", "build", "bin", "include", "testbin", "e2e/topolvm.img", "*/.docker_temp_*"]
 
-local_resource("hypertopolvm", "make -C e2e topolvm.img", deps=all_go_files, ignore=ignores)
+local_resource("hypertopolvm", "make -C e2e e2e-bin", deps=all_go_files, ignore=ignores)
 
 docker_build("topolvm:dev", "e2e/tmpbin", dockerfile="e2e/Dockerfile")
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,31 @@
+allow_k8s_contexts('kind-topolvm-e2e')
+
+def get_all_go_files():
+  return str(local("find -type f -name '*.go' -not -name '*_test.go'")).split("\n")
+
+all_go_files = get_all_go_files()
+ignores=["e2e/tmpbin", "e2e/bin", "e2e/build", "build", "bin", "include", "testbin", "e2e/topolvm.img", "*/.docker_temp_*"]
+
+local_resource("hypertopolvm", "make -C e2e topolvm.img", deps=all_go_files, ignore=ignores)
+
+docker_build("topolvm:dev", "e2e/tmpbin", dockerfile="e2e/Dockerfile")
+
+load("ext://cert_manager", "deploy_cert_manager")
+deploy_cert_manager()
+
+load('ext://namespace', 'namespace_create')
+namespace_create(
+  'topolvm-system',
+  labels=['topolvm.cybozu.com/webhook: ignore']
+)
+
+local("kubectl label namespace kube-system topolvm.cybozu.com/webhook=ignore --overwrite")
+
+k8s_yaml(
+  helm("./charts/topolvm",
+    namespace="topolvm-system",
+    name="topolvm",
+    values=["e2e/manifests/values/deployment-scheduler.yaml"],
+    set=["cert-manager.enabled=false"]
+  )
+)

--- a/csi-sidecars.mk
+++ b/csi-sidecars.mk
@@ -3,11 +3,6 @@ EXTERNAL_PROVISIONER_VERSION = 3.0.0
 EXTERNAL_RESIZER_VERSION = 1.3.0
 NODE_DRIVER_REGISTRAR_VERSION = 2.3.0
 LIVENESSPROBE_VERSION = 2.4.0
-CSI_SIDECARS = \
-	external-provisioner \
-	external-resizer \
-	node-driver-registrar \
-	livenessprobe
 
 GOPATH ?= $(shell go env GOPATH)
 
@@ -19,9 +14,13 @@ LIVENESSPROBE_SRC         = $(SRC_ROOT)/livenessprobe
 
 OUTPUT_DIR ?= .
 
-build: $(CSI_SIDECARS)
+.PHONY: build
+build: $(OUTPUT_DIR)/csi-provisioner
+build: $(OUTPUT_DIR)/csi-resizer
+build: $(OUTPUT_DIR)/csi-node-driver-registrar
+build: $(OUTPUT_DIR)/livenessprobe
 
-external-provisioner:
+$(OUTPUT_DIR)/csi-provisioner:
 	rm -rf $(EXTERNAL_PROVISIONER_SRC)
 	mkdir -p $(EXTERNAL_PROVISIONER_SRC)
 	curl -sSLf https://github.com/kubernetes-csi/external-provisioner/archive/v$(EXTERNAL_PROVISIONER_VERSION).tar.gz | \
@@ -29,7 +28,7 @@ external-provisioner:
 	make -C $(EXTERNAL_PROVISIONER_SRC)
 	cp -f $(EXTERNAL_PROVISIONER_SRC)/bin/csi-provisioner $(OUTPUT_DIR)/
 
-external-resizer:
+$(OUTPUT_DIR)/csi-resizer:
 	rm -rf $(EXTERNAL_RESIZER_SRC)
 	mkdir -p $(EXTERNAL_RESIZER_SRC)
 	curl -sSLf https://github.com/kubernetes-csi/external-resizer/archive/v$(EXTERNAL_RESIZER_VERSION).tar.gz | \
@@ -37,7 +36,7 @@ external-resizer:
 	make -C $(EXTERNAL_RESIZER_SRC)
 	cp -f $(EXTERNAL_RESIZER_SRC)/bin/csi-resizer $(OUTPUT_DIR)/
 
-node-driver-registrar:
+$(OUTPUT_DIR)/csi-node-driver-registrar:
 	rm -rf $(NODE_DRIVER_REGISTRAR_SRC)
 	mkdir -p $(NODE_DRIVER_REGISTRAR_SRC)
 	curl -sSLf https://github.com/kubernetes-csi/node-driver-registrar/archive/v$(NODE_DRIVER_REGISTRAR_VERSION).tar.gz | \
@@ -45,12 +44,10 @@ node-driver-registrar:
 	make -C $(NODE_DRIVER_REGISTRAR_SRC)
 	cp -f $(NODE_DRIVER_REGISTRAR_SRC)/bin/csi-node-driver-registrar $(OUTPUT_DIR)/
 
-livenessprobe:
+$(OUTPUT_DIR)/livenessprobe:
 	rm -rf $(LIVENESSPROBE_SRC)
 	mkdir -p $(LIVENESSPROBE_SRC)
 	curl -sSLf https://github.com/kubernetes-csi/livenessprobe/archive/v$(LIVENESSPROBE_VERSION).tar.gz | \
         tar zxf - --strip-components 1 -C $(LIVENESSPROBE_SRC)
 	make -C $(LIVENESSPROBE_SRC)
 	cp -f $(LIVENESSPROBE_SRC)/bin/livenessprobe $(OUTPUT_DIR)/
-
-.PHONY: build $(CSI_SIDECARS)

--- a/docs/tilt.md
+++ b/docs/tilt.md
@@ -1,0 +1,30 @@
+# Using Tilt for developing TopoLVM
+
+[Tilt](https://tilt.dev/) is a tool to help with development of microservices.
+It does it by automating rebuilding the relevant binaries and (re)deploying the components that changed.
+
+## Deploy TopoLVM with Tilt
+
+The e2e environment is used for tilt, so it must be set up first:
+
+```bash
+make -C e2e setup
+make -C e2e start-lvmd
+make -C e2e launch-kind
+```
+
+Now you can run tilt and start coding:
+
+```bash
+tilt up
+```
+
+Tilt will deploy topolvm in the KinD cluster and automatically recompile and deploy any changes you make.
+
+## Limitations
+
+Tilt does not handle `lvmd`.
+This is beacuse `lvmd` needs root privileges and tilt cannot ask for sudo password.
+It may be possible to run tilt as root, but this is not recommended.
+
+If you make changes to `lvmd` you will instead have to compile the code manually and restart the systemd units.

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -69,15 +69,21 @@ SCHEDULER_CONFIG := scheduler-config-v1beta1-$(TEST_SCHEDULER_MANIFEST).yaml
 GO_FILES := $(shell find .. -path ../e2e -prune -o -name '*.go' -print)
 BACKING_STORE := ./build
 
-topolvm.img: $(GO_FILES)
-	rm -rf tmpbin
+.PHONY: csi-sidecars
+csi-sidecars:
+	mkdir -p tmpbin
+	$(MAKE) -f ../csi-sidecars.mk OUTPUT_DIR=tmpbin
+
+.PHONY: e2e-bin
+e2e-bin: $(GO_FILES)
 	mkdir -p tmpbin
 	CGO_ENABLED=0 go build -o tmpbin/hypertopolvm ../pkg/hypertopolvm
-	ln -s hypertopolvm ./tmpbin/lvmd
-	ln -s hypertopolvm ./tmpbin/topolvm-scheduler
-	ln -s hypertopolvm ./tmpbin/topolvm-node
-	ln -s hypertopolvm ./tmpbin/topolvm-controller
-	$(MAKE) -f ../csi-sidecars.mk OUTPUT_DIR=tmpbin
+	ln -sf hypertopolvm ./tmpbin/lvmd
+	ln -sf hypertopolvm ./tmpbin/topolvm-scheduler
+	ln -sf hypertopolvm ./tmpbin/topolvm-node
+	ln -sf hypertopolvm ./tmpbin/topolvm-controller
+
+topolvm.img: e2e-bin csi-sidecars
 	docker build --no-cache --rm=false -f Dockerfile -t topolvm:dev tmpbin
 	docker save -o $@ topolvm:dev
 
@@ -172,7 +178,8 @@ clean: stop-lvmd
 		topolvm.img \
 		build/ \
 		$(BACKING_STORE)/backing_store* \
-		/tmp/topolvm/scheduler/scheduler-config.yaml
+		/tmp/topolvm/scheduler/scheduler-config.yaml \
+		tmpbin
 
 .PHONY: setup
 setup:

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -66,7 +66,7 @@ HELM_SKIP_NODE_FINALIZE_FLAG :=
 endif
 
 SCHEDULER_CONFIG := scheduler-config-v1beta1-$(TEST_SCHEDULER_MANIFEST).yaml
-GO_FILES := $(shell find .. -prune -o -path ../e2e -prune -o -name '*.go' -print)
+GO_FILES := $(shell find .. -path ../e2e -prune -o -name '*.go' -print)
 BACKING_STORE := ./build
 
 topolvm.img: $(GO_FILES)

--- a/e2e/manifests/values/deployment-scheduler.yaml
+++ b/e2e/manifests/values/deployment-scheduler.yaml
@@ -9,6 +9,10 @@ controller:
     enabled: false
   nodeSelector:
     kubernetes.io/hostname: topolvm-e2e-worker
+  # The nodeSelector above combined with the default podAntiAffinity means we
+  # cannot use RollingUpdate.
+  updateStrategy:
+    type: Recreate
   # sanity test requires that the controller mounts this hostPath to communicate with it
   volumes:
     - name: socket-dir


### PR DESCRIPTION
Fixes #405.

This adds a simple Tiltfile + some instructions on how to use it. I have reused the e2e environment for tilt since I think that is where it would make most sense to work with tilt. I.e. you would change some part of the code or add a breaking e2e test and use tilt to be able to quickly make changes and check the behavior without having to rerun the test.

As mentioned in the docs, I have not included `lvmd` in the Tiltfile since it requires root and tilt doesn't really support that.
I have not tested this with minikube/deamonset.