### PR TITLE
feat: Starting LVMD from within topolvm-node instead of using gRPC

### DIFF
--- a/.github/workflows/e2e-k8s-incluster-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-incluster-lvmd.yaml
@@ -1,4 +1,4 @@
-name: "e2e-k8s-daemonset-lvmd"
+name: "e2e-k8s-incluster-lvmd"
 on:
   pull_request:
     paths-ignore:
@@ -12,12 +12,13 @@ on:
       - "main"
 jobs:
   e2e-k8s-daemonset-lvmd:
-    name: "e2e-k8s-daemonset-lvmd"
+    name: "e2e-k8s-incluster-lvmd"
     runs-on: "ubuntu-20.04"
     strategy:
       fail-fast: false
       matrix:
         kubernetes_versions: ["1.27.3", "1.26.6", "1.25.11"]
+        deployment_type: ["daemonset", "embedded"]
     env:
       KUBERNETES_VERSION: ${{ matrix.kubernetes_versions }}
       STORAGE_CAPACITY: "true"
@@ -63,7 +64,14 @@ jobs:
           CRICTL_VERSION="v1.28.0"
           curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$CRICTL_VERSION/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz --output crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
           sudo tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
-      - run: make -C e2e daemonset-lvmd/create-vg
-      - run: make -C e2e daemonset-lvmd/setup-minikube
-      - run: make -C e2e daemonset-lvmd/launch-minikube
-      - run: make -C e2e daemonset-lvmd/test
+      - run: make -C e2e incluster-lvmd/create-vg
+      - run: make -C e2e incluster-lvmd/setup-minikube
+      - run: make -C e2e incluster-lvmd/launch-minikube
+      - run: make -C e2e incluster-lvmd/test
+        if: ${{ matrix.deployment_type == 'daemonset' }}
+        env:
+          HELM_VALUES_FILE_LVMD: "manifests/values/daemonset-lvmd-storage-capacity.yaml"
+      - run: make -C e2e incluster-lvmd/test
+        if: ${{ matrix.deployment_type == 'embedded' }}
+        env:
+          HELM_VALUES_FILE_LVMD: "manifests/values/embedded-lvmd-storage-capacity.yaml"

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -151,6 +151,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | node.initContainers | list | `[]` | Additional initContainers for the node service. |
 | node.kubeletWorkDirectory | string | `"/var/lib/kubelet"` | Specify the work directory of Kubelet on the host. For example, on microk8s it needs to be set to `/var/snap/microk8s/common/var/lib/kubelet` |
 | node.labels | object | `{}` | Additional labels to be added to the Daemonset. |
+| node.lvmdEmbedded | bool | `false` | Specify whether to embed lvmd in the node container. Should not be used in conjunction with lvmd.managed otherwise lvmd will be started twice. |
 | node.lvmdSocket | string | `"/run/topolvm/lvmd.sock"` | Specify the socket to be used for communication with lvmd. |
 | node.metrics.annotations | object | `{"prometheus.io/port":"metrics"}` | Annotations for Scrape used by Prometheus. |
 | node.metrics.enabled | bool | `true` | If true, enable scraping of metrics by Prometheus. |

--- a/charts/topolvm/templates/lvmd/configmap.yaml
+++ b/charts/topolvm/templates/lvmd/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.lvmd.managed }}
+{{- if or (.Values.lvmd.managed) (.Values.node.lvmdEmbedded) }}
   {{ $global := . }}
   {{- $lvmds := concat ( list .Values.lvmd ) .Values.lvmd.additionalConfigs }}
   {{- range $lvmdidx, $lvmd := $lvmds }}
@@ -15,7 +15,9 @@ metadata:
     {{- include "topolvm.labels" . | nindent 4 }}
 data:
   lvmd.yaml: |
+    {{- if not .Values.node.lvmdEmbedded }}
     socket-name: {{ default .Values.lvmd.socketName $lvmd.socketName }}
+    {{- end }}
     {{- if $lvmd.deviceClasses }}
     device-classes: {{ toYaml $lvmd.deviceClasses | nindent 6 }}
     {{- end }}

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -36,6 +36,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "topolvm.fullname" . }}-node
+      {{- if .Values.node.lvmdEmbedded }}
+      hostPID: true
+      {{- end }}
       {{- with .Values.node.initContainers }}
       initContainers: {{ toYaml . | nindent 6 }}
       {{- end }}
@@ -51,7 +54,11 @@ spec:
           command:
             - /topolvm-node
             - --csi-socket={{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/csi-topolvm.sock
+            {{- if .Values.node.lvmdEmbedded }}
+            - --embed-lvmd
+            {{- else }}
             - --lvmd-socket={{ .Values.node.lvmdSocket }}
+            {{- end }}
           {{- with .Values.node.args }}
           args: {{ toYaml . | nindent 12 }}
           {{- end }}
@@ -99,8 +106,13 @@ spec:
             {{- else }}
             - name: node-plugin-dir
               mountPath: {{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/
+            {{ if .Values.node.lvmdEmbedded }}
+            - name: config
+              mountPath: /etc/topolvm
+            {{ else }}
             - name: lvmd-socket-dir
               mountPath: {{ dir .Values.node.lvmdSocket }}
+            {{ end }}
             - name: pod-volumes-dir
               mountPath: {{ .Values.node.kubeletWorkDirectory }}/pods
               mountPropagation: "Bidirectional"
@@ -207,10 +219,23 @@ spec:
           hostPath:
             path: {{ .Values.node.kubeletWorkDirectory }}/pods/
             type: DirectoryOrCreate
+        {{- if .Values.node.lvmdEmbedded }}
+          {{ $global := . }}
+          {{- $lvmds := concat ( list .Values.lvmd ) .Values.lvmd.additionalConfigs }}
+          {{- range $lvmdidx, $lvmd := $lvmds }}
+            {{/* Undo the "." rewritten by the range block */}}
+            {{- with $global }}
+        - name: config
+          configMap:
+            name: {{ template "topolvm.fullname" . }}-lvmd-{{ $lvmdidx }}
+            {{- end }}
+          {{- end }}
+        {{- else }}
         - name: lvmd-socket-dir
           hostPath:
             path: {{ dir .Values.node.lvmdSocket }}
             type: Directory
+        {{- end }}
         {{- end }}
 
       {{- with .Values.node.tolerations }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -213,6 +213,9 @@ lvmd:
 
 # CSI node service
 node:
+  # node.lvmdEmbedded -- Specify whether to embed lvmd in the node container.
+  # Should not be used in conjunction with lvmd.managed otherwise lvmd will be started twice.
+  lvmdEmbedded: false
   # node.lvmdSocket -- Specify the socket to be used for communication with lvmd.
   lvmdSocket: /run/topolvm/lvmd.sock
   # node.kubeletWorkDirectory -- Specify the work directory of Kubelet on the host.

--- a/controllers/logicalvolume_controller.go
+++ b/controllers/logicalvolume_controller.go
@@ -9,7 +9,6 @@ import (
 	topolvmlegacyv1 "github.com/topolvm/topolvm/api/legacy/v1"
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
 	"github.com/topolvm/topolvm/lvmd/proto"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -33,15 +32,6 @@ type LogicalVolumeReconciler struct {
 //+kubebuilder:rbac:groups=topolvm.io,resources=logicalvolumes,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=topolvm.io,resources=logicalvolumes/status,verbs=get;update;patch
 
-// NewLogicalVolumeReconciler returns LogicalVolumeReconciler with creating lvService and vgService.
-func NewLogicalVolumeReconciler(client client.Client, nodeName string, conn *grpc.ClientConn) *LogicalVolumeReconciler {
-	return &LogicalVolumeReconciler{
-		client:    client,
-		nodeName:  nodeName,
-		vgService: proto.NewVGServiceClient(conn),
-		lvService: proto.NewLVServiceClient(conn),
-	}
-}
 func NewLogicalVolumeReconcilerWithServices(client client.Client, nodeName string, vgService proto.VGServiceClient, lvService proto.LVServiceClient) *LogicalVolumeReconciler {
 	return &LogicalVolumeReconciler{
 		client:    client,

--- a/driver/node.go
+++ b/driver/node.go
@@ -15,7 +15,6 @@ import (
 	"github.com/topolvm/topolvm/filesystem"
 	"github.com/topolvm/topolvm/lvmd/proto"
 	"golang.org/x/sys/unix"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	mountutil "k8s.io/mount-utils"
@@ -36,7 +35,7 @@ const (
 var nodeLogger = ctrl.Log.WithName("driver").WithName("node")
 
 // NewNodeServer returns a new NodeServer.
-func NewNodeServer(nodeName string, conn *grpc.ClientConn, mgr manager.Manager) (csi.NodeServer, error) {
+func NewNodeServer(nodeName string, vgServiceClient proto.VGServiceClient, lvServiceClient proto.LVServiceClient, mgr manager.Manager) (csi.NodeServer, error) {
 	lvService, err := k8s.NewLogicalVolumeService(mgr)
 	if err != nil {
 		return nil, err
@@ -45,8 +44,8 @@ func NewNodeServer(nodeName string, conn *grpc.ClientConn, mgr manager.Manager) 
 	return &nodeServer{
 		server: &nodeServerNoLocked{
 			nodeName:     nodeName,
-			client:       proto.NewVGServiceClient(conn),
-			lvService:    proto.NewLVServiceClient(conn),
+			client:       vgServiceClient,
+			lvService:    lvServiceClient,
 			k8sLVService: lvService,
 			mounter: mountutil.SafeFormatAndMount{
 				Interface: mountutil.New(""),

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -36,7 +36,7 @@ endif
 KIND_CONFIG="topolvm-cluster.yaml"
 MINIKUBE_FEATURE_GATES="ReadWriteOncePod=true"
 
-HELM_VALUES_FILE_LVMD := manifests/values/daemonset-lvmd-storage-capacity.yaml
+HELM_VALUES_FILE_LVMD ?= manifests/values/daemonset-lvmd-storage-capacity.yaml
 
 SCHEDULER_CONFIG := scheduler-config-$(TEST_SCHEDULER_MANIFEST).yaml
 
@@ -238,8 +238,8 @@ $(KUBECTL): | $(BINDIR)
 	$(CURL) -o $@ https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl
 	chmod a+x $@
 
-.PHONY: daemonset-lvmd/create-vg
-daemonset-lvmd/create-vg:
+.PHONY: incluster-lvmd/create-vg
+incluster-lvmd/create-vg:
 	mkdir -p build $(BACKING_STORE)
 	if [ $$(ls -1 $(BACKING_STORE)/backing_store_lvmd* 2>/dev/null | wc -l) -ne 0 ]; then $(MAKE) $(@D)/remove-vg; fi
 
@@ -274,8 +274,8 @@ daemonset-lvmd/create-vg:
 		$$($(SUDO) losetup -j $(BACKING_STORE)/backing_store_lvmd_8 | cut -d: -f1)
 
 
-.PHONY: daemonset-lvmd/remove-vg
-daemonset-lvmd/remove-vg:
+.PHONY: incluster-lvmd/remove-vg
+incluster-lvmd/remove-vg:
 	for i in $$(seq 8); do \
 		if [ "$${j}" -lt 7 ]; then \
 			$(SUDO) vgremove -ffy node-myvg$${i}; \
@@ -285,16 +285,16 @@ daemonset-lvmd/remove-vg:
 		rm -f $(BACKING_STORE)/backing_store_lvmd_$${i}; \
 	done
 
-.PHONY: daemonset-lvmd/setup-minikube
-daemonset-lvmd/setup-minikube:
+.PHONY: incluster-lvmd/setup-minikube
+incluster-lvmd/setup-minikube:
 	mkdir -p $(BINDIR)
 	$(SUDO) apt-get update
 	DEBIAN_FRONTEND=noninteractive $(SUDO) apt-get install -y --no-install-recommends conntrack
 	$(CURL) -o $(BINDIR)/minikube https://github.com/kubernetes/minikube/releases/download/$(MINIKUBE_VERSION)/minikube-linux-amd64
 	chmod a+x $(BINDIR)/minikube
 
-.PHONY: daemonset-lvmd/launch-minikube
-daemonset-lvmd/launch-minikube:
+.PHONY: incluster-lvmd/launch-minikube
+incluster-lvmd/launch-minikube:
 	@if [ "$(STORAGE_CAPACITY)" = false ]; then echo "Only storage capacity mode is supported."; exit 1; fi
 	$(SUDO) -E $(BINDIR)/minikube start \
 		--vm-driver=none \
@@ -306,12 +306,12 @@ daemonset-lvmd/launch-minikube:
 	$(SUDO) chmod -R a+r $$HOME/.kube $(MINIKUBE_HOME)/.minikube
 	$(SUDO) find $(MINIKUBE_HOME)/.minikube -name id_rsa -exec chmod 600 {} ';'
 
-.PHONY: daemonset-lvmd/delete-minikube
-daemonset-lvmd/delete-minikube:
+.PHONY: incluster-lvmd/delete-minikube
+incluster-lvmd/delete-minikube:
 	$(SUDO) -E $(BINDIR)/minikube delete || true
 
-.PHONY: daemonset-lvmd/test
-daemonset-lvmd/test: topolvm.img $(GINKGO) $(HELM) $(KUBECTL)
+.PHONY: incluster-lvmd/test
+incluster-lvmd/test: topolvm.img $(GINKGO) $(HELM) $(KUBECTL)
 	$(MAKE) apply-certmanager-crds
 	$(MAKE) prepare-namespace
 	$(HELM) repo add jetstack https://charts.jetstack.io
@@ -335,5 +335,5 @@ daemonset-lvmd/test: topolvm.img $(GINKGO) $(HELM) $(KUBECTL)
 	DAEMONSET_LVMD=true \
 	$(GINKGO) --fail-fast -v .
 
-.PHONY: daemonset-lvmd/clean
-daemonset-lvmd/clean: daemonset-lvmd/delete-minikube daemonset-lvmd/remove-vg
+.PHONY: incluster-lvmd/clean
+incluster-lvmd/clean: incluster-lvmd/delete-minikube incluster-lvmd/remove-vg

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -62,22 +62,29 @@ Before launching the test, install the following tools.
 Make lvm and launch Kubernetes using minikube with the following commands:
 
 ```bash
-make daemonset-lvmd/create-vg
-make daemonset-lvmd/setup-minikube
-make daemonset-lvmd/launch-minikube
+make incluster-lvmd/create-vg
+make incluster-lvmd/setup-minikube
+make incluster-lvmd/launch-minikube
 ```
 
 Run the tests with the following command.
 You can inspect the Kubernetes cluster using `kubectl` command as well as kind.
 
 ```bash
-make daemonset-lvmd/test
+make incluster-lvmd/test
 ```
+
+By default, this will run lvmd as a `DaemonSet` separate from `topolvm-node`.
+You can also configure the test to use an embedded version of lvmd inside `topolvm-node`.
+
+```bash
+make incluster-lvmd/test HELM_VALUES_FILE_LVMD="manifests/values/embedded-lvmd-storage-capacity.yaml"
+`````
 
 You can cleanup test environment as follows:
 
 ```bash
-make daemonset-lvmd/clean
+make incluster-lvmd/clean
 ```
 
 [kind]: https://github.com/kubernetes-sigs/kind

--- a/e2e/manifests/values/embedded-lvmd-storage-capacity.yaml
+++ b/e2e/manifests/values/embedded-lvmd-storage-capacity.yaml
@@ -1,0 +1,80 @@
+image:
+  repository: topolvm
+  tag: dev
+  pullPolicy: Never
+
+controller:
+  replicaCount: 1
+  storageCapacityTracking:
+    enabled: true
+  securityContext:
+    enabled: false
+  # sanity test requires that the controller mounts this hostPath to communicate with it
+  volumes:
+    - name: socket-dir
+      hostPath:
+        path: /var/lib/kubelet/plugins/topolvm.io/controller
+        type: DirectoryOrCreate
+
+scheduler:
+  enabled: false
+
+node:
+  lvmdEmbedded: true
+
+lvmd:
+  managed: false
+  deviceClasses:
+    - name: "ssd"
+      volume-group: "node-myvg1"
+      default: true
+      spare-gb: 1
+    - name: "hdd1"
+      volume-group: "node-myvg2"
+      spare-gb: 1
+    - name: "hdd2"
+      volume-group: "node-myvg3"
+      spare-gb: 1
+    - name: "raid"
+      volume-group: "node-myvg4"
+      spare-gb: 1
+      lvcreate-options:
+        - "--type=raid1"
+    - name: "thin"
+      volume-group: "node-myvg5"
+      type: thin
+      thin-pool:
+        name: "pool0"
+        overprovision-ratio: 5.0
+    - name: "raid1"
+      volume-group: "node-myvg6"
+      spare-gb: 1
+  lvcreateOptionClasses:
+    - name: "raid1"
+      options:
+        - "--type=raid1"
+
+storageClasses:
+  - name: topolvm-provisioner
+    storageClass:
+      fsType: xfs
+      isDefaultClass: false
+      volumeBindingMode: WaitForFirstConsumer
+      allowVolumeExpansion: true
+      additionalParameters:
+        topolvm.io/device-class: "ssd"
+  - name: topolvm-provisioner-thin
+    storageClass:
+      fsType: xfs
+      isDefaultClass: false
+      volumeBindingMode: WaitForFirstConsumer
+      allowVolumeExpansion: true
+      additionalParameters:
+        topolvm.io/device-class: "thin"
+
+webhook:
+  podMutatingWebhook:
+    enabled: false
+
+cert-manager:
+  enabled: true

--- a/lvmd/embed.go
+++ b/lvmd/embed.go
@@ -1,0 +1,139 @@
+package lvmd
+
+import (
+	"context"
+
+	"github.com/topolvm/topolvm/lvmd/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// NewEmbeddedServiceClients creates clients locally calling instead of using gRPC.
+func NewEmbeddedServiceClients(ctx context.Context, dcmapper *DeviceClassManager, ocmapper *LvcreateOptionClassManager) (
+	proto.LVServiceClient,
+	proto.VGServiceClient,
+) {
+	vgServiceServerInstance, notifier := NewVGService(dcmapper)
+	lvServiceServerInstance := NewLVService(dcmapper, ocmapper, notifier)
+	caller := &embeddedServiceClients{
+		lvServiceServer: lvServiceServerInstance,
+		vgServiceServer: vgServiceServerInstance,
+	}
+	caller.vgWatch = &embeddedChannelWatch{ctx: ctx, watch: make(chan any)}
+	go caller.vgServiceServer.Watch(&proto.Empty{}, caller.vgWatch)
+	return caller, caller
+}
+
+// embeddedServiceClients is a struct holding indirections to the local lvmd server.
+// It implements both the LVServiceClient and VGServiceClient interfaces.
+// It also includes a watch for redirecting the vg watch to the local caller.
+type embeddedServiceClients struct {
+	lvServiceServer proto.LVServiceServer
+	vgServiceServer proto.VGServiceServer
+	vgWatch         *embeddedChannelWatch
+}
+
+// embeddedChannelWatch is a local implementation of the VGService_WatchClient and VGService_WatchServer that is used by vgService.
+// it uses an unbound blocking channel to send and receive messages.
+type embeddedChannelWatch struct {
+	watch chan any
+	ctx   context.Context
+}
+
+// SetHeader is stubbed out to satisfy the grpc.ServerStream interface.
+func (l *embeddedChannelWatch) SetHeader(md metadata.MD) error { return nil }
+
+// SendHeader is stubbed out to satisfy the grpc.ServerStream interface.
+func (l *embeddedChannelWatch) SendHeader(md metadata.MD) error { return nil }
+
+// SetTrailer is stubbed out to satisfy the grpc.ServerStream interface.
+func (l *embeddedChannelWatch) SetTrailer(md metadata.MD) {}
+
+// Header is stubbed out to satisfy the grpc.ClientStream interface.
+func (l *embeddedChannelWatch) Header() (metadata.MD, error) { return nil, nil }
+
+// Trailer is stubbed out to satisfy the grpc.ClientStream interface.
+func (l *embeddedChannelWatch) Trailer() metadata.MD { return nil }
+
+// CloseSend is stubbed out to satisfy the grpc.ClientStream interface.
+func (l *embeddedChannelWatch) CloseSend() error { return nil }
+
+// Context is relaying the server context to satisfy the grpc.ClientStream and grpc.ServerStream interface.
+// Client Context is ignored as the server context is always living longer.
+func (l *embeddedChannelWatch) Context() context.Context { return l.ctx }
+
+// Recv is used to receive a WatchResponse as a VGService_WatchClient.
+func (l *embeddedChannelWatch) Recv() (*proto.WatchResponse, error) {
+	m := new(proto.WatchResponse)
+	if err := l.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// Send is used to send a WatchResponse as a VGService_WatchServer.
+func (l *embeddedChannelWatch) Send(m *proto.WatchResponse) error {
+	return l.SendMsg(m)
+}
+
+// SendMsg is used to send messages to the channel both as a grpc.ClientStream and as a grpc.ServerStream.
+func (l *embeddedChannelWatch) SendMsg(m interface{}) error {
+	l.watch <- m
+	return nil
+}
+
+// RecvMsg is used to receive messages from the channel both as a grpc.ClientStream and as a grpc.ServerStream.
+func (l *embeddedChannelWatch) RecvMsg(m interface{}) error {
+	select {
+	case received, ok := <-l.watch:
+		if !ok {
+			return status.Error(codes.Aborted, "watch closed")
+		}
+		receivedMsg, ok := received.(gproto.Message)
+		if !ok {
+			return status.Error(codes.Internal, "did not receive Message")
+		}
+		mMsg, ok := m.(gproto.Message)
+		if !ok {
+			return status.Error(codes.Internal, "pointer passed is not a Message")
+		}
+		gproto.Merge(mMsg, receivedMsg)
+	case <-l.ctx.Done():
+		return l.ctx.Err()
+	}
+	return nil
+}
+
+// Watch returns a local implementation of the VGService_WatchClient interface that is also implementing the VGService_WatchServer interface.
+// This is used to redirect the watch to the local caller via channel.
+// Any call other than send and receive will be ignored as they are not necessary.
+func (l *embeddedServiceClients) Watch(_ context.Context, _ *proto.Empty, _ ...grpc.CallOption) (proto.VGService_WatchClient, error) {
+	return l.vgWatch, nil
+}
+
+func (l *embeddedServiceClients) CreateLV(ctx context.Context, in *proto.CreateLVRequest, _ ...grpc.CallOption) (*proto.CreateLVResponse, error) {
+	return l.lvServiceServer.CreateLV(ctx, in)
+}
+
+func (l *embeddedServiceClients) RemoveLV(ctx context.Context, in *proto.RemoveLVRequest, _ ...grpc.CallOption) (*proto.Empty, error) {
+	return l.lvServiceServer.RemoveLV(ctx, in)
+}
+
+func (l *embeddedServiceClients) ResizeLV(ctx context.Context, in *proto.ResizeLVRequest, _ ...grpc.CallOption) (*proto.Empty, error) {
+	return l.lvServiceServer.ResizeLV(ctx, in)
+}
+
+func (l *embeddedServiceClients) CreateLVSnapshot(ctx context.Context, in *proto.CreateLVSnapshotRequest, _ ...grpc.CallOption) (*proto.CreateLVSnapshotResponse, error) {
+	return l.lvServiceServer.CreateLVSnapshot(ctx, in)
+}
+
+func (l *embeddedServiceClients) GetLVList(ctx context.Context, in *proto.GetLVListRequest, _ ...grpc.CallOption) (*proto.GetLVListResponse, error) {
+	return l.vgServiceServer.GetLVList(ctx, in)
+}
+
+func (l *embeddedServiceClients) GetFreeBytes(ctx context.Context, in *proto.GetFreeBytesRequest, _ ...grpc.CallOption) (*proto.GetFreeBytesResponse, error) {
+	return l.vgServiceServer.GetFreeBytes(ctx, in)
+}

--- a/lvmd/embed_test.go
+++ b/lvmd/embed_test.go
@@ -1,0 +1,66 @@
+package lvmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/topolvm/topolvm/lvmd/proto"
+)
+
+func TestNewEmbeddedServiceClients(t *testing.T) {
+	overprovisionRatio := float64(2.0)
+	tests := []struct {
+		name          string
+		deviceClasses []*DeviceClass
+	}{
+
+		{"volumegroup", []*DeviceClass{
+			{
+				Name:        "ssd",
+				VolumeGroup: "test_vgservice",
+			}},
+		},
+		{"thinpool", []*DeviceClass{
+			{
+				Name:        "ssd",
+				VolumeGroup: "test_vgservice",
+				Type:        TypeThin,
+				ThinPoolConfig: &ThinPoolConfig{
+					Name:               "test_pool",
+					OverprovisionRatio: overprovisionRatio,
+				},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			_, vgclient := NewEmbeddedServiceClients(ctx, NewDeviceClassManager(tt.deviceClasses), NewLvcreateOptionClassManager(nil))
+
+			watchClient, err := vgclient.Watch(ctx, &proto.Empty{}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			go func() {
+				if err := watchClient.SendMsg(&proto.WatchResponse{
+					FreeBytes: 1,
+				}); err != nil {
+					t.Error(err)
+					return
+				}
+			}()
+
+			res, err := watchClient.Recv()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.FreeBytes != 1 {
+				t.Fatal("no free byte set")
+			}
+
+		})
+	}
+}

--- a/pkg/topolvm-node/cmd/root.go
+++ b/pkg/topolvm-node/cmd/root.go
@@ -4,10 +4,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/topolvm/topolvm"
+	lvmd "github.com/topolvm/topolvm/pkg/lvmd/cmd"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -17,6 +19,8 @@ var config struct {
 	lvmdSocket  string
 	metricsAddr string
 	zapOpts     zap.Options
+	embedLvmd   bool
+	lvmd        lvmd.Config
 }
 
 var rootCmd = &cobra.Command{
@@ -31,7 +35,7 @@ NODE_NAME environment variable or --nodename flag.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return subMain()
+		return subMain(cmd.Context())
 	},
 }
 
@@ -50,6 +54,8 @@ func init() {
 	fs.StringVar(&config.lvmdSocket, "lvmd-socket", topolvm.DefaultLVMdSocket, "UNIX domain socket of lvmd service")
 	fs.StringVar(&config.metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	fs.String("nodename", "", "The resource name of the running node")
+	fs.BoolVar(&config.embedLvmd, "embed-lvmd", false, "Runs LVMD locally by embedding it instead of calling it externally via gRPC")
+	fs.StringVar(&cfgFilePath, "config", filepath.Join("/etc", "topolvm", "lvmd.yaml"), "config file")
 
 	viper.BindEnv("nodename", "NODE_NAME")
 	viper.BindPFlag("nodename", fs.Lookup("nodename"))

--- a/runners/metrics_exporter.go
+++ b/runners/metrics_exporter.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/topolvm/topolvm"
 	"github.com/topolvm/topolvm/lvmd/proto"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
@@ -62,7 +61,7 @@ var _ manager.LeaderElectionRunnable = &metricsExporter{}
 
 // NewMetricsExporter creates controller-runtime's manager.Runnable to run
 // a metrics exporter for a node.
-func NewMetricsExporter(conn *grpc.ClientConn, client client.Client, nodeName string) manager.Runnable {
+func NewMetricsExporter(vgServiceClient proto.VGServiceClient, client client.Client, nodeName string) manager.Runnable {
 
 	// metrics available under volumegroup subsystem
 	availableBytes := prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -123,7 +122,7 @@ func NewMetricsExporter(conn *grpc.ClientConn, client client.Client, nodeName st
 	return &metricsExporter{
 		client:         client,
 		nodeName:       nodeName,
-		vgService:      proto.NewVGServiceClient(conn),
+		vgService:      vgServiceClient,
 		availableBytes: availableBytes,
 		sizeBytes:      sizeBytes,
 		thinPool: &thinPoolMetricsExporter{


### PR DESCRIPTION
To run TopoLVM on Edge currently requires quite a lot of memory for a minimal installation. One of the main reasons for that is due to the lvmd container running as a separate DaemonSet from the topolvm-node DaemonSet. The idea is to combine these two into a single DaemonSet to reduce the memory footprint as they are usually run within the same pod anyway when lvmd is not running as a systemd service.

For more details see the [dedicated enhancement proposal](https://github.com/topolvm/topolvm/blob/main/docs/proposals/lvmd-within-topolvm-node.md#starting-lvmd-from-within-topolvm-node-instead-of-using-grpc)

TODO:
- [x] Create E2E Test Pipeline in the Matrix
- [x] Validate HELM Chart changes are correct