### PR TITLE
feat(chart): allow affinity to be set for node and lvmd

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -119,6 +119,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | livenessProbe.topolvm_node | object | `{"failureThreshold":null,"initialDelaySeconds":10,"periodSeconds":60,"timeoutSeconds":3}` | Specify resources. # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | livenessProbe.topolvm_scheduler | object | `{"failureThreshold":null,"initialDelaySeconds":10,"periodSeconds":60,"timeoutSeconds":3}` | Specify livenessProbe. # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | lvmd.additionalConfigs | list | `[]` | Define additional LVM Daemon configs if you have additional types of nodes. Please ensure nodeSelectors are non overlapping. |
+| lvmd.affinity | object | `{}` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | lvmd.args | list | `[]` | Arguments to be passed to the command. |
 | lvmd.deviceClasses | list | `[{"default":true,"name":"ssd","spare-gb":10,"volume-group":"myvg1"}]` | Specify the device-class settings. |
 | lvmd.env | list | `[]` | extra environment variables |
@@ -132,6 +133,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | lvmd.updateStrategy | object | `{}` | Specify updateStrategy. |
 | lvmd.volumeMounts | list | `[]` | Specify volumeMounts. |
 | lvmd.volumes | list | `[]` | Specify volumes. |
+| node.affinity | object | `{}` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | node.args | list | `[]` | Arguments to be passed to the command. |
 | node.kubeletWorkDirectory | string | `"/var/lib/kubelet"` | Specify the work directory of Kubelet on the host. For example, on microk8s it needs to be set to `/var/snap/microk8s/common/var/lib/kubelet` |
 | node.lvmdSocket | string | `"/run/topolvm/lvmd.sock"` | Specify the socket to be used for communication with lvmd. |

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -105,6 +105,9 @@ spec:
       {{- with $lvmd.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $lvmd.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
 ---
     {{- end }}
   {{- end }}

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -201,3 +201,6 @@ spec:
       {{- with .Values.node.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.node.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -164,6 +164,10 @@ lvmd:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
 
+  # lvmd.affinity -- Specify affinity.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
   # lvmd.volumes -- Specify volumes.
   volumes: []
   #  - name: lvmd-socket-dir
@@ -271,6 +275,10 @@ node:
   # node.nodeSelector -- Specify nodeSelector.
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}
+
+  # node.affinity -- Specify affinity.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
 
   # node.volumes -- Specify volumes.
   volumes: []


### PR DESCRIPTION
Sometimes the nodeSelectors are too unflexible, so we would like to use the affinity.nodeAffinity nodeSelectorTerms. This PR adds the possibility to specify affinity rules for node and lvmd similar to the controller and the scheduler daemonsets/deployments.