### PR TITLE
Set fail-fast option to false

### DIFF
--- a/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
@@ -15,6 +15,7 @@ jobs:
     name: "e2e-k8s-daemonset-lvmd"
     runs-on: "ubuntu-18.04"
     strategy:
+      fail-fast: false
       matrix:
         kubernetes_versions: ["1.23.3", "1.22.2", "1.21.2"]
         storage_capacity: ["false", "true"]

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -15,6 +15,7 @@ jobs:
     name: "e2e-k8s"
     runs-on: "ubuntu-18.04"
     strategy:
+      fail-fast: false
       matrix:
         kubernetes_versions: ["1.23.3", "1.22.2", "1.21.2"]
         test_scheduler_manifest: ["daemonset", "deployment"]


### PR DESCRIPTION
It is now possible to re-run only failed jobs by themselves with the update of Github Actions. Therefore, even if some jobs fail, I want to change them so that other jobs will continue.
This can reduce the cost of re-run jobs.

- https://github.blog/changelog/2022-03-17-github-actions-re-run-only-failed-or-individual-jobs/
- https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions
- https://github.community/t/error-the-operation-was-canceled-in-ci/166506/4
- https://stackoverflow.com/questions/61070925/github-actions-disable-auto-cancel-when-job-fails
