### PR TITLE
improve the explanation of the release note format

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,10 @@ Follow [semantic versioning 2.0.0][semver] to choose the new version number.
 The format of release notes
 ---------------------------
 
-Release note is edited in the release procedure. The result should look something like:
+In the release procedure for both the app and Helm Chart, the release note is generated automatically,
+and then it is edited manually. In this step, PRs should be classified based on [Keep a CHANGELOG](https://keepachangelog.com/en/1.1.0/).
+
+The result should look something like:
 
 ```markdown
  ## What's Changed


### PR DESCRIPTION
fixes: 75fa457df63c26819aae24d83c01df4755ac784b

In this PR, I fixed a similar problem with the following comment for pvc-autoresizer.
https://github.com/topolvm/pie/pull/90#discussion_r1363581087

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
