### PR TITLE
stabilize helm test.

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "charts/**"
+      - "ct.yaml"
 
 jobs:
   lint-test:
@@ -50,7 +51,7 @@ jobs:
           make -C e2e daemonset-lvmd/create-vg
           make -C e2e daemonset-lvmd/setup-minikube
           make -C e2e daemonset-lvmd/update-minikube-setting
-          make -C e2e topolvm.img
+          make -C e2e prepare-namespace
 
       - name: "Apply cert-manager CRDs"
         run: kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.0/cert-manager.crds.yaml

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ KIND_NODE_VERSION=v1.21.1
 
 ENVTEST_KUBERNETES_VERSION=1.23
 
+PROTOC_GEN_GO_VERSION := $(shell awk '/google.golang.org\/protobuf/ {print substr($$2, 2)}' go.mod)
 PROTOC_GEN_DOC_VERSION := $(shell awk '/github.com\/pseudomuto\/protoc-gen-doc/ {print substr($$2, 2)}' go.mod)
 PROTOC_GEN_GO_GRPC_VERSION := $(shell awk '/google.golang.org\/grpc\/cmd\/protoc-gen-go-grpc/ {print substr($$2, 2)}' go.mod)
 
@@ -181,7 +182,7 @@ tools: install-kind ## Install development tools.
 	curl -sfL -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-linux-x86_64.zip
 	unzip -o protoc.zip bin/protoc 'include/*'
 	rm -f protoc.zip
-	GOBIN=$(BINDIR) go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+	GOBIN=$(BINDIR) go install google.golang.org/protobuf/cmd/protoc-gen-go@v$(PROTOC_GEN_GO_VERSION)
 	GOBIN=$(BINDIR) go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v$(PROTOC_GEN_GO_GRPC_VERSION)
 	GOBIN=$(BINDIR) go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v$(PROTOC_GEN_DOC_VERSION)
 

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,5 +2,7 @@
 target-branch: main
 validate-maintainers: false
 check-version-increment: false
+namespace: topolvm-system
+release-label: app.kubernetes.io/instance
 chart-repos:
   - jetstack=https://charts.jetstack.io

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -84,6 +84,12 @@ topolvm.img: $(GO_FILES)
 	mkdir -p /tmp/topolvm/scheduler
 	sed -e "s|@DEPLOYMENT_SCHEDULER_HOST@|topolvm-e2e-worker|" $< > $@
 
+.PHONY: prepare-namespace
+prepare-namespace:
+	$(KUBECTL) create namespace topolvm-system
+	$(KUBECTL) label namespace topolvm-system topolvm.cybozu.com/webhook=ignore
+	$(KUBECTL) label namespace kube-system topolvm.cybozu.com/webhook=ignore
+
 .PHONY: launch-kind
 launch-kind: /tmp/topolvm/scheduler/scheduler-config.yaml
 	$(SUDO) rm -rf /tmp/topolvm/controller /tmp/topolvm/worker*
@@ -164,9 +170,7 @@ create-cluster: topolvm.img
 	$(MAKE) launch-kind
 	$(KIND) load image-archive --name=$(KIND_CLUSTER_NAME) $<
 	$(KUBECTL) apply -f https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.crds.yaml
-	$(KUBECTL) create namespace topolvm-system
-	$(KUBECTL) label namespace topolvm-system topolvm.cybozu.com/webhook=ignore
-	$(KUBECTL) label namespace kube-system topolvm.cybozu.com/webhook=ignore
+	$(MAKE) prepare-namespace
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo update
 	$(HELM) dependency build ../charts/topolvm/
@@ -270,13 +274,11 @@ endif
 .PHONY: daemonset-lvmd/test
 daemonset-lvmd/test: topolvm.img
 	$(KUBECTL) apply -f https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.crds.yaml
-	$(KUBECTL) create namespace topolvm-system
-	$(KUBECTL) label namespace topolvm-system topolvm.cybozu.com/webhook=ignore
-	$(KUBECTL) label namespace kube-system topolvm.cybozu.com/webhook=ignore
+	$(MAKE) prepare-namespace
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo update
 	$(HELM) dependency build ../charts/topolvm/
-	$(HELM) install --create-namespace --namespace=topolvm-system topolvm ../charts/topolvm/ -f $(HELM_VALUES_FILE_LVMD) $(HELM_SKIP_NODE_FINALIZE_FLAG)
+	$(HELM) install --namespace=topolvm-system topolvm ../charts/topolvm/ -f $(HELM_VALUES_FILE_LVMD) $(HELM_SKIP_NODE_FINALIZE_FLAG)
 	$(KUBECTL) apply -f manifests/common/
 	$(SUDO) -E env PATH=${PATH} E2ETEST=1 BINDIR=$(BINDIR) STORAGE_CAPACITY=$(STORAGE_CAPACITY) SKIP_NODE_FINALIZE=$(SKIP_NODE_FINALIZE) READ_WRITE_ONCE_POD=$(READ_WRITE_ONCE_POD) DAEMONSET_LVMD=true GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn $(GINKGO) --failFast -v .
 


### PR DESCRIPTION
In default, ct cli installs manifests built from a chart into random generated namespace.
However, topolvm requires a proper prepared namespace, CI suffers from flakiness.
This PR prepares a namespace and use it when ci install runs.