### PR TITLE
Fix e2e/topolvm.img is not updated properly.

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -66,7 +66,7 @@ else
 SCHEDULER_DEPLOYMENT_CONFIG := scheduler-config-v1beta2-deployment.yaml
 endif
 
-GO_FILES := $(shell find .. -prune -o -path ../e2e -prune -o -name '*.go' -print)
+GO_FILES := $(shell find .. -path ../e2e -prune -o -name '*.go' -print)
 BACKING_STORE := ./build
 
 topolvm.img: $(GO_FILES)


### PR DESCRIPTION
e2e/topolvm.img is not updated properly because Makefile bug.

Signed-off-by: Yuma Ogami <yuma-ogami@cybozu.co.jp>