### PR TITLE
Add init containers

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -85,6 +85,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | cert-manager.enabled | bool | `false` | Install cert-manager together. # ref: https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm |
 | controller.affinity | string | `"podAntiAffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n    - labelSelector:\n        matchExpressions:\n          - key: app.kubernetes.io/component\n            operator: In\n            values:\n              - controller\n          - key: app.kubernetes.io/name\n            operator: In\n            values:\n              - {{ include \"topolvm.name\" . }}\n      topologyKey: kubernetes.io/hostname\n"` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | controller.args | list | `[]` | Arguments to be passed to the command. |
+| controller.initContainers | list | `[]` | Additional initContainers for the controller service. |
 | controller.labels | object | `{}` | Additional labels to be added to the Deployment. |
 | controller.minReadySeconds | int | `nil` | Specify minReadySeconds. |
 | controller.nodeFinalize.skipped | bool | `false` | Skip automatic cleanup of PhysicalVolumeClaims when a Node is deleted. |
@@ -133,6 +134,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | lvmd.args | list | `[]` | Arguments to be passed to the command. |
 | lvmd.deviceClasses | list | `[{"default":true,"name":"ssd","spare-gb":10,"volume-group":"myvg1"}]` | Specify the device-class settings. |
 | lvmd.env | list | `[]` | extra environment variables |
+| lvmd.initContainers | list | `[]` | Additional initContainers for the lvmd service. |
 | lvmd.labels | object | `{}` | Additional labels to be added to the Daemonset. |
 | lvmd.lvcreateOptionClasses | list | `[]` | Specify the lvcreate-option-class settings. |
 | lvmd.managed | bool | `true` | If true, set up lvmd service with DaemonSet. |
@@ -147,6 +149,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | lvmd.volumes | list | `[]` | Specify volumes. |
 | node.affinity | object | `{}` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | node.args | list | `[]` | Arguments to be passed to the command. |
+| node.initContainers | list | `[]` | Additional initContainers for the node service. |
 | node.kubeletWorkDirectory | string | `"/var/lib/kubelet"` | Specify the work directory of Kubelet on the host. For example, on microk8s it needs to be set to `/var/snap/microk8s/common/var/lib/kubelet` |
 | node.labels | object | `{}` | Additional labels to be added to the Daemonset. |
 | node.lvmdSocket | string | `"/run/topolvm/lvmd.sock"` | Specify the socket to be used for communication with lvmd. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -43,6 +43,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-controller
+      {{- with .Values.controller.initContainers }}
+      initContainers: {{ toYaml . | nindent 6 }}
+      {{- end }}
       containers:
         - name: topolvm-controller
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -46,6 +46,9 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-lvmd
       hostPID: true
+      {{- with .Values.lvmd.initContainers }}
+      initContainers: {{ toYaml . | nindent 6 }}
+      {{- end }}
       containers:
         - name: lvmd
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -36,6 +36,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-node
+      {{- with .Values.node.initContainers }}
+      initContainers: {{ toYaml . | nindent 6 }}
+      {{- end }}
       containers:
         - name: topolvm-node
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -219,6 +219,9 @@ lvmd:
   # lvmd.labels -- Additional labels to be added to the Daemonset.
   labels: {}
 
+  # lvmd.initContainers -- Additional initContainers for the lvmd service.
+  initContainers: []
+
 # CSI node service
 node:
   # node.lvmdSocket -- Specify the socket to be used for communication with lvmd.
@@ -347,6 +350,9 @@ node:
   # node.labels -- Additional labels to be added to the Daemonset.
   labels: {}
 
+  # node.initContainers -- Additional initContainers for the node service.
+  initContainers: []
+
 # CSI controller service
 controller:
   # controller.replicaCount -- Number of replicas for CSI controller service.
@@ -454,6 +460,9 @@ controller:
   podLabels: {}
   # controller.labels -- Additional labels to be added to the Deployment.
   labels: {}
+
+  # controller.initContainers -- Additional initContainers for the controller service.
+  initContainers: []
 
 resources:
   # resources.topolvm_node -- Specify resources.


### PR DESCRIPTION
related #751 

It would be nice to have the ability to add custom `initConatiners` to any of the existing services `[controller, lvmd, node]` to allow a user to extend the functionality for custom use-cases.

```
❯ cat testvalues.yaml
lvmd:
  initContainers:
  - name: custom-commands
    image: docker.io/bash:5.2.15
    resources:
      limits:
        cpu: 100m
        memory: 32Mi
    command:
    - 'bash'
    - '-e'
    - '-c'
    - |-
      echo "running custom commands"

# initContainers working properly
❯ helm template topo . -s templates/lvmd/daemonset.yaml -f testvalues.yaml | yq '.spec.template.spec.initContainers'
- command:
    - bash
    - -e
    - -c
    - echo "running custom commands"
  image: docker.io/bash:5.2.15
  name: custom-commands
  resources:
    limits:
      cpu: 100m
      memory: 32Mi

# Without initContainers, nothing changes with the podTemplateSpec
❯ helm template topo . -s templates/lvmd/daemonset.yaml | yq '.spec.template.spec'
serviceAccountName: topo-topolvm-lvmd
hostPID: true
containers:
  - name: lvmd
    image: "ghcr.io/topolvm/topolvm-with-sidecar:0.21.0"
    securityContext:
      privileged: true
    command:
      - /lvmd
      - --container
    livenessProbe:
      exec:
        command:
          - /lvmd
          - health
      initialDelaySeconds: 10
      timeoutSeconds: 3
      periodSeconds: 60
    volumeMounts:
      - name: config
        mountPath: /etc/topolvm
      - name: lvmd-socket-dir
        mountPath: /run/topolvm
volumes:
  - name: config
    configMap:
      name: topo-topolvm-lvmd-0
  - name: lvmd-socket-dir
    hostPath:
      path: /run/topolvm
      type: DirectoryOrCreate
```