### PR TITLE
Use lvm JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Supported environments
 - Kubernetes: 1.24, 1.23, 1.22
 - Node OS: Linux with LVM2 (*1)
 - Filesystems: ext4, xfs, btrfs(experimental)
+- lvm version 2.02.163 or later (adds JSON output support)
 
 *1 The host's Linux Kernel must be v4.9 or later which supports `rmapbt` and `reflink`, if you use xfs filesystem with an official docker image.
 

--- a/lvmd/command/lvm.go
+++ b/lvmd/command/lvm.go
@@ -43,6 +43,8 @@ func wrapExecCommand(cmd string, args ...string) *exec.Cmd {
 func CallLVM(cmd string, args ...string) error {
 	args = append([]string{cmd}, args...)
 	c := wrapExecCommand(lvm, args...)
+	c.Env = os.Environ()
+	c.Env = append(c.Env, "LC_ALL=C")
 	log.Info("invoking LVM command", map[string]interface{}{
 		"args": args,
 	})

--- a/lvmd/command/lvm.go
+++ b/lvmd/command/lvm.go
@@ -114,6 +114,15 @@ func FindVolumeGroup(name string) (*VolumeGroup, error) {
 	return nil, ErrNotFound
 }
 
+func SearchVolumeGroupList(vgs []*VolumeGroup, name string) (*VolumeGroup, error) {
+	for _, vg := range vgs {
+		if vg.state.name == name {
+			return vg, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
 func filter_lv(vg_name string, lvs []lv) []lv {
 	var filtered []lv
 	for _, l := range lvs {

--- a/lvmd/command/lvm.go
+++ b/lvmd/command/lvm.go
@@ -3,12 +3,9 @@ package command
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cybozu-go/log"
@@ -55,117 +52,41 @@ func CallLVM(cmd string, args ...string) error {
 // LVInfo is a map of lv attributes to values.
 type LVInfo map[string]string
 
-func parseOneLine(line string) LVInfo {
-	ret := LVInfo{}
-	line = strings.TrimSpace(line)
-	for _, token := range strings.Split(line, " ") {
-		if len(token) == 0 {
-			continue
-		}
-		// assume token is "k=v"
-		kv := strings.Split(token, "=")
-		k, v := kv[0], kv[1]
-		// k[5:] removes "LVM2_" prefix.
-		k = strings.ToLower(k[5:])
-		// assume v is 'some-value'
-		v = strings.Trim(v, "'")
-		ret[k] = v
-	}
-	return ret
-}
-
-// parseLines parses output from lvm.
-func parseLines(output string) []LVInfo {
-	ret := []LVInfo{}
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if len(line) == 0 {
-			continue
-		}
-		info := parseOneLine(line)
-		ret = append(ret, info)
-	}
-	return ret
-}
-
-// parseOutput calls lvm family and parses output from it.
-//
-// cmd is a command name of lvm family.
-// fields are comma separated field names.
-// args is optional arguments for lvm command.
-func parseOutput(cmd, fields string, args ...string) ([]LVInfo, error) {
-	arg := []string{
-		cmd, "-o", fields,
-		"--noheadings", "--separator= ",
-		"--units=b", "--nosuffix",
-		"--unbuffered", "--nameprefixes",
-	}
-	arg = append(arg, args...)
-	c := wrapExecCommand(lvm, arg...)
-	c.Stderr = os.Stderr
-	stdout, err := c.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-	if err := c.Start(); err != nil {
-		return nil, err
-	}
-	out, err := io.ReadAll(stdout)
-	if err != nil {
-		return nil, err
-	}
-	if err := c.Wait(); err != nil {
-		return nil, err
-	}
-	return parseLines(string(out)), nil
-}
-
 // VolumeGroup represents a volume group of linux lvm.
 type VolumeGroup struct {
-	name string
+	state vg
+	lvs   []lv
+}
+
+func (g *VolumeGroup) Update() error {
+	vgs, lvs, err := getLVMState()
+	if err != nil {
+		return err
+	}
+	for _, vg := range vgs {
+		if vg.name == g.Name() {
+			g.state = vg
+			break
+		}
+	}
+
+	g.lvs = filter_lv(g.Name(), lvs)
+	return nil
 }
 
 // Name returns the volume group name.
 func (g *VolumeGroup) Name() string {
-	return g.name
+	return g.state.name
 }
 
 // Size returns the capacity of the volume group in bytes.
 func (g *VolumeGroup) Size() (uint64, error) {
-	infoList, err := parseOutput("vgs", "vg_size", g.name)
-	if err != nil {
-		return 0, err
-	}
-
-	if len(infoList) != 1 {
-		return 0, errors.New("volume group not found: " + g.name)
-	}
-
-	info := infoList[0]
-	vgSize, err := strconv.ParseUint(info["vg_size"], 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return vgSize, nil
+	return g.state.size, nil
 }
 
 // Free returns the free space of the volume group in bytes.
 func (g *VolumeGroup) Free() (uint64, error) {
-	infoList, err := parseOutput("vgs", "vg_free", g.name)
-	if err != nil {
-		return 0, err
-	}
-
-	if len(infoList) != 1 {
-		return 0, errors.New("volume group not found: " + g.name)
-	}
-
-	info := infoList[0]
-	vgFree, err := strconv.ParseUint(info["vg_free"], 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return vgFree, nil
+	return g.state.free, nil
 }
 
 // CreateVolumeGroup calls "vgcreate" to create a volume group.
@@ -193,26 +114,33 @@ func FindVolumeGroup(name string) (*VolumeGroup, error) {
 	return nil, ErrNotFound
 }
 
+func filter_lv(vg_name string, lvs []lv) []lv {
+	var filtered []lv
+	for _, l := range lvs {
+		if l.vgName == vg_name {
+			filtered = append(filtered, l)
+		}
+	}
+	return filtered
+}
+
 // ListVolumeGroups lists all volume groups.
 func ListVolumeGroups() ([]*VolumeGroup, error) {
-	infoList, err := parseOutput("vgs", "vg_name")
+	vgs, lvs, err := getLVMState()
 	if err != nil {
 		return nil, err
 	}
+
 	groups := []*VolumeGroup{}
-	for _, info := range infoList {
-		groups = append(groups, &VolumeGroup{info["vg_name"]})
+	for _, vg := range vgs {
+		groups = append(groups, &VolumeGroup{vg, filter_lv(vg.name, lvs)})
 	}
 	return groups, nil
 }
 
 // FindVolume finds a named logical volume in this volume group.
 func (g *VolumeGroup) FindVolume(name string) (*LogicalVolume, error) {
-	volumes, err := g.ListVolumes()
-	if err != nil {
-		return nil, err
-	}
-	for _, volume := range volumes {
+	for _, volume := range g.ListVolumes() {
 		if volume.Name() == name {
 			return volume, nil
 		}
@@ -221,61 +149,42 @@ func (g *VolumeGroup) FindVolume(name string) (*LogicalVolume, error) {
 }
 
 // ListVolumes lists all logical volumes in this volume group.
-func (g *VolumeGroup) ListVolumes() ([]*LogicalVolume, error) {
-	infoList, err := parseOutput(
-		"lvs",
-		"lv_name,lv_path,lv_size,lv_kernel_major,lv_kernel_minor,origin,origin_size,pool_lv,thin_count,lv_tags",
-		g.Name())
-	if err != nil {
-		return nil, err
-	}
+func (g *VolumeGroup) ListVolumes() []*LogicalVolume {
 	var ret []*LogicalVolume
-	lvNameSet := make(map[string]struct{})
-	for _, info := range infoList {
-		if len(info["thin_count"]) > 0 {
-			continue
-		}
-		// Avoid listing duplicate LVs divided with segments
-		if _, ok := lvNameSet[info["lv_name"]]; ok {
-			continue
-		}
-		lvNameSet[info["lv_name"]] = struct{}{}
-		size, err := strconv.ParseUint(info["lv_size"], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		var origin *string
-		if len(info["origin"]) > 0 {
-			originName := info["origin"]
-			origin = &originName
-		}
-		var pool *string
-		if len(info["pool_lv"]) > 0 {
-			poolLv := info["pool_lv"]
-			pool = &poolLv
-		}
-		if origin != nil && pool == nil {
-			// this volume is a snapshot, but not a thin volume.
-			size, err = strconv.ParseUint(info["origin_size"], 10, 64)
-			if err != nil {
-				return nil, err
+
+	for i, lv := range g.lvs {
+		if !lv.isThinPool() {
+			size := lv.size
+
+			var origin *string
+			if len(lv.origin) > 0 {
+				origin = &g.lvs[i].origin
 			}
+
+			var pool *string
+			if len(lv.poolLV) > 0 {
+				pool = &g.lvs[i].poolLV
+			}
+
+			if origin != nil && pool == nil {
+				// this volume is a snapshot, but not a thin volume.
+				size = lv.originSize
+			}
+
+			ret = append(ret, newLogicalVolume(
+				lv.name,
+				lv.path,
+				g,
+				size,
+				origin,
+				pool,
+				uint32(lv.major),
+				uint32(lv.minor),
+				lv.tags,
+			))
 		}
-		major, _ := strconv.ParseUint(info["lv_kernel_major"], 10, 32)
-		minor, _ := strconv.ParseUint(info["lv_kernel_minor"], 10, 32)
-		ret = append(ret, newLogicalVolume(
-			info["lv_name"],
-			info["lv_path"],
-			g,
-			size,
-			origin,
-			pool,
-			uint32(major),
-			uint32(minor),
-			strings.Split(info["lv_tags"], ","),
-		))
 	}
-	return ret, nil
+	return ret
 }
 
 // CreateVolume creates logical volume in this volume group.
@@ -302,16 +211,16 @@ func (g *VolumeGroup) CreateVolume(name string, size uint64, tags []string, stri
 	if err := CallLVM("lvcreate", lvcreateArgs...); err != nil {
 		return nil, err
 	}
+	if err := g.Update(); err != nil {
+		return nil, err
+	}
+
 	return g.FindVolume(name)
 }
 
 // FindPool finds a named thin pool in this volume group.
 func (g *VolumeGroup) FindPool(name string) (*ThinPool, error) {
-	pools, err := g.ListPools()
-	if err != nil {
-		return nil, err
-	}
-	for _, pool := range pools {
+	for _, pool := range g.ListPools() {
 		if pool.Name() == name {
 			return pool, nil
 		}
@@ -320,23 +229,14 @@ func (g *VolumeGroup) FindPool(name string) (*ThinPool, error) {
 }
 
 // ListPools lists all thin pool volumes in this volume group.
-func (g *VolumeGroup) ListPools() ([]*ThinPool, error) {
-	infoList, err := parseOutput("lvs", "lv_name,lv_size,thin_count", g.Name())
-	if err != nil {
-		return nil, err
-	}
+func (g *VolumeGroup) ListPools() []*ThinPool {
 	ret := []*ThinPool{}
-	for _, info := range infoList {
-		if len(info["thin_count"]) == 0 {
-			continue
+	for _, lv := range g.lvs {
+		if lv.isThinPool() {
+			ret = append(ret, newThinPool(lv.name, g, lv))
 		}
-		lvSize, err := strconv.ParseUint(info["lv_size"], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		ret = append(ret, newThinPool(info["lv_name"], g, lvSize))
 	}
-	return ret, nil
+	return ret
 }
 
 // CreatePool creates a pool for thin-provisioning volumes.
@@ -345,15 +245,16 @@ func (g *VolumeGroup) CreatePool(name string, size uint64) (*ThinPool, error) {
 		"--size", fmt.Sprintf("%vg", size>>30)); err != nil {
 		return nil, err
 	}
+	if err := g.Update(); err != nil {
+		return nil, err
+	}
 	return g.FindPool(name)
 }
 
 // ThinPool represents a lvm thin pool.
 type ThinPool struct {
-	fullname string
-	name     string
-	vg       *VolumeGroup
-	size     uint64
+	vg    *VolumeGroup
+	state lv
 }
 
 // ThinPoolUsage holds current usage of lvm thin pool
@@ -368,24 +269,21 @@ func fullName(name string, vg *VolumeGroup) string {
 	return fmt.Sprintf("%v/%v", vg.Name(), name)
 }
 
-func newThinPool(name string, vg *VolumeGroup, size uint64) *ThinPool {
-	fullname := fullName(name, vg)
+func newThinPool(name string, vg *VolumeGroup, lvm_lv lv) *ThinPool {
 	return &ThinPool{
-		fullname,
-		name,
 		vg,
-		size,
+		lvm_lv,
 	}
 }
 
 // Name returns thin pool name.
 func (t *ThinPool) Name() string {
-	return t.name
+	return t.state.name
 }
 
 // FullName returns a VG prefixed name.
 func (t *ThinPool) FullName() string {
-	return t.fullname
+	return t.state.fullName
 }
 
 // VG returns a volume group in which the thin pool is.
@@ -395,45 +293,35 @@ func (t *ThinPool) VG() *VolumeGroup {
 
 // Size returns a size of the thin pool.
 func (t *ThinPool) Size() uint64 {
-	return t.size
+	return t.state.size
 }
 
 // Resize the thin pool capacity.
 func (t *ThinPool) Resize(newSize uint64) error {
-	if t.size == newSize {
+	if t.state.size == newSize {
 		return nil
 	}
-	if err := CallLVM("lvresize", "-f", "-L", fmt.Sprintf("%vb", newSize), t.fullname); err != nil {
+	if err := CallLVM("lvresize", "-f", "-L", fmt.Sprintf("%vb", newSize), t.state.fullName); err != nil {
 		return err
 	}
-	t.size = newSize
-	return nil
+	return t.vg.Update()
 }
 
 // ListVolumes lists all volumes in this thin pool.
-func (t *ThinPool) ListVolumes() ([]*LogicalVolume, error) {
-	volumes, err := t.vg.ListVolumes()
-	if err != nil {
-		return nil, err
-	}
+func (t *ThinPool) ListVolumes() []*LogicalVolume {
 	ret := []*LogicalVolume{}
-	for _, volume := range volumes {
-		if volume.pool != nil && *volume.pool == t.name {
+	for _, volume := range t.vg.ListVolumes() {
+		if volume.pool != nil && *volume.pool == t.state.name {
 			ret = append(ret, volume)
 		}
 	}
-	return ret, nil
+	return ret
 }
 
 // FindVolume finds a named logical volume in this thin pool
 func (t *ThinPool) FindVolume(name string) (*LogicalVolume, error) {
-	volumes, err := t.vg.ListVolumes()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, volume := range volumes {
-		if volume.name == name && volume.pool != nil && *volume.pool == t.name {
+	for _, volume := range t.vg.ListVolumes() {
+		if volume.name == name && volume.pool != nil && *volume.pool == t.state.name {
 			return volume, nil
 		}
 	}
@@ -460,6 +348,9 @@ func (t *ThinPool) CreateVolume(name string, size uint64, tags []string, stripe 
 	if err := CallLVM("lvcreate", lvcreateArgs...); err != nil {
 		return nil, err
 	}
+	if err := t.vg.Update(); err != nil {
+		return nil, err
+	}
 	return t.vg.FindVolume(name)
 }
 
@@ -467,42 +358,15 @@ func (t *ThinPool) CreateVolume(name string, size uint64, tags []string, stripe 
 // sum of virtualsizes of all thinlvs and size of thinpool
 func (t *ThinPool) Free() (*ThinPoolUsage, error) {
 	tpu := &ThinPoolUsage{}
-	infoList, err := parseOutput("lvs", "lv_size,data_percent,metadata_percent,pool_lv", "-S", fmt.Sprintf("lv_name=%s||pool_lv=%s", t.Name(), t.Name()))
-	if err != nil {
-		return nil, err
-	}
+	tpu.DataPercent = t.state.dataPercent
+	tpu.MetadataPercent = t.state.metaDataPercent
+	tpu.SizeBytes = t.state.size
 
-	if len(infoList) < 1 {
-		return nil, errors.New("thin pool not found: " + t.FullName())
-	}
-
-	var virtualSize uint64
-	for _, info := range infoList {
-		if info["pool_lv"] == "" {
-			// thin pool
-			tpu.DataPercent, err = strconv.ParseFloat(info["data_percent"], 64)
-			if err != nil {
-				return nil, err
-			}
-			tpu.MetadataPercent, err = strconv.ParseFloat(info["metadata_percent"], 64)
-			if err != nil {
-				return nil, err
-			}
-			tpu.SizeBytes, err = strconv.ParseUint(info["lv_size"], 10, 64)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			// thin lv
-			lvSize, err := strconv.ParseUint(info["lv_size"], 10, 64)
-			if err != nil {
-				return nil, err
-			}
-			virtualSize += lvSize
+	for _, l := range t.vg.lvs {
+		if l.poolLV == t.state.name {
+			tpu.VirtualBytes += l.size
 		}
 	}
-
-	tpu.VirtualBytes = virtualSize
 	return tpu, nil
 }
 
@@ -633,6 +497,11 @@ func (l *LogicalVolume) Snapshot(name string, cowSize uint64, tags []string) (*L
 		}
 
 		time.Sleep(2 * time.Second)
+
+		if err := l.vg.Update(); err != nil {
+			return nil, err
+		}
+
 		snapLV, err := l.vg.FindVolume(name)
 		if err != nil {
 			return nil, err
@@ -658,6 +527,10 @@ func (l *LogicalVolume) Snapshot(name string, cowSize uint64, tags []string) (*L
 	if err := CallLVM("lvcreate", lvcreateArgs...); err != nil {
 		return nil, err
 	}
+	if err := l.vg.Update(); err != nil {
+		return nil, err
+	}
+
 	return l.vg.FindVolume(name)
 }
 
@@ -689,13 +562,19 @@ func (l *LogicalVolume) Resize(newSize uint64) error {
 	if err := CallLVM("lvresize", "-L", fmt.Sprintf("%vb", newSize), l.fullname); err != nil {
 		return err
 	}
-	l.size = newSize
+	if err := l.vg.Update(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // Remove this volume.
 func (l *LogicalVolume) Remove() error {
-	return CallLVM("lvremove", "-f", l.path)
+	if err := CallLVM("lvremove", "-f", l.path); err != nil {
+		return err
+	}
+	return l.vg.Update()
 }
 
 // Rename this volume.

--- a/lvmd/command/lvm_json.go
+++ b/lvmd/command/lvm_json.go
@@ -186,18 +186,23 @@ func parseLVMJSON(data []byte) (vgs []vg, lvs []lv, _ error) {
 
 // Issue single lvm command that retrieves everything we need in one call and get the output as JSON
 func getLVMState() (vgs []vg, lvs []lv, _ error) {
+
+	// Note: fullreport doesn't have an option to omit an entire section, so in those cases we limit
+	// the column to 1 and then exclude it to remove.
 	args := []string{
 		"fullreport",
+		"--profile", "lvmdbusd",
+		"--config", "report {pvs_cols_full=\"pv_name\" segs_cols_full=\"lv_uuid\" pvsegs_cols_full=\"lv_uuid\" }",
+		"--configreport", "pv", "-o-pv_name",
+		"--configreport", "seg", "-o-lv_uuid",
+		"--configreport", "pvseg", "-o-lv_uuid",
 		"--configreport", "vg", "-o", "vg_name,vg_uuid,vg_size,vg_free",
 		"--configreport", "lv", "-o", "lv_uuid,lv_name,lv_full_name,lv_path,lv_size," +
 			"lv_kernel_major,lv_kernel_minor,origin,origin_size,pool_lv,lv_tags," +
 			"lv_attr,vg_name,data_percent,metadata_percent,pool_lv",
-		"--configreport", "pv", "-o", "pv_name",
-		"--reportformat", "json",
 	}
 
 	c := wrapExecCommand(lvm, args...)
-	c.Env = append(c.Env, "LVM_COMMAND_PROFILE=lvmdbusd")
 	c.Stderr = os.Stderr
 	stdout, err := c.StdoutPipe()
 	if err != nil {

--- a/lvmd/command/lvm_json.go
+++ b/lvmd/command/lvm_json.go
@@ -1,0 +1,218 @@
+package command
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type vg struct {
+	name string
+	uuid string
+	size uint64
+	free uint64
+}
+
+type lv struct {
+	name            string
+	fullName        string
+	uuid            string
+	path            string
+	major           uint64
+	minor           uint64
+	origin          string
+	originSize      uint64
+	poolLV          string
+	tags            []string
+	attr            string
+	vgName          string
+	size            uint64
+	dataPercent     float64
+	metaDataPercent float64
+}
+
+func (u *lv) isThinPool() bool {
+	return u.attr[0] == 't'
+}
+
+func (u *vg) UnmarshalJSON(data []byte) error {
+	type vgInternal struct {
+		Name string `json:"vg_name"`
+		UUID string `json:"vg_uuid"`
+		Size string `json:"vg_size"`
+		Free string `json:"vg_free"`
+	}
+
+	var temp vgInternal
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	u.name = temp.Name
+	u.uuid = temp.UUID
+
+	var convErr error
+	u.size, convErr = strconv.ParseUint(temp.Size, 10, 64)
+	if convErr != nil {
+		return convErr
+	}
+	u.free, convErr = strconv.ParseUint(temp.Free, 10, 64)
+	if convErr != nil {
+		return convErr
+	}
+
+	return nil
+}
+
+func (u *lv) UnmarshalJSON(data []byte) error {
+	type lvInternal struct {
+		Name            string `json:"lv_name"`
+		FullName        string `json:"lv_full_name"`
+		UUID            string `json:"lv_uuid"`
+		Path            string `json:"lv_path"`
+		Major           string `json:"lv_kernel_major"`
+		Minor           string `json:"lv_kernel_minor"`
+		Origin          string `json:"origin"`
+		OriginSize      string `json:"origin_size"`
+		PoolLV          string `json:"pool_lv"`
+		Tags            string `json:"lv_tags"`
+		Attr            string `json:"lv_attr"`
+		VgName          string `json:"vg_name"`
+		Size            string `json:"lv_size"`
+		DataPercent     string `json:"data_percent"`
+		MetaDataPercent string `json:"metadata_percent"`
+	}
+
+	var temp lvInternal
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	u.name = temp.Name
+	u.fullName = temp.FullName
+	u.uuid = temp.UUID
+	u.path = temp.Path
+
+	var convErr error
+	u.major, convErr = strconv.ParseUint(temp.Major, 10, 32)
+	if convErr != nil {
+		return convErr
+	}
+	u.minor, convErr = strconv.ParseUint(temp.Minor, 10, 32)
+	if convErr != nil {
+		return convErr
+	}
+
+	u.origin = temp.Origin
+	if len(temp.OriginSize) > 0 {
+		u.originSize, convErr = strconv.ParseUint(temp.OriginSize, 10, 64)
+		if convErr != nil {
+			return convErr
+		}
+	}
+
+	u.poolLV = temp.PoolLV
+	u.tags = strings.Split(temp.Tags, ",")
+	u.attr = temp.Attr
+	u.vgName = temp.VgName
+
+	if len(temp.Size) > 0 {
+		u.size, convErr = strconv.ParseUint(temp.Size, 10, 64)
+		if convErr != nil {
+			return convErr
+		}
+	}
+
+	if len(temp.DataPercent) > 0 {
+		u.dataPercent, convErr = strconv.ParseFloat(temp.DataPercent, 64)
+		if convErr != nil {
+			return convErr
+		}
+	}
+
+	if len(temp.MetaDataPercent) > 0 {
+		u.metaDataPercent, convErr = strconv.ParseFloat(temp.MetaDataPercent, 64)
+		if convErr != nil {
+			return convErr
+		}
+	}
+	return nil
+}
+
+func parseLVMJSON(data []byte) (vgs []vg, lvs []lv, _ error) {
+	type lvmResponse struct {
+		Report json.RawMessage `json:"report"`
+		Log    json.RawMessage `json:"log"`
+	}
+
+	type lvmEntries struct {
+		Vg json.RawMessage `json:"vg"`
+		Lv json.RawMessage `json:"lv"`
+	}
+
+	var result lvmResponse
+
+	if parseErr := json.Unmarshal(data, &result); parseErr != nil {
+		return nil, nil, parseErr
+	}
+
+	if result.Report != nil {
+		var entries []lvmEntries
+		if parseErr := json.Unmarshal(result.Report, &entries); parseErr != nil {
+			return nil, nil, parseErr
+		}
+
+		for _, e := range entries {
+			if e.Vg != nil {
+				var tvgs []vg
+				if parseErr := json.Unmarshal(e.Vg, &tvgs); parseErr != nil {
+					return nil, nil, parseErr
+				}
+				vgs = append(vgs, tvgs...)
+			}
+			if e.Lv != nil {
+				var tlvs []lv
+				if parseErr := json.Unmarshal(e.Lv, &tlvs); parseErr != nil {
+					return nil, nil, parseErr
+				}
+				lvs = append(lvs, tlvs...)
+			}
+		}
+	}
+	return vgs, lvs, nil
+}
+
+// Issue single lvm command that retrieves everything we need in one call and get the output as JSON
+func getLVMState() (vgs []vg, lvs []lv, _ error) {
+	args := []string{
+		"fullreport",
+		"--configreport", "vg", "-o", "vg_name,vg_uuid,vg_size,vg_free",
+		"--configreport", "lv", "-o", "lv_uuid,lv_name,lv_full_name,lv_path,lv_size," +
+			"lv_kernel_major,lv_kernel_minor,origin,origin_size,pool_lv,lv_tags," +
+			"lv_attr,vg_name,data_percent,metadata_percent,pool_lv",
+		"--configreport", "pv", "-o", "pv_name",
+		"--reportformat", "json",
+	}
+
+	c := wrapExecCommand(lvm, args...)
+	c.Env = append(c.Env, "LVM_COMMAND_PROFILE=lvmdbusd")
+	c.Stderr = os.Stderr
+	stdout, err := c.StdoutPipe()
+	if err != nil {
+		return vgs, lvs, err
+	}
+	if err := c.Start(); err != nil {
+		return nil, nil, err
+	}
+	out, err := io.ReadAll(stdout)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.Wait(); err != nil {
+		return nil, nil, err
+	}
+
+	return parseLVMJSON(out)
+}

--- a/lvmd/command/lvm_json_test.go
+++ b/lvmd/command/lvm_json_test.go
@@ -1,0 +1,264 @@
+package command
+
+import (
+	"os"
+	"testing"
+
+	"github.com/topolvm/topolvm/lvmd/testutils"
+)
+
+func TestLvmJSON(t *testing.T) {
+
+	goodJSON := `
+	  {
+		"report": [
+		  {
+			"vg": [
+			  {
+				"vg_name": "myvg1",
+				"vg_uuid": "P8en82-LNUe-MERd-mOTT-XlAS-fkp8-1bleiB",
+				"vg_size": "2199014866944",
+				"vg_free": "2198482190336"
+			  }
+			],
+			"pv": [
+			  {},
+			  {}
+			],
+			"lv": [
+			  {
+				"lv_uuid": "n3eoy5-R1B3-9S6A-rBwo-3n9f-mIxA-Dy4nnw",
+				"lv_name": "thinpool",
+				"lv_full_name": "myvg1/thinpool",
+				"lv_path": "",
+				"lv_size": "524288000",
+				"lv_kernel_major": "253",
+				"lv_kernel_minor": "2",
+				"origin": "",
+				"origin_size": "",
+				"pool_lv": "",
+				"lv_tags": "some_tag,some_tag2",
+				"lv_attr": "twi-a-tz--",
+				"vg_name": "myvg1",
+				"data_percent": "0.00",
+				"metadata_percent": "10.84"
+			  }
+			],
+			"pvseg": [
+			  {},
+			  {},
+			  {},
+			  {},
+			  {}
+			],
+			"seg": [
+			  {}
+			]
+		  }
+		],
+		"log": []
+	  }
+	`
+	vgs, lvs, err := parseLVMJSON([]byte(goodJSON))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vgs == nil {
+		t.Fatal("vgs unexpectedly nil")
+	}
+
+	if lvs == nil {
+		t.Fatal("lvs unexpectedly nil")
+	}
+
+	if len(lvs) != 1 {
+		t.Fatal("Incorrect number of LVs returned: ", len(lvs))
+	}
+
+	if len(vgs) != 1 {
+		t.Fatal("Incorrect number of VGs returned: ", len(vgs))
+	}
+
+	lv := lvs[0]
+
+	if lv.uuid != "n3eoy5-R1B3-9S6A-rBwo-3n9f-mIxA-Dy4nnw" {
+		t.Fatal("Incorrect uuid: ", lv.uuid)
+	}
+
+	if lv.name != "thinpool" {
+		t.Fatal("Incorrect name: ", lv.name)
+	}
+
+	if lv.fullName != "myvg1/thinpool" {
+		t.Fatal("Incorrect full name: ", lv.fullName)
+	}
+
+	if lv.path != "" {
+		t.Fatal("Incorrect path: ", lv.path)
+	}
+
+	if lv.size != 524288000 {
+		t.Fatal("Incorrect size: ", lv.size)
+	}
+
+	if lv.major != 253 {
+		t.Fatal("Incorrect major number:", lv.major)
+	}
+
+	if lv.minor != 2 {
+		t.Fatal("Incorrect minor number:", lv.minor)
+	}
+
+	if lv.origin != "" {
+		t.Fatal("Incorrect origin:", lv.origin)
+	}
+
+	if lv.originSize != 0 {
+		t.Fatal("Incorrect origin size:", lv.originSize)
+	}
+
+	if lv.poolLV != "" {
+		t.Fatal("Incorrect pool lv:", lv.poolLV)
+	}
+
+	if len(lv.tags) != 2 {
+		t.Fatal("Incorrect number of tags:", len(lv.tags))
+	}
+
+	if lv.tags[0] != "some_tag" || lv.tags[1] != "some_tag2" {
+		t.Fatal("Incorrect tags:", lv.tags)
+	}
+
+	if lv.attr != "twi-a-tz--" {
+		t.Fatal("Incorrect attr data: ", lv.attr)
+	}
+
+	if lv.vgName != "myvg1" {
+		t.Fatal("Incorrect VG name: ", lv.vgName)
+	}
+
+	if lv.dataPercent != 0 {
+		t.Fatal("Incorrect data percent: ", lv.dataPercent)
+	}
+
+	if lv.metaDataPercent != 10.84 {
+		t.Fatal("Incorrect meta data percent:", lv.metaDataPercent)
+	}
+
+	vg := vgs[0]
+	if vg.name != "myvg1" {
+		t.Fatal("Incorrect vg.name: ", vg.name)
+	}
+
+	if vg.uuid != "P8en82-LNUe-MERd-mOTT-XlAS-fkp8-1bleiB" {
+		t.Fatal("Incorrect vg.uuid: ", vg.uuid)
+	}
+
+	if vg.size != 2199014866944 {
+		t.Fatal("Incorrect vg.size: ", vg.size)
+	}
+
+	if vg.free != 2198482190336 {
+		t.Fatal("Incorrect vg.free: ", vg.free)
+	}
+}
+
+func TestLvmJSONBad(t *testing.T) {
+	truncatedJSON := `
+	  {
+		"report": [
+		  {
+			"vg": [
+			  {
+				"vg_name": "myvg1",
+				"vg_uuid": "P8en82-LNUe-MERd-mOTT-XlAS-fkp8-1bleiB",
+				"vg_size": "2199014866944",
+				"vg_free": "2198482190336"
+			  }
+			],
+			"pv": [
+			  {},
+			  {}
+			],
+			"lv": [
+	`
+	vgs, lvs, err := parseLVMJSON([]byte(truncatedJSON))
+
+	if vgs != nil {
+		t.Fatal("Expected vgs to be nil!")
+	}
+
+	if lvs != nil {
+		t.Fatal("Expected lvs to be nil")
+	}
+
+	if err == nil {
+		t.Fatal("Expected an err, got none")
+	}
+
+}
+
+func TestLvmRetrieval(t *testing.T) {
+	uid := os.Getuid()
+	if uid != 0 {
+		t.Skip("run as root")
+	}
+
+	vgName := "test_lvm_json"
+	lvName := "test_lvm_json_lv"
+	loop, err := testutils.MakeLoopbackDevice(vgName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = testutils.MakeLoopbackVG(vgName, loop)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer testutils.CleanLoopbackVG(vgName, []string{loop}, []string{vgName})
+
+	vgs, lvs, err := getLVMState()
+
+	if err != nil {
+		t.Fatal("Unexpected err returned: ", err)
+	}
+
+	if lvs != nil {
+		t.Fatal("Expected lvs to be nil")
+	}
+
+	if len(vgs) != 1 {
+		t.Fatal("Expected 1 vg: ", len(vgs))
+	}
+
+	err = testutils.MakeLoopbackLV(lvName, vgName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vgs, lvs, err = getLVMState()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if lvs == nil {
+		t.Fatal("Expected LVs to exist")
+	}
+
+	if len(lvs) != 1 {
+		t.Fatal("Expected 1 LV to exist")
+	}
+
+	vg := vgs[0]
+	if vg.name != vgName {
+		t.Fatal("Incorrect vg name: ", vg.name)
+	}
+
+	lv := lvs[0]
+	if lv.name != lvName {
+		t.Fatal("Incorrect lv name: ", lv.name)
+	}
+}

--- a/lvmd/lvservice.go
+++ b/lvmd/lvservice.go
@@ -140,15 +140,7 @@ func (s *lvService) RemoveLV(_ context.Context, req *proto.RemoveLVRequest) (*pr
 	}
 	// ListVolumes on VolumeGroup or ThinPool returns ThinLogicalVolumes as well
 	// and no special handling for removal of LogicalVolume is needed
-	lvs, err := vg.ListVolumes()
-	if err != nil {
-		log.Error("failed to list volumes", map[string]interface{}{
-			log.FnError: err,
-		})
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
-	for _, lv := range lvs {
+	for _, lv := range vg.ListVolumes() {
 		if lv.Name() != req.GetName() {
 			continue
 		}

--- a/lvmd/lvservice_test.go
+++ b/lvmd/lvservice_test.go
@@ -95,6 +95,11 @@ func TestLVService(t *testing.T) {
 	if err != nil {
 		t.Error("failed to create logical volume")
 	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
+	}
+
 	lv, err := vg.FindVolume("test1")
 	if err != nil {
 		t.Fatal(err)
@@ -130,6 +135,11 @@ func TestLVService(t *testing.T) {
 	if count != 2 {
 		t.Errorf("unexpected count: %d", count)
 	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
+	}
+
 	lv, err = vg.FindVolume("test1")
 	if err != nil {
 		t.Fatal(err)
@@ -161,6 +171,10 @@ func TestLVService(t *testing.T) {
 	if count != 3 {
 		t.Errorf("unexpected count: %d", count)
 	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
+	}
 	_, err = vg.FindVolume("test1")
 	if err != command.ErrNotFound {
 		t.Error("unexpected error: ", err)
@@ -190,6 +204,11 @@ func TestLVService(t *testing.T) {
 	if err != nil {
 		t.Error("failed to create logical volume")
 	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
+	}
+
 	lv, err = pool.FindVolume("testp1")
 	if err != nil {
 		t.Fatal(err)
@@ -225,6 +244,11 @@ func TestLVService(t *testing.T) {
 	if count != 3 {
 		t.Errorf("unexpected count: %d", count)
 	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
+	}
+
 	lv, err = pool.FindVolume("testp1")
 	if err != nil {
 		t.Fatal(err)
@@ -242,6 +266,10 @@ func TestLVService(t *testing.T) {
 	}
 	if count != 4 {
 		t.Errorf("unexpected count: %d", count)
+	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
 	}
 	_, err = pool.FindVolume("test1")
 	if err != command.ErrNotFound {
@@ -274,6 +302,11 @@ func TestLVService(t *testing.T) {
 	if err != nil {
 		t.Error("failed to create logical volume")
 	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
+	}
+
 	lv, err = pool.FindVolume("sourceVol")
 	if err != nil {
 		t.Fatal(err)
@@ -311,6 +344,11 @@ func TestLVService(t *testing.T) {
 	if err != nil {
 		t.Error("failed to create logical volume")
 	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
+	}
+
 	lv, err = pool.FindVolume("snap1")
 	if err != nil {
 		t.Fatal(err)
@@ -347,6 +385,11 @@ func TestLVService(t *testing.T) {
 	if err != nil {
 		t.Error("failed to create logical volume")
 	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
+	}
+
 	lv, err = pool.FindVolume("restoredsnap1")
 	if err != nil {
 		t.Fatal(err)

--- a/lvmd/lvservice_test.go
+++ b/lvmd/lvservice_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/topolvm/topolvm/lvmd/command"
 	"github.com/topolvm/topolvm/lvmd/proto"
+	"github.com/topolvm/topolvm/lvmd/testutils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -19,16 +20,16 @@ func TestLVService(t *testing.T) {
 	}
 
 	vgName := "test_lvservice"
-	loop, err := MakeLoopbackDevice(vgName)
+	loop, err := testutils.MakeLoopbackDevice(vgName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = MakeLoopbackVG(vgName, loop)
+	err = testutils.MakeLoopbackVG(vgName, loop)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer CleanLoopbackVG(vgName, []string{loop}, []string{vgName})
+	defer testutils.CleanLoopbackVG(vgName, []string{loop}, []string{vgName})
 
 	vg, err := command.FindVolumeGroup(vgName)
 	if err != nil {

--- a/lvmd/testutils/test_utils.go
+++ b/lvmd/testutils/test_utils.go
@@ -1,4 +1,4 @@
-package lvmd
+package testutils
 
 import (
 	"bytes"
@@ -42,6 +42,18 @@ func MakeLoopbackVG(name string, devices ...string) error {
 	out, err := exec.Command("vgcreate", args...).CombinedOutput()
 	if err != nil {
 		log.Error("failed to vgcreate", map[string]interface{}{
+			"output": string(out),
+		})
+		return err
+	}
+	return nil
+}
+
+func MakeLoopbackLV(name string, vg string) error {
+	args := []string{"-L1G", "-n", name, vg}
+	out, err := exec.Command("lvcreate", args...).CombinedOutput()
+	if err != nil {
+		log.Error("failed lvcreate", map[string]interface{}{
 			"output": string(out),
 		})
 		return err

--- a/lvmd/vgservice_test.go
+++ b/lvmd/vgservice_test.go
@@ -314,6 +314,11 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if err := vg.Update(); err != nil {
+		t.Fatal(err)
+	}
+
 	freeBytes, err := vg.Free()
 	if err != nil {
 		t.Fatal(err)

--- a/lvmd/vgservice_test.go
+++ b/lvmd/vgservice_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/topolvm/topolvm/lvmd/command"
 	"github.com/topolvm/topolvm/lvmd/proto"
+	"github.com/topolvm/topolvm/lvmd/testutils"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -404,24 +405,24 @@ func TestVGService(t *testing.T) {
 	}
 
 	vgName := "test_vgservice"
-	loop1, err := MakeLoopbackDevice(vgName + "1")
+	loop1, err := testutils.MakeLoopbackDevice(vgName + "1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	loop2, err := MakeLoopbackDevice(vgName + "2")
+	loop2, err := testutils.MakeLoopbackDevice(vgName + "2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	loop3, err := MakeLoopbackDevice(vgName + "3")
+	loop3, err := testutils.MakeLoopbackDevice(vgName + "3")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = MakeLoopbackVG(vgName, loop1, loop2, loop3)
+	err = testutils.MakeLoopbackVG(vgName, loop1, loop2, loop3)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer CleanLoopbackVG(vgName, []string{loop1, loop2, loop3}, []string{vgName + "1", vgName + "2", vgName + "3"})
+	defer testutils.CleanLoopbackVG(vgName, []string{loop1, loop2, loop3}, []string{vgName + "1", vgName + "2", vgName + "3"})
 
 	vg, err := command.FindVolumeGroup(vgName)
 	if err != nil {

--- a/lvmd/vgservice_test.go
+++ b/lvmd/vgservice_test.go
@@ -363,7 +363,7 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	testp2.Remove()
 
 	t.Run("thinpool-stripe-raid", func(t *testing.T) {
-		t.Skip("investigae support of striped and raid for thinlvs")
+		t.Skip("investigate support of striped and raid for thinlvs")
 		// TODO (leelavg):
 		// 1. confirm that stripe, stripesize and raid isn't possible on thin lv
 		// 2. if above is true, enforce some sensible defaults during validation of deviceclass

--- a/pkg/lvmd/cmd/root.go
+++ b/pkg/lvmd/cmd/root.go
@@ -76,8 +76,15 @@ func subMain() error {
 	if err != nil {
 		return err
 	}
+
+	vgs, err := command.ListVolumeGroups()
+	if err != nil {
+		log.Error("Error while retrieving volume groups", map[string]interface{}{})
+		return err
+	}
+
 	for _, dc := range config.DeviceClasses {
-		vg, err := command.FindVolumeGroup(dc.VolumeGroup)
+		vg, err := command.SearchVolumeGroupList(vgs, dc.VolumeGroup)
 		if err != nil {
 			log.Error("Volume group not found:", map[string]interface{}{
 				"volume_group": dc.VolumeGroup,


### PR DESCRIPTION
Lvm has had JSON output for a while.  This PR shows a possible usage of it and the usage of`fullreport` for retrieving the entire state of lvm in one go.  Unfortunately lvm double quotes the numeric values it returns in JSON which prevents the standard JSON unmarshal from working, requiring a custom `UnmarshalJSON`.  I'll be working with upstream lvm to see about addressing this which would make this code change simpler ref. https://bugzilla.redhat.com/show_bug.cgi?id=2100126.

This PR also reduces the number of calls into lvm.  In general the cost of forking & exec'ing lvm usually dwarfs the time spent in the calling code, or at least it did when working the lvm dbus service implementation.

~This PR is not complete and not well tested, but I wanted to see if there was any interest in such a change before spending more time on it.~