### PR TITLE
Allow multiple device-classes with same VG

### DIFF
--- a/lvmd/device_class_manager_test.go
+++ b/lvmd/device_class_manager_test.go
@@ -262,7 +262,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			valid: true,
 		},
 		{
 			deviceClasses: []*DeviceClass{
@@ -435,15 +435,18 @@ func TestDeviceClassManager(t *testing.T) {
 		t.Error("'unknown' should not be found")
 	}
 
-	dc, err = manager.FindDeviceClassByVGName("hdd2-vg")
+	dcs, err := manager.FindDeviceClassesByVGName("hdd2-vg")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dc.GetSpare() != spare100gb<<30 {
+	if len(dcs) == 0 {
+		t.Error("No device-class was found for hdd2-vg")
+	}
+	if dcs[0].GetSpare() != spare100gb<<30 {
 		t.Error("hdd2's spare should be 100GB")
 	}
 
-	_, err = manager.FindDeviceClassByVGName("unknown")
+	_, err = manager.FindDeviceClassesByVGName("unknown")
 	if err != ErrNotFound {
 		t.Error("'unknown' should not be found")
 	}

--- a/lvmd/vgservice.go
+++ b/lvmd/vgservice.go
@@ -189,27 +189,29 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 			})
 		}
 
-		dc, err := s.dcManager.FindDeviceClassByVGName(vg.Name())
+		dcs, err := s.dcManager.FindDeviceClassesByVGName(vg.Name())
 		if err == ErrNotFound {
 			continue
 		}
 
-		spare := dc.GetSpare()
-		if vgFree < spare {
-			vgFree = 0
-		} else {
-			vgFree -= spare
-		}
+		for _, dc := range dcs {
+			spare := dc.GetSpare()
+			if vgFree < spare {
+				vgFree = 0
+			} else {
+				vgFree -= spare
+			}
 
-		if dc.Default {
-			res.FreeBytes = vgFree
-		}
+			if dc.Default {
+				res.FreeBytes = vgFree
+			}
 
-		res.Items = append(res.Items, &proto.WatchItem{
-			DeviceClass: dc.Name,
-			FreeBytes:   vgFree,
-			SizeBytes:   vgSize,
-		})
+			res.Items = append(res.Items, &proto.WatchItem{
+				DeviceClass: dc.Name,
+				FreeBytes:   vgFree,
+				SizeBytes:   vgSize,
+			})
+		}
 	}
 	return server.Send(res)
 }


### PR DESCRIPTION
Device-classes with repeated VG are now accepted, so you can create classes with different lv raid types (raid0, raid1) to use same VG.

Example:

```yaml
device-classes:
  - default: false
    name: "ssd-raid0"
    spare-gb: 10
    volume-group: "vg0"
    lvcreate-options: [ "--type=raid0" ]

  - default: true
    name: "ssd-raid1"
    spare-gb: 10
    volume-group: "vg0"
    lvcreate-options: [ "--type=raid1" ]
```