### PR TITLE
Correct scoring calculation to match codebase

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -194,7 +194,7 @@ The node scoring for Pod scheduling can be fine-tuned with the following two way
 
 The scoring expression in `topolvm-scheduler` is as follows:
 ```
-min(10, max(0, log2(capacity >> 30 / divisor)))
+min(10, max(0, log2((capacity >> 30) / divisor)))
 ```
 For example, the default of `divisor` is `1`, then if a node has the free disk capacity more than `1024GiB`, `topolvm-scheduler` scores the node as `10`. `divisor` should be adjusted to suit each environment. It can be specified the default value and values for each device-class in [scheduler-options.yaml](./manifests/overlays/daemonset-scheduler/scheduler-options.yaml) as follows:
 


### PR DESCRIPTION
The divide operator has a higher precedence than the shift operator, but this calculation does not happen as written here, in the codebase `capacityToScore()` capacity is first shifted and then divided.