### PR TITLE
improve livenessProbe get csi-node-driver-registrar healthz by httpGet

### DIFF
--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -98,13 +98,16 @@ spec:
             - /csi-node-driver-registrar
             - --csi-address={{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/csi-topolvm.sock
             - --kubelet-registration-path={{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/csi-topolvm.sock
+            - --health-port=9809
+          ports:
+            - containerPort: 9809
+              name: healthz
           livenessProbe:
-            exec:
-              command:
-              - /csi-node-driver-registrar
-              - --kubelet-registration-path={{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/csi-topolvm.sock
-              - --mode=kubelet-registration-probe
-            initialDelaySeconds: 3
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
           lifecycle:
             preStop:
               exec:

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -98,7 +98,7 @@ spec:
             - /csi-node-driver-registrar
             - --csi-address={{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/csi-topolvm.sock
             - --kubelet-registration-path={{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/csi-topolvm.sock
-            - --health-port=9809
+            - --http-endpoint=:9809
           ports:
             - containerPort: 9809
               name: healthz
@@ -106,8 +106,9 @@ spec:
             httpGet:
               path: /healthz
               port: healthz
-            initialDelaySeconds: 5
-            timeoutSeconds: 5
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
Use health-check-with-an-exec-probe vs use health-check-with-an-http-get
https://github.com/kubernetes-csi/node-driver-registrar/tree/release-2.5#health-check-with-an-exec-probe
when use health-check-with-an-exec-probe, csi-node-driver-registrar lost connection,health-check-with-an-exec-probe cannot determine whether the socket exists. but when use http-get, it can determine whether the socket exists. code is different.
health-check-with-an-exec-probe:
https://github.com/kubernetes-csi/node-driver-registrar/blob/release-2.5/cmd/csi-node-driver-registrar/main.go#L152
health-check-with-an-http-get:
https://github.com/kubernetes-csi/node-driver-registrar/blob/release-2.5/cmd/csi-node-driver-registrar/node_register.go#L99
when node-driver-registrar is running , exec it remove /registration/{{ include "topolvm.pluginName" . }}-reg.sock. You'll find out