### PR TITLE
add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Maintainers can approve and merge PRs.
+# @toshipp: Toshikuni Fukaya
+# @llamerada-jp: Yuji Ito
+# @satoru-takeuchi: Satoru Takeuchi
+# @cupnes: Yuma Ohgami
+# @daichimukai: Daichi Mukai
+# @peng225: Shinya Hayashi
+* @toshipp @llamerada-jp @satoru-takeuchi @cupnes @daichimukai @peng225

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,0 @@
-Maintainers can approve and merge PRs.
-
-* Toshikuni Fukaya ([toshipp](https://github.com/toshipp))
-* Yuji Ito ([llamerada-jp](https://github.com/llamerada-jp))
-* Satoru Takeuchi ([satoru-takeuchi](https://github.com/satoru-takeuchi))
-* Yuma Ohgami ([cupnes](https://github.com/cupnes))
-* Daichi Mukai ([daichimukai](https://github.com/daichimukai))
-* Shinya Hayashi ([peng225](https://github.com/peng225))


### PR DESCRIPTION
CODEOWNERS can be used for branch protection. I prefer to use it instead of MAINTAINER.md.