### PR TITLE
example: retry applying sample pods and pvcs manifest

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -45,7 +45,7 @@ run:
 	$(HELM) install --namespace=topolvm-system topolvm ../charts/topolvm/ -f ./values.yaml
 	$(KUBECTL) wait --for=condition=available --timeout=120s -n topolvm-system deployments/topolvm-controller
 	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system certificate/topolvm-mutatingwebhook
-	$(KUBECTL) apply -f podpvc.yaml
+	timeout 120 sh -c "until $(KUBECTL) apply -f podpvc.yaml; do sleep 10; done"
 	$(KUBECTL) wait --for=condition=ready --timeout=60s -n default pod -l app=example
 
 setup: $(KUBECTL)


### PR DESCRIPTION
As an attempt that try to stabilize creating example environment, in the
commit 31f8d5329c7e ("example: wait for topolvm controller mutating
webhook to become ready") we started to wait for certification to be
ready, which appears to be not enough as we can see in [^1]. To wait for
webhook to become ready, there might be no simple way other than just
try until it succeeds, as Kubernetes does [^2].

[^1]: https://github.com/topolvm/pvc-autoresizer/runs/7036132661?check_suite_focus=true
[^2]: https://github.com/kubernetes/kubernetes/blob/411ecc3b6296d095050ed641c6880d78bbcedc39/test/e2e/apimachinery/webhook.go#L2388-L2415