### PR TITLE
helm: allow environment variables configuration

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -104,6 +104,14 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | controller.tolerations | list | `[]` | Specify tolerations. # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | controller.updateStrategy | object | `{}` | Specify updateStrategy. |
 | controller.volumes | list | `[{"emptyDir":{},"name":"socket-dir"}]` | Specify volumes. |
+| env.csi_provisioner | list | `[]` | Specify environment variables for csi_provisioner container. |
+| env.csi_registrar | list | `[]` | Specify environment variables for csi_registrar container. |
+| env.csi_resizer | list | `[]` | Specify environment variables for csi_resizer container. |
+| env.csi_snapshotter | list | `[]` | Specify environment variables for csi_snapshotter container. |
+| env.liveness_probe | list | `[]` | Specify environment variables for liveness_probe container. |
+| env.topolvm_controller | list | `[]` | Specify environment variables for topolvm_controller container. |
+| env.topolvm_node | list | `[]` | Specify environment variables for topolvm_node container. |
+| env.topolvm_scheduler | list | `[]` | Specify environment variables for topolvm_scheduler container. |
 | image.csi.csiProvisioner | string | `nil` | Specify csi-provisioner image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.tag }}` will be used. |
 | image.csi.csiResizer | string | `nil` | Specify csi-resizer image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.tag }}` will be used. |
 | image.csi.csiSnapshotter | string | `nil` | Specify csi-snapshot image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.tag }}` will be used. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -46,11 +46,16 @@ spec:
             {{- if .Values.controller.nodeFinalize.skipped }}
             - --skip-node-finalize
             {{- end }}
-          {{ if .Values.useLegacy }}
+          {{- if or .Values.useLegacy .Values.env.topolvm_controller }}
           env:
+            {{- if .Values.useLegacy }}
             - name: USE_LEGACY
               value: "true"
-          {{ end }}
+            {{- end }}
+            {{- with .Values.env.topolvm_controller }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
           {{- with .Values.controller.args }}
           args: {{ toYaml . | nindent 12 }}
           {{- end }}
@@ -112,6 +117,9 @@ spec:
           {{- with .Values.resources.csi_provisioner }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.env.csi_provisioner }}
+          env: {{ toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /csi-provisioner
             - --csi-address=/run/topolvm/csi-topolvm.sock
@@ -153,6 +161,9 @@ spec:
           {{- with .Values.resources.csi_resizer }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.env.csi_resizer }}
+          env: {{ toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - /csi-resizer
             - --csi-address=/run/topolvm/csi-topolvm.sock
@@ -178,6 +189,9 @@ spec:
           {{- end }}
           {{- with .Values.resources.csi_snapshotter }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env.csi_snapshotter }}
+          env: {{- toYaml . | nindent 12 }}
           {{- end }}
           command:
             - /csi-snapshotter
@@ -215,7 +229,9 @@ spec:
           {{- with .Values.resources.liveness_probe }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
-
+          {{- with .Values.env.liveness_probe }}
+          env: {{ toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: certs
           secret:

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -81,6 +81,9 @@ spec:
             - name: USE_LEGACY
               value: "true"
             {{ end }}
+            {{- with .Values.env.topolvm_node }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             {{- if .Values.node.volumeMounts.topolvmNode }}
             {{- toYaml .Values.node.volumeMounts.topolvmNode | nindent 12 }}
@@ -140,6 +143,9 @@ spec:
           {{- with .Values.resources.csi_registrar }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.env.csi_registrar }}
+          env: {{ toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: node-plugin-dir
               mountPath: {{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/
@@ -164,6 +170,9 @@ spec:
               name: livenessprobe
           {{- with .Values.resources.liveness_probe }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env.liveness_probe }}
+          env: {{ toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: node-plugin-dir

--- a/charts/topolvm/templates/scheduler/daemonset.yaml
+++ b/charts/topolvm/templates/scheduler/daemonset.yaml
@@ -49,11 +49,16 @@ spec:
           command:
             - /topolvm-scheduler
             - --config=/etc/topolvm/scheduler-options.yaml
-          {{ if .Values.useLegacy }}
+          {{- if or .Values.useLegacy .Values.env.topolvm_scheduler }}
           env:
+            {{- if .Values.useLegacy }}
             - name: USE_LEGACY
               value: "true"
-          {{ end }}
+            {{- end }}
+            {{- with .Values.env.topolvm_scheduler }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
           {{- with .Values.scheduler.args }}
           args: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/topolvm/templates/scheduler/deployment.yaml
+++ b/charts/topolvm/templates/scheduler/deployment.yaml
@@ -50,11 +50,16 @@ spec:
           command:
             - /topolvm-scheduler
             - --config=/etc/topolvm/scheduler-options.yaml
-          {{ if .Values.useLegacy }}
+          {{- if or .Values.useLegacy .Values.env.topolvm_scheduler }}
           env:
+            {{- if .Values.useLegacy }}
             - name: USE_LEGACY
               value: "true"
-          {{ end }}
+            {{- end }}
+            {{- with .Values.env.topolvm_scheduler }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
           {{- with .Values.scheduler.args }}
           args: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -518,6 +518,26 @@ resources:
   #    memory: "200Mi"
   #    cpu: "200m"
 
+env:
+  # env.topolvm_node -- Specify environment variables for topolvm_node container.
+  topolvm_node: []
+  # env.csi_registrar -- Specify environment variables for csi_registrar container.
+  csi_registrar: []
+  # env.liveness_probe -- Specify environment variables for liveness_probe container.
+  liveness_probe: []
+  # env.topolvm_controller -- Specify environment variables for topolvm_controller container.
+  topolvm_controller: []
+  # env.csi_provisioner -- Specify environment variables for csi_provisioner container.
+  csi_provisioner: []
+  # env.csi_resizer -- Specify environment variables for csi_resizer container.
+  csi_resizer: []
+  # env.csi_snapshotter -- Specify environment variables for csi_snapshotter container.
+  csi_snapshotter: []
+  # To specify environment variables for lvmd, use lvmd.env instead.
+  # lvmd: []
+  # env.topolvm_scheduler -- Specify environment variables for topolvm_scheduler container.
+  topolvm_scheduler: []
+
 livenessProbe:
   # livenessProbe.topolvm_node -- Specify resources.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/


### PR DESCRIPTION
This commit allows us to set environment variables for all containers that this helm chart installs. This enables us, for instance, to set GOMAXPROCS for Go binaries, which might be appropriate to set along with resources.limits.cpu.

Issue: https://github.com/topolvm/topolvm/issues/726
