### PR TITLE
Update e2e tests to handle snapshot csi tests

### DIFF
--- a/.github/workflows/e2e-k8s-workflow.yaml
+++ b/.github/workflows/e2e-k8s-workflow.yaml
@@ -7,6 +7,9 @@ on:
       skip_node_finalize:
         default: "false"
         type: string
+      thin_csi_sanity:
+        default: "false"
+        type: string
 
 jobs:
   e2e-k8s:
@@ -20,6 +23,7 @@ jobs:
       KUBERNETES_VERSION: ${{ matrix.kubernetes_versions }}
       TEST_SCHEDULER_MANIFEST: ${{ inputs.test_scheduler_manifest }}
       SKIP_NODE_FINALIZE: ${{ inputs.skip_node_finalize }}
+      TEST_THIN_DEVICECLASS: ${{ inputs.thin_csi_sanity }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -24,3 +24,9 @@ jobs:
     uses: ./.github/workflows/e2e-k8s-workflow.yaml
     with:
       skip_node_finalize: "true"
+  
+  thin-snapshot-csi:
+    uses: ./.github/workflows/e2e-k8s-workflow.yaml
+    with:
+      thin_csi_sanity: "true"
+

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -3,6 +3,7 @@ KUBERNETES_VERSION ?= 1.24.2
 TEST_SCHEDULER_MANIFEST ?= daemonset
 STORAGE_CAPACITY ?= false
 SKIP_NODE_FINALIZE ?= false
+TEST_THIN_DEVICECLASS ?= false
 
 ## Dependency versions
 MINIKUBE_VERSION := v1.26.0
@@ -32,6 +33,7 @@ ifeq ($(STORAGE_CAPACITY),true)
 HELM_VALUES_FILE := manifests/values/storage-capacity.yaml
 endif
 
+
 KIND_CONFIG="topolvm-cluster.yaml"
 MINIKUBE_FEATURE_GATES="ReadWriteOncePod=true"
 
@@ -42,6 +44,13 @@ HELM_SKIP_NODE_FINALIZE_FLAG := --set controller.nodeFinalize.skipped=true
 else
 HELM_SKIP_NODE_FINALIZE_FLAG :=
 endif
+
+ifeq ($(TEST_THIN_DEVICECLASS),false)
+GINKGO_SKIP_SNAPSHOT_CSI_TESTS := -skip='snapshot' -skip='CreateSnapshot' -skip='DeleteSnapshot' -skip='source volume'
+else
+GINKGO_SKIP_SNAPSHOT_CSI_TESTS :=
+endif
+
 
 SCHEDULER_CONFIG := scheduler-config-$(TEST_SCHEDULER_MANIFEST).yaml
 
@@ -165,7 +174,8 @@ test: create-cluster
 	STORAGE_CAPACITY=$(STORAGE_CAPACITY) \
 	SKIP_NODE_FINALIZE=$(SKIP_NODE_FINALIZE) \
 	GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn \
-	$(GINKGO) -skip='snapshot' -skip='CreateSnapshot' -skip='DeleteSnapshot' -skip='source volume' --failFast -v .
+	$(GINKGO) $(GINKGO_SKIP_SNAPSHOT_CSI_TESTS) --failFast -v .
+
 
 .PHONY: clean
 clean: stop-lvmd


### PR DESCRIPTION
This commit provides a way to configure the e2e tests to run csi snapshot
tests only for thin device classes.

Signed-off-by: N Balachandran <nibalach@redhat.com>