### PR TITLE
fix: send correct proto.WatchResponse for thin and thick lvs

### DIFF
--- a/deploy/lvmd-config/lvmd.yaml
+++ b/deploy/lvmd-config/lvmd.yaml
@@ -4,3 +4,9 @@ device-classes:
     volume-group: myvg1
     default: true
     spare-gb: 10
+  - name: ssd-thin
+    volume-group: myvg1
+    type: thin
+    thin-pool:
+      name: thinpool
+      overprovision-ratio: 10.0

--- a/example/Makefile
+++ b/example/Makefile
@@ -44,10 +44,11 @@ run:
 	$(HELM) install --namespace=topolvm-system topolvm ../charts/topolvm/ -f ./values.yaml
 	$(KUBECTL) wait --for=condition=available --timeout=120s -n topolvm-system deployments/topolvm-controller
 	$(KUBECTL) apply -f podpvc.yaml
+	$(KUBECTL) wait --for=condition=ready --timeout=60s -n default pod -l app=example
 
 setup: $(KUBECTL)
 	$(SUDO) apt-get update
-	$(SUDO) apt-get install -y lvm2 xfsprogs
+	$(SUDO) apt-get install -y lvm2 xfsprogs thin-provisioning-tools
 	cd ..; $(MAKE) install-kind
 	mkdir -p $(BINDIR)
 	mkdir -p build
@@ -87,6 +88,7 @@ start-lvmd: $(TMPDIR)/lvmd/lvmd.yaml
 	truncate --size=20G $(BACKING_STORE)/backing_store; \
 	$(SUDO) losetup -f $(BACKING_STORE)/backing_store; \
 	$(SUDO) vgcreate -f -y myvg1 $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store | cut -d: -f1); \
+	$(SUDO) lvcreate -T myvg1/thinpool -L 2G; \
 	$(SUDO) systemd-run --unit=lvmd.service $(shell pwd)/build/lvmd --config=$(TMPDIR)/lvmd/lvmd.yaml; \
 
 stop-lvmd:

--- a/example/podpvc.yaml
+++ b/example/podpvc.yaml
@@ -14,8 +14,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: my-pod
+  namespace: default
   labels:
     app.kubernetes.io/name: my-pod
+    app: example
 spec:
   containers:
   - name: ubuntu
@@ -28,3 +30,37 @@ spec:
     - name: my-volume
       persistentVolumeClaim:
         claimName: topolvm-pvc
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: topolvm-pvc-thin
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      # thin-pool size - 2G, with overprovision - 2G *10 and 10Gi ask should work
+      storage: 10Gi
+  storageClassName: topolvm-provisioner-thin
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod-thin
+  namespace: default
+  labels:
+    app.kubernetes.io/name: my-pod-thin
+    app: example
+spec:
+  containers:
+  - name: ubuntu
+    image: quay.io/cybozu/ubuntu:20.04
+    command: ["/usr/local/bin/pause"]
+    volumeMounts:
+    - mountPath: /test1
+      name: my-volume
+  volumes:
+    - name: my-volume
+      persistentVolumeClaim:
+        claimName: topolvm-pvc-thin

--- a/example/values.yaml
+++ b/example/values.yaml
@@ -9,3 +9,19 @@ podSecurityPolicy:
 
 cert-manager:
   enabled: true
+
+storageClasses:
+  - name: topolvm-provisioner
+    storageClass:
+      fsType: xfs
+      isDefaultClass: false
+      volumeBindingMode: WaitForFirstConsumer
+      allowVolumeExpansion: true
+  - name: topolvm-provisioner-thin
+    storageClass:
+      fsType: xfs
+      isDefaultClass: false
+      volumeBindingMode: WaitForFirstConsumer
+      allowVolumeExpansion: true
+      additionalParameters:
+        "topolvm.cybozu.com/device-class": "ssd-thin"

--- a/lvmd/vgservice_test.go
+++ b/lvmd/vgservice_test.go
@@ -416,7 +416,7 @@ func TestVGService(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer CleanLoopbackVG(vgName, []string{loop1, loop2}, []string{vgName + "1", vgName + "2", vgName + "3"})
+	defer CleanLoopbackVG(vgName, []string{loop1, loop2, loop3}, []string{vgName + "1", vgName + "2", vgName + "3"})
 
 	vg, err := command.FindVolumeGroup(vgName)
 	if err != nil {


### PR DESCRIPTION
- a vg can host both thin and thick vols at same time
- this pr makes that distinction clear and send the WatchResponse correctly
- existing code will either send WatchResponse for thick or thin vols but not for both
- add thin vol steps in example build

Signed-off-by: Leela Venkaiah G <lgangava@redhat.com>