### PR TITLE
Added arm64 images

### DIFF
--- a/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
@@ -26,6 +26,12 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64/v8
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: cache go dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/e2e-k8s-workflow.yaml
+++ b/.github/workflows/e2e-k8s-workflow.yaml
@@ -29,6 +29,12 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64/v8
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: cache go dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,10 +13,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64/v8
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: cache go dependencies
@@ -33,7 +29,7 @@ jobs:
       - run: make test
       - run: make groupname-test
       - run: sudo -E env PATH=${PATH} go test -count=1 -race -v ./lvmd ./driver ./filesystem
-      - run: make push
+      - run: make multi-platform-images
 
   example:
     name: "example"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
       - run: make test
       - run: make groupname-test
       - run: sudo -E env PATH=${PATH} go test -count=1 -race -v ./lvmd ./driver ./filesystem
-      - run: make image
+      - run: make push
 
   example:
     name: "example"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,12 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64/v8
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: cache go dependencies
         uses: actions/cache@v3
         with:
@@ -46,6 +52,12 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64/v8
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: cache go dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,12 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "1.18"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64/v8
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: cache go dependencies
         uses: actions/cache@v3
         with:
@@ -40,13 +46,12 @@ jobs:
       - run: make setup
       - run: make build/lvmd TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
       - run: tar czf lvmd-${{ steps.check_version.outputs.version }}.tar.gz -C ./build lvmd
-      - run: make image TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
-      - run: make tag push IMAGE_TAG=${{ steps.check_version.outputs.version }}
+      - run: make push TOPOLVM_VERSION=${{ steps.check_version.outputs.version }} IMAGE_TAG=${{ steps.check_version.outputs.version }}
       - name: "Push branch tag"
         if: ${{ steps.check_version.outputs.prerelease == 'false' }}
         run: |
           BRANCH=$(echo ${{ steps.check_version.outputs.version }} | cut -d "." -f 1-2)
-          make tag push IMAGE_TAG=$BRANCH
+          make tag IMAGE_TAG=$BRANCH ORIGINAL_IMAGE_TAG=${{ steps.check_version.outputs.version }}
       - name: "Create Release"
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
       - run: make setup
       - run: make build/lvmd TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
       - run: tar czf lvmd-${{ steps.check_version.outputs.version }}.tar.gz -C ./build lvmd
-      - run: make push TOPOLVM_VERSION=${{ steps.check_version.outputs.version }} IMAGE_TAG=${{ steps.check_version.outputs.version }}
+      - run: make push PUSH_IMAGES=true TOPOLVM_VERSION=${{ steps.check_version.outputs.version }} IMAGE_TAG=${{ steps.check_version.outputs.version }}
       - name: "Push branch tag"
         if: ${{ steps.check_version.outputs.prerelease == 'false' }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
       - run: make setup
       - run: make build/lvmd TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
       - run: tar czf lvmd-${{ steps.check_version.outputs.version }}.tar.gz -C ./build lvmd
-      - run: make push PUSH_IMAGES=true TOPOLVM_VERSION=${{ steps.check_version.outputs.version }} IMAGE_TAG=${{ steps.check_version.outputs.version }}
+      - run: make multi-platform-images PUSH=true TOPOLVM_VERSION=${{ steps.check_version.outputs.version }} IMAGE_TAG=${{ steps.check_version.outputs.version }}
       - name: "Push branch tag"
         if: ${{ steps.check_version.outputs.prerelease == 'false' }}
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 # Build Container
-FROM golang:1.18-buster AS build-env
+FROM --platform=$BUILDPLATFORM golang:1.18-buster AS build-env
 
 # Get argment
 ARG TOPOLVM_VERSION
+ARG TARGETARCH
 
 COPY . /workdir
 WORKDIR /workdir
 
 RUN touch csi/*.go lvmd/proto/*.go \
-    && make build-topolvm TOPOLVM_VERSION=${TOPOLVM_VERSION}
+    && make build-topolvm TOPOLVM_VERSION=${TOPOLVM_VERSION} GOARCH=${TARGETARCH}
 
 # TopoLVM container
-FROM ubuntu:18.04
+FROM --platform=$TARGETPLATFORM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/Dockerfile.with-sidecar
+++ b/Dockerfile.with-sidecar
@@ -1,16 +1,35 @@
-ARG IMAGE_PREFIX
+FROM --platform=$BUILDPLATFORM golang:1.18-buster AS build-env
 
-# Build Container
-FROM golang:1.18-buster AS build-env
+# Get argment
+ARG TOPOLVM_VERSION
+ARG TARGETARCH
 
 COPY . /workdir
 WORKDIR /workdir
 
-RUN make csi-sidecars
+RUN touch csi/*.go lvmd/proto/*.go \
+    && make build-topolvm TOPOLVM_VERSION=${TOPOLVM_VERSION} GOARCH=${TARGETARCH} \
+    && make csi-sidecars GOARCH=${TARGETARCH}
 
 # TopoLVM container
-FROM ${IMAGE_PREFIX}topolvm:devel
+FROM --platform=$TARGETPLATFORM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends \
+        btrfs-progs \
+        file \
+        xfsprogs \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build-env /workdir/build/hypertopolvm /hypertopolvm
+
+RUN ln -s hypertopolvm /lvmd \
+    && ln -s hypertopolvm /topolvm-scheduler \
+    && ln -s hypertopolvm /topolvm-node \
+    && ln -s hypertopolvm /topolvm-controller
+
+COPY --from=build-env /workdir/LICENSE /LICENSE
 COPY --from=build-env /workdir/build/csi-provisioner /csi-provisioner
 COPY --from=build-env /workdir/build/csi-node-driver-registrar /csi-node-driver-registrar
 COPY --from=build-env /workdir/build/csi-resizer /csi-resizer

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ PROTOC_GEN_GO_VERSION := $(shell awk '/google.golang.org\/protobuf/ {print subst
 PROTOC_GEN_DOC_VERSION := $(shell awk '/github.com\/pseudomuto\/protoc-gen-doc/ {print substr($$2, 2)}' go.mod)
 PROTOC_GEN_GO_GRPC_VERSION := $(shell awk '/google.golang.org\/grpc\/cmd\/protoc-gen-go-grpc/ {print substr($$2, 2)}' go.mod)
 
-PUSH_IMAGES ?= false
+PUSH ?= false
 BUILDX_PUSH_OPTIONS := "-o type=tar,dest=build/topolvm.tar"
-ifeq ($(PUSH_IMAGES),true)
+ifeq ($(PUSH),true)
 BUILDX_PUSH_OPTIONS := --push
 endif
 
@@ -198,8 +198,8 @@ image: ## Build topolvm images.
 create-docker-container: ## Create docker-container.
 	docker buildx create --use
 
-.PHONY: push
-push: ## Push topolvm images.
+.PHONY: multiplatform-images
+multi-platform-images: ## Push multi-platform topolvm images.
 	mkdir -p build
 	docker buildx build --no-cache $(BUILDX_PUSH_OPTIONS) \
 		--platform linux/amd64,linux/arm64/v8 \

--- a/example/Makefile
+++ b/example/Makefile
@@ -38,7 +38,7 @@ $(KUBECTL):
 
 build/topolvm.img: $(GO_FILES)
 	$(MAKE) -C .. image IMAGE_PREFIX=ghcr.io/topolvm/
-	$(MAKE) -C .. tag IMAGE_PREFIX=ghcr.io/topolvm/ IMAGE_TAG=$(TOPOLVM_VERSION)
+	docker tag ghcr.io/topolvm/topolvm-with-sidecar:devel ghcr.io/topolvm/topolvm-with-sidecar:$(TOPOLVM_VERSION)
 	docker save -o $@ ghcr.io/topolvm/topolvm-with-sidecar:$(TOPOLVM_VERSION)
 
 .PHONY: run


### PR DESCRIPTION
This PR makes topolvm support building and pushing multi-architecture images.

- #378 



### Make install docker-buildx and emulators in the local environment

```
$ make setup
```

### Create your docker-container if you needed

```
$ create-docker-container
```

### Test multi-arch build in the local environment

```
$ make push
```

### Build multi-arch images and push images

```
$ make push PUSH_IMAGES=true
```
