### PR TITLE
ci: reuse topolvm.img in e2e test matrix

### DIFF
--- a/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
@@ -78,7 +78,6 @@ jobs:
           CRICTL_VERSION="v1.25.0"
           curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz --output crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
           sudo tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
-      - run: make -C e2e setup
       - run: make -C e2e daemonset-lvmd/create-vg
       - run: make -C e2e daemonset-lvmd/setup-minikube
       - run: make -C e2e daemonset-lvmd/launch-minikube

--- a/.github/workflows/e2e-k8s-workflow.yaml
+++ b/.github/workflows/e2e-k8s-workflow.yaml
@@ -40,9 +40,11 @@ jobs:
             go-
       - uses: actions/cache/restore@v3
         with:
-          path: e2e/topolvm.img
-          key: e2e-topolvm-img-${{ github.sha }}
+          path: |
+            bin
+            e2e/bin
+            e2e/topolvm.img
+          key: e2e-cache-${{ github.sha }}
       - run: touch e2e/topolvm.img # update timestamp not to rebuild image
-      - run: make -C e2e setup
       - run: make -C e2e start-lvmd
       - run: make -C e2e test

--- a/.github/workflows/e2e-k8s-workflow.yaml
+++ b/.github/workflows/e2e-k8s-workflow.yaml
@@ -29,8 +29,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: "go.mod"
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: cache go dependencies
         uses: actions/cache@v3
         with:
@@ -40,14 +38,11 @@ jobs:
           key: go-${{ hashFiles('go.sum', 'Makefile') }}
           restore-keys: |
             go-
-      - name: cache e2e sidecar binaries
-        uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         with:
-          path: |
-            e2e/tmpbin
-          key: e2e-sidecars-${{ hashFiles('csi-sidecars.mk') }}
-          restore-keys: |
-            e2e-sidecars-
+          path: e2e/topolvm.img
+          key: e2e-topolvm-img-${{ github.sha }}
+      - run: touch e2e/topolvm.img # update timestamp not to rebuild image
       - run: make -C e2e setup
       - run: make -C e2e start-lvmd
       - run: make -C e2e test

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -12,20 +12,56 @@ on:
       - "main"
 
 jobs:
+  build:
+    runs-on: "ubuntu-20.04"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: cache go dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ hashFiles('go.sum', 'Makefile') }}
+          restore-keys: |
+            go-
+      - name: cache e2e sidecar binaries
+        uses: actions/cache@v3
+        with:
+          path: |
+            e2e/tmpbin
+          key: e2e-sidecars-${{ hashFiles('csi-sidecars.mk') }}
+          restore-keys: |
+            e2e-sidecars-
+      - run: make -C e2e topolvm.img
+      - uses: actions/cache/save@v3
+        with:
+          path: e2e/topolvm.img
+          key: e2e-topolvm-img-${{ github.sha }}
+
   default:
+    needs: build
     uses: ./.github/workflows/e2e-k8s-workflow.yaml
 
   scheduler-manifest:
+    needs: build
     uses: ./.github/workflows/e2e-k8s-workflow.yaml
     with:
       test_scheduler_manifest: "deployment"
 
   thin-snapshot-csi:
+    needs: build
     uses: ./.github/workflows/e2e-k8s-workflow.yaml
     with:
       thin_csi_sanity: "true"
 
   use-legacy:
+    needs: build
     uses: ./.github/workflows/e2e-k8s-workflow.yaml
     with:
       use_legacy: "true"

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -38,11 +38,15 @@ jobs:
           key: e2e-sidecars-${{ hashFiles('csi-sidecars.mk') }}
           restore-keys: |
             e2e-sidecars-
+      - run: make -C e2e setup
       - run: make -C e2e topolvm.img
       - uses: actions/cache/save@v3
         with:
-          path: e2e/topolvm.img
-          key: e2e-topolvm-img-${{ github.sha }}
+          path: |
+            bin
+            e2e/bin
+            e2e/topolvm.img
+          key: e2e-cache-${{ github.sha }}
 
   default:
     needs: build

--- a/Makefile
+++ b/Makefile
@@ -254,19 +254,30 @@ ct-lint: ## Lint and validate a chart.
 
 ##@ Setup
 
+$(BINDIR):
+	mkdir -p $@
+
 .PHONY: install-kind
-install-kind:
+install-kind: | $(BINDIR)
 	GOBIN=$(BINDIR) go install sigs.k8s.io/kind@$(KIND_VERSION)
 
 .PHONY: install-container-structure-test
-install-container-structure-test:
-	mkdir -p $(BINDIR)
+install-container-structure-test: | $(BINDIR)
 	$(CURL) -o $(CONTAINER_STRUCTURE_TEST) \
 		https://storage.googleapis.com/container-structure-test/v$(CONTAINER_STRUCTURE_TEST_VERSION)/container-structure-test-linux-amd64 \
     && chmod +x $(CONTAINER_STRUCTURE_TEST)
 
+.PHONY: install-helm
+install-helm: | $(BINDIR)
+	$(CURL) https://get.helm.sh/helm-v$(HELM_VERSION)-linux-amd64.tar.gz \
+		| tar xvz -C $(BINDIR) --strip-components 1 linux-amd64/helm
+
+.PHONY: install-helm-docs
+install-helm-docs: | $(BINDIR)
+	GOBIN=$(BINDIR) go install github.com/norwoodj/helm-docs/cmd/helm-docs@v$(HELM_DOCS_VERSION)
+
 .PHONY: tools
-tools: install-kind install-container-structure-test ## Install development tools.
+tools: install-kind install-container-structure-test install-helm install-helm-docs | $(BINDIR) ## Install development tools.
 	GOBIN=$(BINDIR) go install honnef.co/go/tools/cmd/staticcheck@latest
 	# Follow the official documentation to install the `latest` version, because explicitly specifying the version will get an error.
 	GOBIN=$(BINDIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
@@ -279,9 +290,6 @@ tools: install-kind install-container-structure-test ## Install development tool
 	GOBIN=$(BINDIR) go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v$(PROTOC_GEN_GO_GRPC_VERSION)
 	GOBIN=$(BINDIR) go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v$(PROTOC_GEN_DOC_VERSION)
 
-	GOBIN=$(BINDIR) go install github.com/norwoodj/helm-docs/cmd/helm-docs@v$(HELM_DOCS_VERSION)
-	$(CURL) https://get.helm.sh/helm-v$(HELM_VERSION)-linux-amd64.tar.gz \
-		| tar xvz -C $(BINDIR) --strip-components 1 linux-amd64/helm
 	$(CURL) https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -o $(BINDIR)/yq \
 		&& chmod +x $(BINDIR)/yq
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ CHART_TESTING_VERSION=3.7.1
 YQ_VERSION=4.18.1
 BUILDX_VERSION=0.9.1
 CONTAINER_STRUCTURE_TEST_VERSION=1.14.0
-GINKGO_VERSION := $(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print substr($$2, 2)}' go.mod)
 
 SUDO := sudo
 CURL := curl -sSLf
@@ -279,8 +278,6 @@ tools: install-kind install-container-structure-test ## Install development tool
 	GOBIN=$(BINDIR) go install google.golang.org/protobuf/cmd/protoc-gen-go@v$(PROTOC_GEN_GO_VERSION)
 	GOBIN=$(BINDIR) go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v$(PROTOC_GEN_GO_GRPC_VERSION)
 	GOBIN=$(BINDIR) go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v$(PROTOC_GEN_DOC_VERSION)
-
-	GOBIN=$(BINDIR) go install github.com/onsi/ginkgo/v2/ginkgo@v$(GINKGO_VERSION)
 
 	GOBIN=$(BINDIR) go install github.com/norwoodj/helm-docs/cmd/helm-docs@v$(HELM_DOCS_VERSION)
 	$(CURL) https://get.helm.sh/helm-v$(HELM_VERSION)-linux-amd64.tar.gz \

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -16,7 +16,7 @@ SUDO := sudo
 CURL := curl -sSLf
 KIND_CLUSTER_NAME := topolvm-e2e
 KIND := ../bin/kind
-KUBECTL := $(BINDIR)/kubectl
+KUBECTL := $(BINDIR)/kubectl-$(KUBERNETES_VERSION)
 HELM := ../bin/helm
 GINKGO := $(BINDIR)/ginkgo-$(GINKGO_VERSION)
 
@@ -73,23 +73,23 @@ topolvm.img: $(GO_FILES)
 	sed -e "s|@DEPLOYMENT_SCHEDULER_HOST@|topolvm-e2e-worker|" $< > $@
 
 .PHONY: prepare-namespace
-prepare-namespace:
+prepare-namespace: $(KUBECTL)
 	$(KUBECTL) create namespace topolvm-system
 	$(KUBECTL) label namespace topolvm-system $(DOMAIN_NAME)/webhook=ignore
 	$(KUBECTL) label namespace kube-system $(DOMAIN_NAME)/webhook=ignore
 
 .PHONY: apply-certmanager-crds
-apply-certmanager-crds:
+apply-certmanager-crds: $(KUBECTL)
 	$(KUBECTL) apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.crds.yaml
 
 .PHONY: launch-kind
-launch-kind: /tmp/topolvm/scheduler/scheduler-config.yaml
+launch-kind: /tmp/topolvm/scheduler/scheduler-config.yaml $(KIND)
 	$(SUDO) rm -rf /tmp/topolvm/controller /tmp/topolvm/worker*
 	sed -e "s|@KUBERNETES_VERSION@|$(KUBERNETES_VERSION)|" $(KIND_CONFIG) > /tmp/$(KIND_CONFIG)
 	$(KIND) create cluster --name=$(KIND_CLUSTER_NAME) --config /tmp/$(KIND_CONFIG) --image $(KIND_NODE_IMAGE)
 
 .PHONY: shutdown-kind
-shutdown-kind:
+shutdown-kind: $(KIND)
 	$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME) || true
 	sleep 2
 	for d in $$($(SUDO) find /tmp/topolvm -type d); do \
@@ -175,7 +175,7 @@ stop-lvmd:
 	done
 
 .PHONY: create-cluster
-create-cluster: topolvm.img
+create-cluster: topolvm.img $(HELM) $(KIND) $(KUBECTL)
 	$(MAKE) shutdown-kind
 	$(MAKE) launch-kind
 	$(MAKE) apply-certmanager-crds
@@ -190,7 +190,7 @@ create-cluster: topolvm.img
 	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system certificate/topolvm-mutatingwebhook
 
 .PHONY: prepare-test
-prepare-test:
+prepare-test: $(KUBECTL)
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$(EXTERNAL_SNAPSHOTTER_VERSION)/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$(EXTERNAL_SNAPSHOTTER_VERSION)/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$(EXTERNAL_SNAPSHOTTER_VERSION)/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
@@ -204,7 +204,7 @@ run-test: $(GINKGO)
 	$(SUDO) -E env \
 	PATH=${PATH} \
 	E2ETEST=1 \
-	BINDIR=$(BINDIR) \
+	KUBECTL=$(KUBECTL) \
 	STORAGE_CAPACITY=$(STORAGE_CAPACITY) \
 	$(GINKGO) $(GINKGO_SKIP_SNAPSHOT_CSI_TESTS) --fail-fast -v $(GINKGO_FLAGS) .
 
@@ -222,16 +222,29 @@ clean: stop-lvmd
 		tmpbin/ \
 		/tmp/topolvm/scheduler/scheduler-config.yaml
 
-$(GINKGO):
+.PHONY: setup
+setup:
+	$(MAKE) $(GINKGO)
+	$(MAKE) $(HELM)
+	$(MAKE) $(KIND)
+	$(MAKE) $(KUBECTL)
+
+$(BINDIR):
+	mkdir -p $@
+
+$(GINKGO): | $(BINDIR)
 	GOBIN=$(BINDIR) go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
 	mv $(BINDIR)/ginkgo $@
 
-.PHONY: setup
-setup:
-	cd ..; $(MAKE) setup
-	mkdir -p $(BINDIR)
-	$(CURL) -o $(BINDIR)/kubectl https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl
-	chmod a+x $(BINDIR)/kubectl
+$(HELM):
+	$(MAKE) -C .. install-helm
+
+$(KIND):
+	$(MAKE) -C .. install-kind
+
+$(KUBECTL): | $(BINDIR)
+	$(CURL) -o $@ https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl
+	chmod a+x $@
 
 .PHONY: daemonset-lvmd/create-vg
 daemonset-lvmd/create-vg:
@@ -308,7 +321,7 @@ daemonset-lvmd/delete-minikube:
 	$(SUDO) -E $(BINDIR)/minikube delete || true
 
 .PHONY: daemonset-lvmd/test
-daemonset-lvmd/test: topolvm.img $(GINKGO)
+daemonset-lvmd/test: topolvm.img $(GINKGO) $(HELM) $(KUBECTL)
 	$(MAKE) apply-certmanager-crds
 	$(MAKE) prepare-namespace
 	$(HELM) repo add jetstack https://charts.jetstack.io
@@ -327,7 +340,7 @@ daemonset-lvmd/test: topolvm.img $(GINKGO)
 	$(SUDO) -E env \
 	PATH=${PATH} \
 	E2ETEST=1 \
-	BINDIR=$(BINDIR) \
+	KUBECTL=$(KUBECTL) \
 	STORAGE_CAPACITY=$(STORAGE_CAPACITY) \
 	DAEMONSET_LVMD=true \
 	$(GINKGO) -skip='snapshot' -skip='CreateSnapshot' -skip='DeleteSnapshot'  -skip='source volume' --fail-fast -v .

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -9,6 +9,7 @@ USE_LEGACY ?= ""
 ## Dependency versions
 MINIKUBE_VERSION := v1.28.0
 CERT_MANAGER_VERSION := v1.7.0
+GINKGO_VERSION := $(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' ../go.mod)
 
 BINDIR := $(shell pwd)/bin
 SUDO := sudo
@@ -17,7 +18,7 @@ KIND_CLUSTER_NAME := topolvm-e2e
 KIND := ../bin/kind
 KUBECTL := $(BINDIR)/kubectl
 HELM := ../bin/helm
-GINKGO := ../bin/ginkgo
+GINKGO := $(BINDIR)/ginkgo-$(GINKGO_VERSION)
 
 MINIKUBE_HOME = $(BINDIR)
 export MINIKUBE_HOME
@@ -199,7 +200,7 @@ prepare-test:
 
 .PHONY: run-test
 run-test: GINKGO_FLAGS =
-run-test:
+run-test: $(GINKGO)
 	$(SUDO) -E env \
 	PATH=${PATH} \
 	E2ETEST=1 \
@@ -220,6 +221,10 @@ clean: stop-lvmd
 		build/ \
 		tmpbin/ \
 		/tmp/topolvm/scheduler/scheduler-config.yaml
+
+$(GINKGO):
+	GOBIN=$(BINDIR) go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+	mv $(BINDIR)/ginkgo $@
 
 .PHONY: setup
 setup:
@@ -303,7 +308,7 @@ daemonset-lvmd/delete-minikube:
 	$(SUDO) -E $(BINDIR)/minikube delete || true
 
 .PHONY: daemonset-lvmd/test
-daemonset-lvmd/test: topolvm.img
+daemonset-lvmd/test: topolvm.img $(GINKGO)
 	$(MAKE) apply-certmanager-crds
 	$(MAKE) prepare-namespace
 	$(HELM) repo add jetstack https://charts.jetstack.io

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -11,7 +11,6 @@ Setup environment
 1. Prepare Ubuntu machine.
 2. [Install Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-using-the-repository).
 3. Add yourself to `docker` group.  e.g. `sudo adduser $USER docker`
-4. Run `make setup`.
 
 How to run tests
 ----------------

--- a/e2e/helper_test.go
+++ b/e2e/helper_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -40,11 +39,11 @@ func execAtLocal(cmd string, input []byte, args ...string) ([]byte, []byte, erro
 }
 
 func kubectl(args ...string) (stdout []byte, stderr []byte, err error) {
-	return execAtLocal(filepath.Join(binDir, "kubectl"), nil, args...)
+	return execAtLocal(kubectlPath, nil, args...)
 }
 
 func kubectlWithInput(input []byte, args ...string) (stdout []byte, stderr []byte, err error) {
-	return execAtLocal(filepath.Join(binDir, "kubectl"), input, args...)
+	return execAtLocal(kubectlPath, input, args...)
 }
 
 func containString(s []string, target string) bool {

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -16,7 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var binDir string
+var kubectlPath string
 var skipMessageForStorageCapacity string = "skip because current environment is storage capacity"
 
 func TestMtest(t *testing.T) {
@@ -99,10 +99,10 @@ func getDaemonsetLvmdNodeName() string {
 var pausePodYAML []byte
 
 var _ = BeforeSuite(func() {
-	By("Getting the directory path which contains some binaries")
-	binDir = os.Getenv("BINDIR")
-	Expect(binDir).ShouldNot(BeEmpty())
-	fmt.Println("This test uses the binaries under " + binDir)
+	By("Getting kubectl binary")
+	kubectlPath = os.Getenv("KUBECTL")
+	Expect(kubectlPath).ShouldNot(BeEmpty())
+	fmt.Println("This test uses a kubectl at " + kubectlPath)
 
 	if !isDaemonsetLvmdEnvSet() {
 		By("Waiting for kindnet to get ready")


### PR DESCRIPTION
This PR changes to cache topolvm.img and depedency tools in e2e tests. See commit messages for details.