### PR TITLE
make CI faster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,11 @@
-build
+.git
 bin
-include
-example
+build
+charts
+config
+deploy
+docs
 e2e
+example
+include
+testbin

--- a/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
@@ -1,7 +1,11 @@
 name: "e2e-k8s-daemonset-lvmd"
 on:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
   push:
+    paths-ignore:
+      - "**/*.md"
     branches:
       - "main"
 jobs:

--- a/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
@@ -23,6 +23,15 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.17"
+      - name: cache go dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: |
+            go-
       - run: make -C e2e setup
       - run: make -C e2e daemonset-lvmd/create-vg
       - run: make -C e2e daemonset-lvmd/setup-minikube

--- a/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
@@ -32,6 +32,14 @@ jobs:
           key: go-${{ hashFiles('go.sum', 'Makefile') }}
           restore-keys: |
             go-
+      - name: cache e2e sidecar binaries
+        uses: actions/cache@v3
+        with:
+          path: |
+            e2e/tmpbin
+          key: e2e-sidecars-${{ hashFiles('csi-sidecars.mk') }}
+          restore-keys: |
+            e2e-sidecars-
       - run: make -C e2e setup
       - run: make -C e2e daemonset-lvmd/create-vg
       - run: make -C e2e daemonset-lvmd/setup-minikube

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -1,7 +1,11 @@
 name: "e2e-k8s"
 on:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
   push:
+    paths-ignore:
+      - "**/*.md"
     branches:
       - "main"
 jobs:

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -24,6 +24,15 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.17"
+      - name: cache go dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: |
+            go-
       - run: make -C e2e setup
       - run: make -C e2e start-lvmd
       - run: make -C e2e test

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -33,6 +33,14 @@ jobs:
           key: go-${{ hashFiles('go.sum', 'Makefile') }}
           restore-keys: |
             go-
+      - name: cache e2e sidecar binaries
+        uses: actions/cache@v3
+        with:
+          path: |
+            e2e/tmpbin
+          key: e2e-sidecars-${{ hashFiles('csi-sidecars.mk') }}
+          restore-keys: |
+            e2e-sidecars-
       - run: make -C e2e setup
       - run: make -C e2e start-lvmd
       - run: make -C e2e test

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -21,6 +21,16 @@ jobs:
         with:
           go-version: "1.17"
 
+      - name: cache go dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: |
+            go-
+
       - name: "Setup Tools"
         run: |
           make -C e2e setup

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,11 @@
 name: "Main"
 on:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
   push:
+    paths-ignore:
+      - "**/*.md"
     branches:
       - "main"
 jobs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,11 +13,21 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.17"
+      - name: cache go dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: |
+            go-
       - run: make setup
       - run: make check-uncommitted
       - run: make test
       - run: sudo -E env PATH=${PATH} go test -race -v ./lvmd ./driver ./filesystem
       - run: make image
+
   example:
     name: "example"
     runs-on: "ubuntu-18.04"
@@ -29,5 +39,14 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.17"
+      - name: cache go dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: |
+            go-
       - run: make setup
       - run: make run BUILD_IMAGE=true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,15 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.17"
+      - name: cache go dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: |
+            go-
       - run: make setup
       - run: make build/lvmd TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
       - run: tar czf lvmd-${{ steps.check_version.outputs.version }}.tar.gz -C ./build lvmd

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG TOPOLVM_VERSION
 COPY . /workdir
 WORKDIR /workdir
 
-RUN touch csi/*.go lvmd/proto/*.go docs/*.md \
-    && make build TOPOLVM_VERSION=${TOPOLVM_VERSION}
+RUN touch csi/*.go lvmd/proto/*.go \
+    && make build-topolvm TOPOLVM_VERSION=${TOPOLVM_VERSION}
 
 # TopoLVM container
 FROM ubuntu:18.04

--- a/Dockerfile.with-sidecar
+++ b/Dockerfile.with-sidecar
@@ -1,38 +1,19 @@
+ARG IMAGE_PREFIX
+
 # Build Container
 FROM golang:1.17-buster AS build-env
-
-# Get argment
-ARG TOPOLVM_VERSION
 
 COPY . /workdir
 WORKDIR /workdir
 
-RUN touch csi/*.go lvmd/proto/*.go docs/*.md \
-    && make build TOPOLVM_VERSION=${TOPOLVM_VERSION}
+RUN make csi-sidecars
 
 # TopoLVM container
-FROM ubuntu:18.04
+FROM ${IMAGE_PREFIX}topolvm:devel
 
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get -y install --no-install-recommends \
-        btrfs-progs \
-        file \
-        xfsprogs \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=build-env /workdir/build/hypertopolvm /hypertopolvm
-
-RUN ln -s hypertopolvm /lvmd \
-    && ln -s hypertopolvm /topolvm-scheduler \
-    && ln -s hypertopolvm /topolvm-node \
-    && ln -s hypertopolvm /topolvm-controller
-
-# CSI sidecar
 COPY --from=build-env /workdir/build/csi-provisioner /csi-provisioner
 COPY --from=build-env /workdir/build/csi-node-driver-registrar /csi-node-driver-registrar
 COPY --from=build-env /workdir/build/csi-resizer /csi-resizer
 COPY --from=build-env /workdir/build/livenessprobe /livenessprobe
-COPY --from=build-env /workdir/LICENSE /LICENSE
 
 ENTRYPOINT ["/hypertopolvm"]

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,6 @@ install-kind:
 
 .PHONY: tools
 tools: install-kind ## Install development tools.
-	GOBIN=$(BINDIR) go install golang.org/x/tools/cmd/goimports@latest
 	GOBIN=$(BINDIR) go install honnef.co/go/tools/cmd/staticcheck@latest
 	GOBIN=$(BINDIR) go install github.com/gostaticanalysis/nilerr/cmd/nilerr@latest
 	# Follow the official documentation to install the `latest` version, because explicitly specifying the version will get an error.
@@ -199,20 +198,6 @@ setup: ## Setup local environment.
 	$(SUDO) apt-get update
 	$(SUDO) apt-get -y install --no-install-recommends $(PACKAGES)
 	$(MAKE) tools
-
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef
 
 .PHONY: kind-node
 kind-node:

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,10 @@ clean: ## Clean working directory.
 ##@ Build
 
 .PHONY: build
-build: build/hypertopolvm build/lvmd csi-sidecars ## Build binaries.
+build: build-topolvm csi-sidecars ## Build binaries.
+
+.PHONY: build-topolvm
+build-topolvm: build/hypertopolvm build/lvmd
 
 build/hypertopolvm: $(GO_FILES)
 	mkdir -p build
@@ -152,7 +155,7 @@ csi-sidecars: ## Build sidecar images.
 .PHONY: image
 image: ## Build topolvm images.
 	docker build --no-cache -t $(IMAGE_PREFIX)topolvm:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) .
-	docker build --no-cache -t $(IMAGE_PREFIX)topolvm-with-sidecar:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) -f Dockerfile.with-sidecar .
+	docker build --no-cache -t $(IMAGE_PREFIX)topolvm-with-sidecar:devel --build-arg IMAGE_PREFIX=$(IMAGE_PREFIX) -f Dockerfile.with-sidecar .
 
 .PHONY: tag
 tag: ## Tag topolvm images.

--- a/csi-sidecars.mk
+++ b/csi-sidecars.mk
@@ -21,36 +21,48 @@ OUTPUT_DIR ?= .
 
 build: $(CSI_SIDECARS)
 
-external-provisioner:
+external-provisioner: $(OUTPUT_DIR)/.csi-provisioner-$(EXTERNAL_PROVISIONER_VERSION)
+	cp -f $< $(OUTPUT_DIR)/csi-provisioner
+
+$(OUTPUT_DIR)/.csi-provisioner-$(EXTERNAL_PROVISIONER_VERSION):
 	rm -rf $(EXTERNAL_PROVISIONER_SRC)
 	mkdir -p $(EXTERNAL_PROVISIONER_SRC)
 	curl -sSLf https://github.com/kubernetes-csi/external-provisioner/archive/v$(EXTERNAL_PROVISIONER_VERSION).tar.gz | \
         tar zxf - --strip-components 1 -C $(EXTERNAL_PROVISIONER_SRC)
 	make -C $(EXTERNAL_PROVISIONER_SRC)
-	cp -f $(EXTERNAL_PROVISIONER_SRC)/bin/csi-provisioner $(OUTPUT_DIR)/
+	cp -f $(EXTERNAL_PROVISIONER_SRC)/bin/csi-provisioner $@
 
-external-resizer:
+external-resizer: $(OUTPUT_DIR)/.csi-resizer-$(EXTERNAL_RESIZER_VERSION)
+	cp -f $< $(OUTPUT_DIR)/csi-resizer
+
+$(OUTPUT_DIR)/.csi-resizer-$(EXTERNAL_RESIZER_VERSION):
 	rm -rf $(EXTERNAL_RESIZER_SRC)
 	mkdir -p $(EXTERNAL_RESIZER_SRC)
 	curl -sSLf https://github.com/kubernetes-csi/external-resizer/archive/v$(EXTERNAL_RESIZER_VERSION).tar.gz | \
         tar zxf - --strip-components 1 -C $(EXTERNAL_RESIZER_SRC)
 	make -C $(EXTERNAL_RESIZER_SRC)
-	cp -f $(EXTERNAL_RESIZER_SRC)/bin/csi-resizer $(OUTPUT_DIR)/
+	cp -f $(EXTERNAL_RESIZER_SRC)/bin/csi-resizer $@
 
-node-driver-registrar:
+node-driver-registrar: $(OUTPUT_DIR)/.csi-node-driver-registrar-$(NODE_DRIVER_REGISTRAR_VERSION)
+	cp -f $< $(OUTPUT_DIR)/csi-node-driver-registrar
+
+$(OUTPUT_DIR)/.csi-node-driver-registrar-$(NODE_DRIVER_REGISTRAR_VERSION):
 	rm -rf $(NODE_DRIVER_REGISTRAR_SRC)
 	mkdir -p $(NODE_DRIVER_REGISTRAR_SRC)
 	curl -sSLf https://github.com/kubernetes-csi/node-driver-registrar/archive/v$(NODE_DRIVER_REGISTRAR_VERSION).tar.gz | \
         tar zxf - --strip-components 1 -C $(NODE_DRIVER_REGISTRAR_SRC)
 	make -C $(NODE_DRIVER_REGISTRAR_SRC)
-	cp -f $(NODE_DRIVER_REGISTRAR_SRC)/bin/csi-node-driver-registrar $(OUTPUT_DIR)/
+	cp -f $(NODE_DRIVER_REGISTRAR_SRC)/bin/csi-node-driver-registrar $@
 
-livenessprobe:
+livenessprobe: $(OUTPUT_DIR)/.livenessprobe-$(LIVENESSPROBE_VERSION)
+	cp -f $< $(OUTPUT_DIR)/livenessprobe
+
+$(OUTPUT_DIR)/.livenessprobe-$(LIVENESSPROBE_VERSION):
 	rm -rf $(LIVENESSPROBE_SRC)
 	mkdir -p $(LIVENESSPROBE_SRC)
 	curl -sSLf https://github.com/kubernetes-csi/livenessprobe/archive/v$(LIVENESSPROBE_VERSION).tar.gz | \
         tar zxf - --strip-components 1 -C $(LIVENESSPROBE_SRC)
 	make -C $(LIVENESSPROBE_SRC)
-	cp -f $(LIVENESSPROBE_SRC)/bin/livenessprobe $(OUTPUT_DIR)/
+	cp -f $(LIVENESSPROBE_SRC)/bin/livenessprobe $@
 
 .PHONY: build $(CSI_SIDECARS)

--- a/e2e/.dockerignore
+++ b/e2e/.dockerignore
@@ -1,2 +1,3 @@
 *
-!build
+!tmpbin
+tmpbin/.*

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -8,4 +8,9 @@ RUN apt-get update \
         xfsprogs \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . /
+COPY tmpbin/* /
+
+RUN ln -sf hypertopolvm lvmd && \
+	ln -sf hypertopolvm topolvm-scheduler && \
+	ln -sf hypertopolvm topolvm-node && \
+	ln -sf hypertopolvm topolvm-controller

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -69,15 +69,10 @@ GO_FILES := $(shell find .. -prune -o -path ../e2e -prune -o -name '*.go' -print
 BACKING_STORE := ./build
 
 topolvm.img: $(GO_FILES)
-	rm -rf tmpbin
 	mkdir -p tmpbin
 	CGO_ENABLED=0 go build -o tmpbin/hypertopolvm ../pkg/hypertopolvm
-	ln -s hypertopolvm ./tmpbin/lvmd
-	ln -s hypertopolvm ./tmpbin/topolvm-scheduler
-	ln -s hypertopolvm ./tmpbin/topolvm-node
-	ln -s hypertopolvm ./tmpbin/topolvm-controller
 	$(MAKE) -f ../csi-sidecars.mk OUTPUT_DIR=tmpbin
-	docker build --no-cache --rm=false -f Dockerfile -t topolvm:dev tmpbin
+	docker build --no-cache --rm=false -f Dockerfile -t topolvm:dev .
 	docker save -o $@ topolvm:dev
 
 /tmp/topolvm/scheduler/scheduler-config.yaml: $(SCHEDULER_CONFIG)
@@ -186,7 +181,7 @@ clean: stop-lvmd
 	rm -rf \
 		topolvm.img \
 		build/ \
-		$(BACKING_STORE)/backing_store* \
+		tmpbin/ \
 		/tmp/topolvm/scheduler/scheduler-config.yaml
 
 .PHONY: setup


### PR DESCRIPTION
- cache go dependencies
- cache e2e sidecar binaries
- do not build container images fully. they are just variants, so one can use another as a base.
- skip tests if md only change.