### PR TITLE
Refactor: use controllerutil to operate finalizers

### DIFF
--- a/e2e/cleanup_test.go
+++ b/e2e/cleanup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/topolvm/topolvm/controllers"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const cleanupTest = "cleanup-test"
@@ -47,15 +48,9 @@ func testCleanup() {
 				return err
 			}
 			for _, node := range nodes.Items {
-				topolvmFinalize := false
-				for _, fn := range node.Finalizers {
-					if fn == topolvm.GetNodeFinalizer() {
-						topolvmFinalize = true
-					}
-				}
 				// Even if node finalize is skipped, the finalizer is still present on the node
 				// The finalizer is added by the metrics-exporter runner from topolvm-node
-				if !topolvmFinalize {
+				if !controllerutil.ContainsFinalizer(&node, topolvm.GetNodeFinalizer()) {
 					return errors.New("topolvm finalizer is not attached")
 				}
 			}

--- a/hook/mutate_persistentvolumeclaim.go
+++ b/hook/mutate_persistentvolumeclaim.go
@@ -70,11 +70,10 @@ func (m *persistentVolumeClaimMutator) Handle(ctx context.Context, req admission
 		return admission.Allowed("no request for TopoLVM")
 	}
 
-	if controllerutil.ContainsFinalizer(pvc, topolvm.PVCFinalizer) {
+	if !controllerutil.AddFinalizer(pvc, topolvm.PVCFinalizer) {
 		return admission.Allowed("already added finalizer")
 	}
 
-	pvc.Finalizers = append(pvc.Finalizers, topolvm.PVCFinalizer)
 	marshaled, err := json.Marshal(pvc)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/runners/metrics_exporter.go
+++ b/runners/metrics_exporter.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -218,16 +219,7 @@ func (m *metricsExporter) updateNode(ctx context.Context, wc proto.VGService_Wat
 
 		node2 := node.DeepCopy()
 
-		var hasFinalizer bool
-		for _, fin := range node.Finalizers {
-			if fin == topolvm.GetNodeFinalizer() {
-				hasFinalizer = true
-				break
-			}
-		}
-		if !hasFinalizer {
-			node2.Finalizers = append(node2.Finalizers, topolvm.GetNodeFinalizer())
-		}
+		controllerutil.AddFinalizer(node2, topolvm.GetNodeFinalizer())
 
 		node2.Annotations[topolvm.GetCapacityKeyPrefix()+topolvm.DefaultDeviceClassAnnotationName] = strconv.FormatUint(res.FreeBytes, 10)
 		for _, item := range res.Items {


### PR DESCRIPTION
We operated finalizers with hand written logic, but controllerutil provides such that.