### PR TITLE
docs: fix incorrect flag description

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -99,7 +99,7 @@ only generic ephemeral volumes are used, these steps are not necessary.
 To remove a node and volumes/pods on the node from the cluster, follow these steps:
 
 1. Run `kubectl drain NODE --ignore-daemonsets=true`.
-    `--ignore-daemonsets=true` avoids `topolvm-node` deletion.
+    `--ignore-daemonsets=true` allows the command to succeed even if pods managed by daemonset exist (e.g. topolvm-node).
     If drain stacks due to PodDisruptionBudgets or something, try `--force` option.
 2. Run `kubectl delete nodes NODE`
 3. TopoLVM will remove Pods and PersistentVolumeClaims on the node.
@@ -109,8 +109,8 @@ To remove a node and volumes/pods on the node from the cluster, follow these ste
 
 To reboot a node without removing volumes, follow these steps:
 
-1. Run `kubectl drain NODE --ignore-daemonsets=true`
-   `--ignore-daemonsets=true` avoids `topolvm-node` deletion.
+1. Run `kubectl drain NODE --ignore-daemonsets=true`.
+   `--ignore-daemonsets=true` allows the command to succeed even if pods managed by daemonset exist (e.g. topolvm-node).
 2. Reboot the node.
 3. Run `kubectl uncordon NODE` after the node comes back online.
 4. After reboot, Pods will be rescheduled to the same node because PVCs remain intact.


### PR DESCRIPTION
Changed to explain that adding --ignore-daemonsets will allow pods to be
evicted. The explanation was the other way around.

Reported by nonylene at Slack.

Signed-off-by: ESASHIKA Kaoru <kaoru-esashika@cybozu.co.jp>