### PR TITLE
Use pre-build cri-dockerd

### DIFF
--- a/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-daemonset-lvmd.yaml
@@ -56,24 +56,9 @@ jobs:
           sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
 
           # Install cri-docker
-          git clone -n https://github.com/Mirantis/cri-dockerd
           CRI_DOCKERD_VERSION="v0.3.1"
-          cd cri-dockerd
-          git checkout ${CRI_DOCKERD_VERSION}
-          mkdir bin
-          go get && go build -o bin/cri-dockerd
-          mkdir -p /usr/local/bin
-          sudo install -o root -g root -m 0755 bin/cri-dockerd /usr/local/bin/cri-dockerd
-          sudo cp -a packaging/systemd/* /etc/systemd/system
-          sudo sed -i -e 's,/usr/bin/cri-dockerd,/usr/local/bin/cri-dockerd,' /etc/systemd/system/cri-docker.service
-
-          # This is a workaround for the following issue.
-          # https://github.com/kubernetes/minikube/issues/15265
-          sudo ln -s /usr/local/bin/cri-dockerd /usr/bin/cri-dockerd
-
-          sudo systemctl daemon-reload
-          sudo systemctl enable cri-docker.service
-          sudo systemctl enable --now cri-docker.socket
+          curl -L -o cri-dockerd.deb https://github.com/Mirantis/cri-dockerd/releases/download/${CRI_DOCKERD_VERSION}/cri-dockerd_${CRI_DOCKERD_VERSION#v}.3-0.ubuntu-focal_amd64.deb
+          sudo dpkg -i cri-dockerd.deb
 
           CRICTL_VERSION="v1.27.0"
           curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz --output crictl-${CRICTL_VERSION}-linux-amd64.tar.gz


### PR DESCRIPTION
Go 1.19.10 has a security fix [1], which introduces a regression for docker client [2], finally it breaks cri-dockerd.  Since we build cri-dockerd in CI environment with latest Go 1.19 release, the regression affects us. But pre-build binary made by old Go release has no regression, we can avoid it using the binary.

[1]: https://github.com/golang/go/commit/5fa6923b1ea891400153d04ddf1545e23b40041b
[2]: https://github.com/moby/moby/issues/45935