### PR TITLE
Use dependabot grouping feature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     rebase-strategy: "disabled"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions-update:
+        patterns:
+          - "*"


### PR DESCRIPTION
To update github actions by single PR, use grouping feature. ref. https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups