### PR TITLE
webhook: allow PVCs with storageClassName set to ""

### DIFF
--- a/hook/mutate_persistentvolumeclaim.go
+++ b/hook/mutate_persistentvolumeclaim.go
@@ -48,6 +48,13 @@ func (m *persistentVolumeClaimMutator) Handle(ctx context.Context, req admission
 		return admission.Allowed("no request for TopoLVM")
 	}
 
+	// A PVC is allowed to set `.spec.storageClassName` equal to "" (empty string) to bound it
+	// to a PV with no storage class. We have nothing to do with such PVCs.
+	// cf. https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+	if *pvc.Spec.StorageClassName == "" {
+		return admission.Allowed("no request for TopoLVM")
+	}
+
 	var sc storagev1.StorageClass
 	err = m.getter.Get(ctx, types.NamespacedName{Name: *pvc.Spec.StorageClassName}, &sc)
 	switch {

--- a/hook/mutate_persistentvolumeclaim_test.go
+++ b/hook/mutate_persistentvolumeclaim_test.go
@@ -22,14 +22,12 @@ func setupMutatePVCResources() {
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func createPVC(sc string, pvcName string) {
+func createPVC(sc *string, pvcName string) {
 	pvc := &corev1.PersistentVolumeClaim{}
 	pvc.Namespace = mutatePVCNamespace
 	pvc.Name = pvcName
 	pvc.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
-	if sc != "" {
-		pvc.Spec.StorageClassName = strPtr(sc)
-	}
+	pvc.Spec.StorageClassName = sc
 	pvc.Spec.Resources.Requests = corev1.ResourceList{
 		"storage": *resource.NewQuantity(10<<30, resource.DecimalSI),
 	}
@@ -57,18 +55,27 @@ func hasTopoLVMFinalizer(pvc *corev1.PersistentVolumeClaim) bool {
 }
 
 var _ = Describe("pvc mutation webhook", func() {
-	It("should not have topolvm.cybozu.com/pvc finalizer when not specified storageclass", func() {
-		pvcName := "empty-storageclass-pvc"
-		createPVC("", pvcName)
+	It("should not have topolvm.cybozu.com/pvc finalizer when no storageclass specified", func() {
+		pvcName := "no-storageclass-pvc"
+		createPVC(nil, pvcName)
 		pvc, err := getPVC(pvcName)
 		Expect(err).ShouldNot(HaveOccurred())
 		hasFinalizer := hasTopoLVMFinalizer(pvc)
-		Expect(hasFinalizer).Should(Equal(false), "finalizer should not be set for storageclass=%s", hostLocalStorageClassName)
+		Expect(hasFinalizer).Should(Equal(false), "finalizer should not be set when no storageclass specified")
+	})
+
+	It("should not have topolvm.cybozu.com/pvc finalizer when storageClassName is empty string", func() {
+		pvcName := "empty-storageclass-pvc"
+		createPVC(strPtr(emptyStorageClassName), pvcName)
+		pvc, err := getPVC(pvcName)
+		Expect(err).ShouldNot(HaveOccurred())
+		hasFinalizer := hasTopoLVMFinalizer(pvc)
+		Expect(hasFinalizer).Should(Equal(false), "finalizer should not be set for storageclass=%s", emptyStorageClassName)
 	})
 
 	It("should not have topolvm.cybozu.com/pvc finalizer when the specified StorageClass does not exist", func() {
 		pvcName := "unexists-storageclass-pvc"
-		createPVC(missingStorageClassName, pvcName)
+		createPVC(strPtr(missingStorageClassName), pvcName)
 		pvc, err := getPVC(pvcName)
 		Expect(err).ShouldNot(HaveOccurred())
 		hasFinalizer := hasTopoLVMFinalizer(pvc)
@@ -77,7 +84,7 @@ var _ = Describe("pvc mutation webhook", func() {
 
 	It("should not have topolvm.cybozu.com/pvc finalizer with storageclass host-local", func() {
 		pvcName := "host-local-pvc"
-		createPVC(hostLocalStorageClassName, pvcName)
+		createPVC(strPtr(hostLocalStorageClassName), pvcName)
 		pvc, err := getPVC(pvcName)
 		Expect(err).ShouldNot(HaveOccurred())
 		hasFinalizer := hasTopoLVMFinalizer(pvc)
@@ -86,7 +93,7 @@ var _ = Describe("pvc mutation webhook", func() {
 
 	It("should have topolvm.cybozu.com/pvc finalizer with storageclass topolvm-provisioner", func() {
 		pvcName := "topolvm-provisioner-pvc"
-		createPVC(topolvmProvisionerStorageClassName, pvcName)
+		createPVC(strPtr(topolvmProvisionerStorageClassName), pvcName)
 		pvc, err := getPVC(pvcName)
 		Expect(err).ShouldNot(HaveOccurred())
 		hasFinalizer := hasTopoLVMFinalizer(pvc)
@@ -95,7 +102,7 @@ var _ = Describe("pvc mutation webhook", func() {
 
 	It("should have topolvm.cybozu.com/pvc finalizer with storageclass topolvm-provisioner-immediate", func() {
 		pvcName := "topolvm-provisioner-immediate-pvc"
-		createPVC(topolvmProvisionerImmediateStorageClassName, pvcName)
+		createPVC(strPtr(topolvmProvisionerImmediateStorageClassName), pvcName)
 		pvc, err := getPVC(pvcName)
 		Expect(err).ShouldNot(HaveOccurred())
 		hasFinalizer := hasTopoLVMFinalizer(pvc)

--- a/hook/suite_test.go
+++ b/hook/suite_test.go
@@ -36,15 +36,14 @@ var testEnv *envtest.Environment
 var testCtx, testCancel = context.WithCancel(context.Background())
 
 const (
+	emptyStorageClassName                       = ""
 	topolvmProvisionerStorageClassName          = "topolvm-provisioner"
 	topolvmProvisioner2StorageClassName         = "topolvm-provisioner2"
 	topolvmProvisioner3StorageClassName         = "topolvm-provisioner3"
 	topolvmProvisionerImmediateStorageClassName = "topolvm-provisioner-immediate"
 	hostLocalStorageClassName                   = "host-local"
 	missingStorageClassName                     = "missing-storageclass"
-)
 
-var (
 	podMutatingWebhookPath = "/pod/mutate"
 	pvcMutatingWebhookPath = "/pvc/mutate"
 )
@@ -149,7 +148,7 @@ var _ = BeforeSuite(func() {
 						FailurePolicy:           &failPolicy,
 						ClientConfig: admissionv1.WebhookClientConfig{
 							Service: &admissionv1.ServiceReference{
-								Path: &podMutatingWebhookPath,
+								Path: strPtr(podMutatingWebhookPath),
 							},
 						},
 						Rules: []admissionv1.RuleWithOperations{
@@ -172,7 +171,7 @@ var _ = BeforeSuite(func() {
 						FailurePolicy:           &failPolicy,
 						ClientConfig: admissionv1.WebhookClientConfig{
 							Service: &admissionv1.ServiceReference{
-								Path: &pvcMutatingWebhookPath,
+								Path: strPtr(pvcMutatingWebhookPath),
 							},
 						},
 						Rules: []admissionv1.RuleWithOperations{


### PR DESCRIPTION
A PVC is allowed to set `.spec.storageClassName` equal to "" (empty
string) to bound it to a PV with no storage class. In the current
implementation, for such volumes admission webhook tries to get storage
class with name of "", which fails with the error like "resource name
may not be empty". This error is different from "not found" error and
not well handled, which results in the admission webhook returns an
internal server error.

This patch changes the admission webhook to allow PVCs with
`.spec.storageClassName` set to "" since topolvm does not need to care
about such PVCs.

Fixes: #502