### PR TITLE
test: update the version of chart-testing-action

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -39,7 +39,7 @@ jobs:
         run: ./bin/helm-docs && git diff --no-patch --exit-code
 
       - name: "Set up chart-testing"
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: "Run chart-testing (lint)"
         run: ct lint --config ct.yaml


### PR DESCRIPTION
`Lint Charts` fails for sure for now. The error logs are:

```
INFO: Downloading bootstrap version 'v2.0.0' of cosign to verify version to be installed...
      https://storage.googleapis.com/cosign-releases/v2.0.0/cosign-linux-amd64
ERROR: Unable to validate cosign version: 'v2.0.0'
```

Probably something wrong happened in `cosign` v2.0.0 image. Let's bypass
this problem by upgrading `chart-testing-version`. This version uses
`cosign` v2.2.0 and it works fine:

```
INFO: Downloading bootstrap version 'v2.2.0' of cosign to verify version to be installed...
      https://github.com/sigstore/cosign/releases/download/v2.2.0/cosign-linux-amd64