### PR TITLE
Minor format & typo fixes

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -99,7 +99,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | controller.prometheus.podMonitor.scrapeTimeout | string | `""` | Scrape timeout. If not set, the Prometheus default scrape timeout is used. |
 | controller.replicaCount | int | `2` | Number of replicas for CSI controller service. |
 | controller.securityContext.enabled | bool | `true` | Enable securityContext. |
-| controller.storageCapacityTracking.enabled | bool | `false` | Enable Storage Capacity Tracking for csi-provisoner. |
+| controller.storageCapacityTracking.enabled | bool | `false` | Enable Storage Capacity Tracking for csi-provisioner. |
 | controller.terminationGracePeriodSeconds | int | `nil` | Specify terminationGracePeriodSeconds. |
 | controller.tolerations | list | `[]` | Specify tolerations. # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | controller.updateStrategy | object | `{}` | Specify updateStrategy. |
@@ -180,7 +180,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | securityContext.runAsGroup | int | `10000` | Specify runAsGroup. |
 | securityContext.runAsUser | int | `10000` | Specify runAsUser. |
 | snapshot.enabled | bool | `true` | Turn on the snapshot feature. |
-| storageClasses | list | `[{"name":"topolvm-provisioner","storageClass":{"additionalParameters":{},"allowVolumeExpansion":true,"annotations":{},"fsType":"xfs","isDefaultClass":false,"reclaimPolicy":null,"volumeBindingMode":"WaitForFirstConsumer"}}]` | Whether to create storageclass(s) ref: https://kubernetes.io/docs/concepts/storage/storage-classes/ |
+| storageClasses | list | `[{"name":"topolvm-provisioner","storageClass":{"additionalParameters":{},"allowVolumeExpansion":true,"annotations":{},"fsType":"xfs","isDefaultClass":false,"reclaimPolicy":null,"volumeBindingMode":"WaitForFirstConsumer"}}]` | Whether to create storageclass(es) ref: https://kubernetes.io/docs/concepts/storage/storage-classes/ |
 | useLegacy | bool | `false` | If true, the legacy plugin name and legacy custom resource group is used(topolvm.cybozu.com). |
 | webhook.caBundle | string | `nil` | Specify the certificate to be used for AdmissionWebhook. |
 | webhook.existingCertManagerIssuer | object | `{}` | Specify the cert-manager issuer to be used for AdmissionWebhook. |

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -330,7 +330,7 @@ controller:
   args: []
 
   storageCapacityTracking:
-    # controller.storageCapacityTracking.enabled -- Enable Storage Capacity Tracking for csi-provisoner.
+    # controller.storageCapacityTracking.enabled -- Enable Storage Capacity Tracking for csi-provisioner.
     enabled: false
 
   securityContext:
@@ -507,10 +507,10 @@ resources:
   #    memory: "200Mi"
   #    cpu: "200m"
 
-# storageClasses -- Whether to create storageclass(s)
+# storageClasses -- Whether to create storageclass(es)
 # ref: https://kubernetes.io/docs/concepts/storage/storage-classes/
 storageClasses:
-  - name: topolvm-provisioner  # Defines name of storage classe.
+  - name: topolvm-provisioner  # Defines name of storage class.
     storageClass:
       # Supported filesystems are: ext4, xfs, and btrfs.
       fsType: xfs

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -175,23 +175,23 @@ Otherwise, `topolvm-scheduler` should be run as Deployment and Service.
 Set the `scheduler.type=daemonset` in the Helm Chart values.
 The default is daemonset.
 
-    ```yaml
-    <snip>
-    scheduler:
-      type: daemonset
-    <snip>
-    ```
+```yaml
+<snip>
+scheduler:
+  type: daemonset
+<snip>
+```
 
 #### Running topolvm-scheduler using Deployment and Service
 
 In this case, you can set the `scheduler.type=deployment` in the Helm Chart values.
 
-    ```yaml
-    <snip>
-    scheduler:
-      type: deployment
-    <snip>
-    ```
+```yaml
+<snip>
+scheduler:
+  type: deployment
+<snip>
+```
 
 This way, `topolvm-scheduler` is exposed by LoadBalancer service.
 
@@ -252,20 +252,20 @@ You can see the limitations of using Storage Capacity Tracking from [here](https
 If you want to use Storage Capacity Tracking instead of using topolvm-scheduler,
 you need to set the `controller.storageCapacityTracking.enabled=true`, `scheduler.enabled=false` and `webhook.podMutatingWebhook.enabled=false` in the Helm Chart values.
 
-    ```yaml
-    <snip>
-    controller:
-      storageCapacityTracking:
-        enabled: true
-    <snip>
-    scheduler:
-      enabled: false
-    <snip>
-    webhook:
-      podMutatingWebhook:
-        enabled: false
-    <snip>
-    ```
+```yaml
+<snip>
+controller:
+  storageCapacityTracking:
+    enabled: true
+<snip>
+scheduler:
+  enabled: false
+<snip>
+webhook:
+  podMutatingWebhook:
+    enabled: false
+<snip>
+```
 
 ## Protect system namespaces from TopoLVM webhook
 


### PR DESCRIPTION
Hi,

I just fixed a few indentation errors that caused to render code sections incorrectly in one of the docs.
Also, I just fixed some minor typos in the `values.yaml` comments.

Kind regards!