### PR TITLE
Helm Chart - Support imagePullSecrets

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -110,6 +110,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | image.csi.livenessProbe | string | `nil` | Specify livenessprobe image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.tag }}` will be used. |
 | image.csi.nodeDriverRegistrar | string | `nil` | Specify csi-node-driver-registrar: image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.tag }}` will be used. |
 | image.pullPolicy | string | `nil` | TopoLVM image pullPolicy. |
+| image.pullSecrets | list | `[]` | List of imagePullSecrets. |
 | image.repository | string | `"ghcr.io/topolvm/topolvm-with-sidecar"` | TopoLVM image repository to use. |
 | image.tag | string | `{{ .Chart.AppVersion }}` | TopoLVM image tag to use. |
 | lvmd.additionalConfigs | list | `[]` | Define additional LVM Daemon configs if you have additional types of nodes. Please ensure nodeSelectors are non overlapping. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -32,6 +32,10 @@ spec:
       {{- with .Values.controller.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-controller
       containers:
         - name: topolvm-controller

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -34,6 +34,10 @@ spec:
       {{- with .Values.lvmd.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-lvmd
       hostPID: true
       containers:

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -39,6 +39,9 @@ spec:
       containers:
         - name: lvmd
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          {{- with .Values.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           securityContext:
             privileged: true
           command:

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -25,6 +25,10 @@ spec:
       {{- with .Values.node.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-node
       containers:
         - name: topolvm-node

--- a/charts/topolvm/templates/scheduler/daemonset.yaml
+++ b/charts/topolvm/templates/scheduler/daemonset.yaml
@@ -35,6 +35,10 @@ spec:
       {{- with .Values.scheduler.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-scheduler
       containers:
         - name: topolvm-scheduler

--- a/charts/topolvm/templates/scheduler/deployment.yaml
+++ b/charts/topolvm/templates/scheduler/deployment.yaml
@@ -36,6 +36,10 @@ spec:
       {{- with .Values.scheduler.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-scheduler
       containers:
         - name: topolvm-scheduler

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -7,10 +7,13 @@ image:
 
   # image.tag -- TopoLVM image tag to use.
   # @default -- `{{ .Chart.AppVersion }}`
-  tag:  # 0.8.3
+  tag:  # 0.18.1
 
   # image.pullPolicy -- TopoLVM image pullPolicy.
   pullPolicy:  # Always
+
+  # image.pullSecrets -- List of imagePullSecrets.
+  pullSecrets: []
 
   csi:
     # image.csi.nodeDriverRegistrar -- Specify csi-node-driver-registrar: image.


### PR DESCRIPTION
Hi,

I noticed that the TopoLVM Helm Chart does not support configuration of `imagePullSecrets` although this seems to be generally considered as good practice - especially when you use on-prem K8s and your own image registry.  Therefore I implemented the support of this setting.

In addition, I found a bug 🐛:
Although you can set the `imagePullPolicy` globally in the `values.yaml` it is not applied to the `lvmd` DaemonSet. I fixed that as well.

Also feel free to cherry pick or let me know if I should adapt anything! 😁 