### PR TITLE
fix condition preventing multiple default device-classes

### DIFF
--- a/lvmd/device_class_manager.go
+++ b/lvmd/device_class_manager.go
@@ -131,7 +131,7 @@ func ValidateDeviceClasses(deviceClasses []*DeviceClass) error {
 			return fmt.Errorf("stripe-size format is \"Size[k|UNIT]\": %s", dc.Name)
 		}
 	}
-	if countDefault != 1 {
+	if countDefault > 1 {
 		return errors.New("should have only one default device-class")
 	}
 	return nil


### PR DESCRIPTION
When there are multiple volume groups and device-classes and more than 1 node then "!=1" condition is triggering false error on secondary and next nodes.