### PR TITLE
Start building images independently of unit tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,6 @@ jobs:
 
   build-images:
     name: "build-images"
-    needs: build
     runs-on: "ubuntu-20.04"
     strategy:
       fail-fast: true


### PR DESCRIPTION
As building images take time, do not wait for unit tests to start it to reduce the overall CI time.