### PR TITLE
add a command to list the relevant PRs in the release procedure.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,6 +63,12 @@ Bump version
     $ sed -r -i "s/checkout v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/checkout v${VERSION}/g" example/README.md
     ```
 4. Edit `CHANGELOG.md` for the new version ([example][]).
+   The candidate of relevant PRs can be obtained by the following command.
+   ```
+   git log --merges --format="%s%x00%b" $(git tag | grep "^v" | sort -V -r | head -n 1)..main | sed -E 's|^Merge pull request #([0-9]*)[^\x0]*\x0(.*)|- \2 ([#\1](https://github.com/topolvm/topolvm/pull/\1))|' | tac
+   ```
+   Please remove PRs which contain changes only to the helm chart.
+
 5. Commit the change and create a pull request:
 
     ```console
@@ -121,6 +127,12 @@ This will prevent the TopoLVM version from going up just by modifying the Helm C
     ```
 
 4. Edit `charts/topolvm/CHANGELOG.md` for the new version ([example][]).
+   The candidate of relevant PRs can be obtained by the following command.
+   ```
+   git log --merges --format="%s%x00%b" $(git tag | grep "^topolvm-chart-v" | sort -V -r | head -n 1)..main | sed -E 's|^Merge pull request #([0-9]*)[^\x0]*\x0(.*)|- \2 ([#\1](https://github.com/topolvm/topolvm/pull/\1))|' | tac
+   ```
+   Please select PRs which contain changes to the helm chart.
+
 5. Commit the change and create a pull request:
 
     ```console


### PR DESCRIPTION
In the release procedure, listing the relevant PRs are boring task.
In this PR, I added a command to obtain the PR list.

The output is in the markdown format, and each line contains the link to the related PR.
An example output is as follows.
```
- Bump chart version to 10.0.0 ([#588](https://github.com/topolvm/topolvm/pull/588))
```

This is interpreted as follows.

- Bump chart version to 10.0.0 ([#588](https://github.com/topolvm/topolvm/pull/588))



Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>