### PR TITLE
Refine exempt-issue-labels to ignore update kubernetes

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -40,6 +40,6 @@ jobs:
           Thank you for your contribution.
         stale-issue-label: "stale"
         stale-pr-label: "stale"
-        exempt-issue-labels: "keepalive"
+        exempt-issue-labels: "keepalive,update kubernetes"
         exempt-pr-labels: "keepalive"
         exempt-draft-pr: true


### PR DESCRIPTION
Issues labelled with update kubernetes would be marked as stale because dependent tools or libraries will not be released immediately. To avoid this, add the label to exempt-issue-labels.