### PR TITLE
fix: rbac rule per release

### DIFF
--- a/charts/topolvm/templates/controller/clusterrolebindings.yaml
+++ b/charts/topolvm/templates/controller/clusterrolebindings.yaml
@@ -1,59 +1,61 @@
+{{- $rlsNamespace := .Release.Namespace -}}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Namespace }}:controller
+  name: {{ printf "%s-controller" $rlsNamespace }}
+  labels:
+    {{- include "topolvm.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ $rlsNamespace }}
+    name: {{ printf "%s-controller" $rlsNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ printf "%s-controller" $rlsNamespace }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ printf "%s-external-provisioner" $rlsNamespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
-    name: {{ template "topolvm.fullname" . }}-controller
+    name: {{ printf "%s-controller" $rlsNamespace }}
 roleRef:
-  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Namespace }}:controller
+  name: {{ printf "%s-external-provisioner" $rlsNamespace }}
+  apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: topolvm-csi-provisioner-role
+  name: {{ printf "%s-csi-resizer" $rlsNamespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
-    name: {{ template "topolvm.fullname" . }}-controller
+    name: {{ printf "%s-controller" $rlsNamespace }}
 roleRef:
   kind: ClusterRole
-  name: topolvm-external-provisioner-runner
+  name: {{ printf "%s-csi-resizer" $rlsNamespace }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: topolvm-csi-resizer-role
-  labels:
-    {{- include "topolvm.labels" . | nindent 4 }}
-subjects:
-  - kind: ServiceAccount
-    namespace: {{ .Release.Namespace }}
-    name: {{ template "topolvm.fullname" . }}-controller
-roleRef:
-  kind: ClusterRole
-  name: topolvm-external-resizer-runner
-  apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: topolvm-csi-snapshotter-role
+  name: {{ printf "%s-external-snapshotter" $rlsNamespace }}
   labels:
   {{- include "topolvm.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
-    name: {{ template "topolvm.fullname" . }}-controller
+    name: {{ printf "%s-controller" $rlsNamespace }}
 roleRef:
   kind: ClusterRole
-  name: topolvm-external-snapshotter-runner
+  name: {{ printf "%s-external-snapshotter" $rlsNamespace }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/topolvm/templates/controller/clusterroles.yaml
+++ b/charts/topolvm/templates/controller/clusterroles.yaml
@@ -1,7 +1,9 @@
+{{- $rlsNamespace := .Release.Namespace -}}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Namespace }}:controller
+  name: {{ printf "%s-controller" $rlsNamespace }}
   labels:
   {{- include "topolvm.labels" . | nindent 4 }}
 rules:
@@ -24,7 +26,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: topolvm-external-provisioner-runner
+  name: {{ printf "%s-external-provisioner" $rlsNamespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
 rules:
@@ -68,7 +70,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: topolvm-external-resizer-runner
+  name: {{ printf "%s-csi-resizer" $rlsNamespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
 rules:
@@ -96,7 +98,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: topolvm-external-snapshotter-runner
+  name: {{ printf "%s-external-snapshotter" $rlsNamespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
 rules:

--- a/charts/topolvm/templates/controller/rolebinding.yaml
+++ b/charts/topolvm/templates/controller/rolebinding.yaml
@@ -1,7 +1,9 @@
+{{- $rlsNamespace := .Release.Namespace -}}
+
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: leader-election
+  name: {{ printf "%s-leader-election" $rlsNamespace }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
@@ -11,13 +13,13 @@ subjects:
     name: {{ template "topolvm.fullname" . }}-controller
 roleRef:
   kind: Role
-  name: leader-election
+  name: {{ printf "%s-leader-election" $rlsNamespace }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-provisioner-role-cfg
+  name: {{ printf "%s-external-provisioner-cfg" $rlsNamespace }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
@@ -27,13 +29,13 @@ subjects:
     name: {{ template "topolvm.fullname" . }}-controller
 roleRef:
   kind: Role
-  name: external-provisioner-cfg
+  name: {{ printf "%s-external-provisioner-cfg" $rlsNamespace }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: csi-resizer-role-cfg
+  name: {{ printf "%s-external-resizer-cfg" $rlsNamespace }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
@@ -43,13 +45,13 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: external-resizer-cfg
+  name: {{ printf "%s-external-resizer-cfg" $rlsNamespace }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-snapshotter-leaderelection
+  name: {{ printf "%s-external-snapshotter-leaderelection" $rlsNamespace }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "topolvm.labels" . | nindent 4 }}
@@ -59,5 +61,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: external-snapshotter-leaderelection
+  name: {{ printf "%s-external-snapshotter-leaderelection" $rlsNamespace }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/topolvm/templates/controller/roles.yaml
+++ b/charts/topolvm/templates/controller/roles.yaml
@@ -1,7 +1,9 @@
+{{- $rlsNamespace := .Release.Namespace -}}
+
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: leader-election
+  name: {{ printf "%s-leader-election" $rlsNamespace }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
@@ -16,7 +18,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-provisioner-cfg
+  name: {{ printf "%s-external-provisioner-cfg" $rlsNamespace }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
@@ -45,7 +47,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-resizer-cfg
+  name: {{ printf "%s-external-resizer-cfg" $rlsNamespace }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
@@ -57,7 +59,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: external-snapshotter-leaderelection
+  name: {{ printf "%s-external-snapshotter-leaderelection" $rlsNamespace }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}

--- a/charts/topolvm/templates/controller/serviceaccount.yaml
+++ b/charts/topolvm/templates/controller/serviceaccount.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "topolvm.fullname" . }}-controller
+  name: {{ printf "%s-controller" .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "topolvm.labels" . | nindent 4 }}
+  labels: {{ - include "topolvm.labels" . | nindent 4 }}

--- a/charts/topolvm/templates/node/clusterrole.yaml
+++ b/charts/topolvm/templates/node/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Namespace }}:node
+  name: {{ printf "%s-node" (include "topolvm.fullname" .) }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
 rules:

--- a/charts/topolvm/templates/node/clusterrolebinding.yaml
+++ b/charts/topolvm/templates/node/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Namespace }}:node
+  name: {{ printf "%s-node" (include "topolvm.fullname" .) }}
   labels:
     {{- include "topolvm.labels" . | nindent 4 }}
 subjects:
@@ -11,4 +11,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Namespace }}:node
+  name: {{ printf "%s-node" (include "topolvm.fullname" .) }}


### PR DESCRIPTION
Signed-off-by: fengxsong <fengxsong@outlook.com>

Rename RBAC rules to avoid conflicts when trying to deploy more than one topolvm instances in single cluster.