### PR TITLE
Make lvm commands independent of the environment

### DIFF
--- a/lvmd/command/lvm_json.go
+++ b/lvmd/command/lvm_json.go
@@ -191,8 +191,7 @@ func getLVMState() (vgs []vg, lvs []lv, _ error) {
 	// the column to 1 and then exclude it to remove.
 	args := []string{
 		"fullreport",
-		"--profile", "lvmdbusd",
-		"--config", "report {pvs_cols_full=\"pv_name\" segs_cols_full=\"lv_uuid\" pvsegs_cols_full=\"lv_uuid\" }",
+		"--config", "report {output_format=json pvs_cols_full=\"pv_name\" segs_cols_full=\"lv_uuid\" pvsegs_cols_full=\"lv_uuid\"} global {units=b suffix=0}",
 		"--configreport", "pv", "-o-pv_name",
 		"--configreport", "seg", "-o-lv_uuid",
 		"--configreport", "pvseg", "-o-lv_uuid",

--- a/lvmd/command/lvm_json_test.go
+++ b/lvmd/command/lvm_json_test.go
@@ -55,8 +55,7 @@ func TestLvmJSON(t *testing.T) {
 			  {}
 			]
 		  }
-		],
-		"log": []
+		]
 	  }
 	`
 	vgs, lvs, err := parseLVMJSON([]byte(goodJSON))


### PR DESCRIPTION
When `lvm fullreport` is used to specify a profile, it works on the
assumption that the profile exists in the environment. However, some
environments may not have a profile. Therefore, modify `lvm fullreport`
not to specify profile.

Signed-off-by: Yuma Ogami <yuma-ogami@cybozu.co.jp>