### PR TITLE
lvm: disable activation skip

### DIFF
--- a/lvmd/command/lvm.go
+++ b/lvmd/command/lvm.go
@@ -666,7 +666,7 @@ func (l *LogicalVolume) Activate(access string) error {
 	case "ro":
 		lvchangeArgs = []string{"-p", "r", l.path}
 	case "rw":
-		lvchangeArgs = []string{"-a", "y", "-K", l.path}
+		lvchangeArgs = []string{"-k", "n", "-a", "y", l.path}
 	default:
 		return fmt.Errorf("unknown access: %s for LogicalVolume %s", access, l.fullname)
 	}


### PR DESCRIPTION
Instead of ignoring activation skip parameter one time,
we need to explicitly disable it; to make sure that
the logical volume does not skip activation in future
too.

Signed-off-by: Yug Gupta <yuggupta27@gmail.com>