### PR TITLE
chore: remove cybozu-log and replace with zap / controller-runtime log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/container-storage-interface/spec v1.6.0
-	github.com/cybozu-go/log v1.6.0
 	github.com/cybozu-go/well v1.10.0
 	github.com/go-logr/logr v1.2.4
 	github.com/golang/protobuf v1.5.3
@@ -39,6 +38,7 @@ require (
 	github.com/aokoli/goutils v1.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cybozu-go/log v1.6.0 // indirect
 	github.com/cybozu-go/netutil v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect

--- a/lvmd/command/lvm_json.go
+++ b/lvmd/command/lvm_json.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"strings"
@@ -158,7 +159,7 @@ func parseFullReportResult(data []byte) ([]vg, []lv, error) {
 }
 
 // Issue single lvm command that retrieves everything we need in one call and get the output as JSON
-func getLVMState() ([]vg, []lv, error) {
+func getLVMState(ctx context.Context) ([]vg, []lv, error) {
 	args := []string{
 		"--reportformat", "json",
 		"--units", "b", "--nosuffix",
@@ -172,7 +173,7 @@ func getLVMState() ([]vg, []lv, error) {
 		"--configreport", "pvseg", "-o,",
 		"--configreport", "seg", "-o,",
 	}
-	stdout, err := callLVMWithStdout("fullreport", args...)
+	stdout, err := callLVMWithStdout(ctx, "fullreport", args...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lvmd/lvservice_test.go
+++ b/lvmd/lvservice_test.go
@@ -6,11 +6,13 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/topolvm/topolvm/lvmd/command"
 	"github.com/topolvm/topolvm/lvmd/proto"
 	"github.com/topolvm/topolvm/lvmd/testutils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func TestLVService(t *testing.T) {
@@ -18,20 +20,21 @@ func TestLVService(t *testing.T) {
 	if uid != 0 {
 		t.Skip("run as root")
 	}
+	ctx := ctrl.LoggerInto(context.Background(), testr.New(t))
 
 	vgName := "test_lvservice"
-	loop, err := testutils.MakeLoopbackDevice(vgName)
+	loop, err := testutils.MakeLoopbackDevice(ctx, vgName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = testutils.MakeLoopbackVG(vgName, loop)
+	err = testutils.MakeLoopbackVG(ctx, vgName, loop)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer testutils.CleanLoopbackVG(vgName, []string{loop}, []string{vgName})
 
-	vg, err := command.FindVolumeGroup(vgName)
+	vg, err := command.FindVolumeGroup(ctx, vgName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +48,7 @@ func TestLVService(t *testing.T) {
 	overprovisionRatio := float64(10.0)
 	poolName := "test_pool"
 	poolSize := uint64(1 << 30)
-	pool, err := vg.CreatePool(poolName, poolSize)
+	pool, err := vg.CreatePool(ctx, poolName, poolSize)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +104,7 @@ func TestLVService(t *testing.T) {
 		t.Error("failed to create logical volume")
 	}
 
-	if err := vg.Update(); err != nil {
+	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -141,7 +144,7 @@ func TestLVService(t *testing.T) {
 		t.Errorf("unexpected count: %d", count)
 	}
 
-	if err := vg.Update(); err != nil {
+	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -177,7 +180,7 @@ func TestLVService(t *testing.T) {
 		t.Errorf("unexpected count: %d", count)
 	}
 
-	if err := vg.Update(); err != nil {
+	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
 	_, err = vg.FindVolume("test1")
@@ -214,7 +217,7 @@ func TestLVService(t *testing.T) {
 		t.Error("failed to create logical volume")
 	}
 
-	if err := vg.Update(); err != nil {
+	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,7 +257,7 @@ func TestLVService(t *testing.T) {
 		t.Errorf("unexpected count: %d", count)
 	}
 
-	if err := vg.Update(); err != nil {
+	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -277,7 +280,7 @@ func TestLVService(t *testing.T) {
 		t.Errorf("unexpected count: %d", count)
 	}
 
-	if err := vg.Update(); err != nil {
+	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
 	_, err = pool.FindVolume("test1")
@@ -317,7 +320,7 @@ func TestLVService(t *testing.T) {
 		t.Error("failed to create logical volume")
 	}
 
-	if err := vg.Update(); err != nil {
+	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -373,7 +376,7 @@ func TestLVService(t *testing.T) {
 		t.Error("failed to create logical volume")
 	}
 
-	if err := vg.Update(); err != nil {
+	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -425,7 +428,7 @@ func TestLVService(t *testing.T) {
 		t.Error("failed to create logical volume")
 	}
 
-	if err := vg.Update(); err != nil {
+	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lvmd/testutils/test_utils.go
+++ b/lvmd/testutils/test_utils.go
@@ -2,14 +2,15 @@ package testutils
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"strings"
 
-	"github.com/cybozu-go/log"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func MakeLoopbackDevice(name string) (string, error) {
+func MakeLoopbackDevice(ctx context.Context, name string) (string, error) {
 	command := exec.Command("losetup", "-f")
 	command.Stderr = os.Stderr
 	loop := bytes.Buffer{}
@@ -21,41 +22,33 @@ func MakeLoopbackDevice(name string) (string, error) {
 	loopDev := strings.TrimRight(loop.String(), "\n")
 	out, err := exec.Command("truncate", "--size=4G", name).CombinedOutput()
 	if err != nil {
-		log.Error("failed to truncate", map[string]interface{}{
-			"output": string(out),
-		})
+		log.FromContext(ctx).Error(err, "failed truncate", "output", string(out))
 		return "", err
 	}
 	out, err = exec.Command("losetup", loopDev, name).CombinedOutput()
 	if err != nil {
-		log.Error("failed to losetup", map[string]interface{}{
-			"output": string(out),
-		})
+		log.FromContext(ctx).Error(err, "failed losetup", "output", string(out))
 		return "", err
 	}
 	return loopDev, nil
 }
 
 // MakeLoopbackVG creates a VG made from loopback device by losetup
-func MakeLoopbackVG(name string, devices ...string) error {
+func MakeLoopbackVG(ctx context.Context, name string, devices ...string) error {
 	args := append([]string{name}, devices...)
 	out, err := exec.Command("vgcreate", args...).CombinedOutput()
 	if err != nil {
-		log.Error("failed to vgcreate", map[string]interface{}{
-			"output": string(out),
-		})
+		log.FromContext(ctx).Error(err, "failed vgcreate", "output", string(out))
 		return err
 	}
 	return nil
 }
 
-func MakeLoopbackLV(name string, vg string) error {
+func MakeLoopbackLV(ctx context.Context, name string, vg string) error {
 	args := []string{"-L1G", "-n", name, vg}
 	out, err := exec.Command("lvcreate", args...).CombinedOutput()
 	if err != nil {
-		log.Error("failed lvcreate", map[string]interface{}{
-			"output": string(out),
-		})
+		log.FromContext(ctx).Error(err, "failed lvcreate", "output", string(out))
 		return err
 	}
 	return nil

--- a/pkg/lvmd/cmd/config.go
+++ b/pkg/lvmd/cmd/config.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
-	"github.com/cybozu-go/log"
 	"github.com/topolvm/topolvm"
 	"github.com/topolvm/topolvm/lvmd"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 )
 
@@ -23,7 +24,7 @@ var config = &Config{
 	SocketName: topolvm.DefaultLVMdSocket,
 }
 
-func loadConfFile(cfgFilePath string) error {
+func loadConfFile(ctx context.Context, cfgFilePath string) error {
 	b, err := os.ReadFile(cfgFilePath)
 	if err != nil {
 		return err
@@ -32,10 +33,10 @@ func loadConfFile(cfgFilePath string) error {
 	if err != nil {
 		return err
 	}
-	log.Info("configuration file loaded: ", map[string]interface{}{
-		"device_classes": config.DeviceClasses,
-		"socket_name":    config.SocketName,
-		"file_name":      cfgFilePath,
-	})
+	log.FromContext(ctx).Info("configuration file loaded",
+		"device_classes", config.DeviceClasses,
+		"socket_name", config.SocketName,
+		"file_name", cfgFilePath,
+	)
 	return nil
 }

--- a/pkg/lvmd/cmd/health.go
+++ b/pkg/lvmd/cmd/health.go
@@ -16,12 +16,12 @@ var healthCmd = &cobra.Command{
 	Short: "Health check for lvmd server",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		return healthSubMain(config)
+		return healthSubMain(cmd.Context(), config)
 	},
 }
 
-func healthSubMain(config *Config) error {
-	err := loadConfFile(cfgFilePath)
+func healthSubMain(ctx context.Context, config *Config) error {
+	err := loadConfFile(ctx, cfgFilePath)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,6 @@ func healthSubMain(config *Config) error {
 	defer conn.Close()
 	client := grpc_health_v1.NewHealthClient(conn)
 
-	ctx := context.Background()
 	res, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes https://github.com/topolvm/topolvm/issues/773 by replacing every log statement in lvmd with a controller runtime logger coming from the command or controller context which aligns it with the other controllers. Effectively makes github.com/cybozu-go/log an indirect due to github.com/cybozu-go/well. Did not remove that for scope reasons