### PR TITLE
Use capacity tracking by default

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -3,9 +3,9 @@
 
 ## Prerequisites
 
-* Configure `kube-scheduler` on the underlying nodes, ref: https://github.com/topolvm/topolvm/tree/master/deploy#configure-kube-scheduler
 * `cert-manager` version `v1.7.0+` installed. ref: https://cert-manager.io/
 * Requires at least `v3.5.0+` version of helm to support
+* (Option) Configure `kube-scheduler` on the underlying nodes if you use topolvm-scheduler, ref: https://github.com/topolvm/topolvm/tree/master/deploy#configure-kube-scheduler
 
 ## :warning: Migration from kustomize to Helm
 
@@ -22,9 +22,9 @@ helm repo update
 
 ## Dependencies
 
-| Repository | Name	| Version |
-| ---------- | ---- | ------- |
-| https://charts.jetstack.io | cert-manager | 1.7.0 |
+| Repository                 | Name         | Version |
+| -------------------------- | ------------ | ------- |
+| https://charts.jetstack.io | cert-manager | 1.7.0   |
 
 ## Quick start
 
@@ -71,10 +71,11 @@ Set the `cert-manager.enabled=true` parameter when installing topolvm chart:
 helm install --namespace=topolvm-system topolvm topolvm/topolvm --set cert-manager.enabled=true
 ```
 
-## Configure kube-scheduler
+## (Option) Configure kube-scheduler
 
+If you use topolvm-scheduler not enabled in default, you need to configure kube-scheduler to use topolvm-scheduler extender.
 The current Chart does not provide an option to make kube-scheduler configurable.
-You need to configure kube-scheduler to use topolvm-scheduler extender by referring to the following document.
+To configure kube-scheduler, see the following document.
 
 [deploy/README.md#configure-kube-scheduler](../../deploy/README.md#configure-kube-scheduler)
 
@@ -102,7 +103,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | controller.prometheus.podMonitor.scrapeTimeout | string | `""` | Scrape timeout. If not set, the Prometheus default scrape timeout is used. |
 | controller.replicaCount | int | `2` | Number of replicas for CSI controller service. |
 | controller.securityContext.enabled | bool | `true` | Enable securityContext. |
-| controller.storageCapacityTracking.enabled | bool | `false` | Enable Storage Capacity Tracking for csi-provisioner. |
+| controller.storageCapacityTracking.enabled | bool | `true` | Enable Storage Capacity Tracking for csi-provisioner. |
 | controller.terminationGracePeriodSeconds | int | `nil` | Specify terminationGracePeriodSeconds. |
 | controller.tolerations | list | `[]` | Specify tolerations. # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | controller.updateStrategy | object | `{}` | Specify updateStrategy. |
@@ -185,7 +186,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | scheduler.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]}]}}}` | Specify affinity on the Deployment or DaemonSet. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | scheduler.args | list | `[]` | Arguments to be passed to the command. |
 | scheduler.deployment.replicaCount | int | `2` | Number of replicas for Deployment. |
-| scheduler.enabled | bool | `true` | If true, enable scheduler extender for TopoLVM |
+| scheduler.enabled | bool | `false` | If true, enable scheduler extender for TopoLVM |
 | scheduler.labels | object | `{}` | Additional labels to be added to the Deployment or Daemonset. |
 | scheduler.minReadySeconds | int | `nil` | Specify minReadySeconds on the Deployment or DaemonSet. |
 | scheduler.nodeSelector | object | `{}` | Specify nodeSelector on the Deployment or DaemonSet. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
@@ -209,7 +210,7 @@ You need to configure kube-scheduler to use topolvm-scheduler extender by referr
 | useLegacy | bool | `false` | If true, the legacy plugin name and legacy custom resource group is used(topolvm.cybozu.com). |
 | webhook.caBundle | string | `nil` | Specify the certificate to be used for AdmissionWebhook. |
 | webhook.existingCertManagerIssuer | object | `{}` | Specify the cert-manager issuer to be used for AdmissionWebhook. |
-| webhook.podMutatingWebhook.enabled | bool | `true` | Enable Pod MutatingWebhook. |
+| webhook.podMutatingWebhook.enabled | bool | `false` | Enable Pod MutatingWebhook. |
 | webhook.pvcMutatingWebhook.enabled | bool | `true` | Enable PVC MutatingWebhook. |
 
 ## Generate Manifests

--- a/charts/topolvm/README.md.gotmpl
+++ b/charts/topolvm/README.md.gotmpl
@@ -3,9 +3,9 @@
 
 ## Prerequisites
 
-* Configure `kube-scheduler` on the underlying nodes, ref: https://github.com/topolvm/topolvm/tree/master/deploy#configure-kube-scheduler
 * `cert-manager` version `v1.7.0+` installed. ref: https://cert-manager.io/
 * Requires at least `v3.5.0+` version of helm to support
+* (Option) Configure `kube-scheduler` on the underlying nodes if you use topolvm-scheduler, ref: https://github.com/topolvm/topolvm/tree/master/deploy#configure-kube-scheduler
 
 ## :warning: Migration from kustomize to Helm
 
@@ -22,9 +22,9 @@ helm repo update
 
 ## Dependencies
 
-| Repository | Name	| Version |
-| ---------- | ---- | ------- |
-| https://charts.jetstack.io | cert-manager | 1.7.0 |
+| Repository                 | Name         | Version |
+| -------------------------- | ------------ | ------- |
+| https://charts.jetstack.io | cert-manager | 1.7.0   |
 
 ## Quick start
 
@@ -71,10 +71,11 @@ Set the `cert-manager.enabled=true` parameter when installing topolvm chart:
 helm install --namespace=topolvm-system topolvm topolvm/topolvm --set cert-manager.enabled=true
 ```
 
-## Configure kube-scheduler
+## (Option) Configure kube-scheduler
 
+If you use topolvm-scheduler not enabled in default, you need to configure kube-scheduler to use topolvm-scheduler extender.
 The current Chart does not provide an option to make kube-scheduler configurable.
-You need to configure kube-scheduler to use topolvm-scheduler extender by referring to the following document.
+To configure kube-scheduler, see the following document.
 
 [deploy/README.md#configure-kube-scheduler](../../deploy/README.md#configure-kube-scheduler)
 

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -39,7 +39,7 @@ image:
 # A scheduler extender for TopoLVM
 scheduler:
   # scheduler.enabled --  If true, enable scheduler extender for TopoLVM
-  enabled: true
+  enabled: false
 
   # scheduler.args -- Arguments to be passed to the command.
   args: []
@@ -347,7 +347,7 @@ controller:
 
   storageCapacityTracking:
     # controller.storageCapacityTracking.enabled -- Enable Storage Capacity Tracking for csi-provisioner.
-    enabled: false
+    enabled: true
 
   securityContext:
     # controller.securityContext.enabled -- Enable securityContext.
@@ -619,7 +619,7 @@ webhook:
     # name: webhook-issuer
   podMutatingWebhook:
     # webhook.podMutatingWebhook.enabled -- Enable Pod MutatingWebhook.
-    enabled: true
+    enabled: false
   pvcMutatingWebhook:
     # webhook.pvcMutatingWebhook.enabled -- Enable PVC MutatingWebhook.
     enabled: true

--- a/e2e/manifests/values/daemonset-lvmd-storage-capacity.yaml
+++ b/e2e/manifests/values/daemonset-lvmd-storage-capacity.yaml
@@ -5,8 +5,6 @@ image:
 
 controller:
   replicaCount: 1
-  storageCapacityTracking:
-    enabled: true
   securityContext:
     enabled: false
   # sanity test requires that the controller mounts this hostPath to communicate with it
@@ -15,9 +13,6 @@ controller:
       hostPath:
         path: /var/lib/kubelet/plugins/topolvm.io/controller
         type: DirectoryOrCreate
-
-scheduler:
-  enabled: false
 
 lvmd:
   socketName: /tmp/topolvm/daemonset_lvmd/lvmd.sock
@@ -70,10 +65,6 @@ storageClasses:
       allowVolumeExpansion: true
       additionalParameters:
         topolvm.io/device-class: "thin"
-
-webhook:
-  podMutatingWebhook:
-    enabled: false
 
 cert-manager:
   enabled: true

--- a/e2e/manifests/values/daemonset-scheduler-legacy.yaml
+++ b/e2e/manifests/values/daemonset-scheduler-legacy.yaml
@@ -5,6 +5,8 @@ image:
 
 controller:
   replicaCount: 1
+  storageCapacityTracking:
+    enabled: false
   securityContext:
     enabled: false
   nodeSelector:
@@ -17,6 +19,7 @@ controller:
         type: DirectoryOrCreate
 
 scheduler:
+  enabled: true
   type: daemonset
 
 lvmd:
@@ -39,3 +42,7 @@ cert-manager:
   enabled: true
 
 useLegacy: true
+
+webhook:
+  podMutatingWebhook:
+    enabled: true

--- a/e2e/manifests/values/daemonset-scheduler.yaml
+++ b/e2e/manifests/values/daemonset-scheduler.yaml
@@ -5,6 +5,8 @@ image:
 
 controller:
   replicaCount: 1
+  storageCapacityTracking:
+    enabled: false
   securityContext:
     enabled: false
   nodeSelector:
@@ -17,6 +19,7 @@ controller:
         type: DirectoryOrCreate
 
 scheduler:
+  enabled: true
   type: daemonset
 
 lvmd:
@@ -37,3 +40,7 @@ storageClasses:
 
 cert-manager:
   enabled: true
+
+webhook:
+  podMutatingWebhook:
+    enabled: true

--- a/e2e/manifests/values/deployment-scheduler.yaml
+++ b/e2e/manifests/values/deployment-scheduler.yaml
@@ -5,6 +5,8 @@ image:
 
 controller:
   replicaCount: 1
+  storageCapacityTracking:
+    enabled: false
   securityContext:
     enabled: false
   nodeSelector:
@@ -17,6 +19,7 @@ controller:
         type: DirectoryOrCreate
 
 scheduler:
+  enabled: true
   type: deployment
   deployment:
     replicaCount: 2
@@ -47,3 +50,7 @@ storageClasses:
 
 cert-manager:
   enabled: true
+
+webhook:
+  podMutatingWebhook:
+    enabled: true

--- a/e2e/manifests/values/embedded-lvmd-storage-capacity.yaml
+++ b/e2e/manifests/values/embedded-lvmd-storage-capacity.yaml
@@ -5,8 +5,6 @@ image:
 
 controller:
   replicaCount: 1
-  storageCapacityTracking:
-    enabled: true
   securityContext:
     enabled: false
   # sanity test requires that the controller mounts this hostPath to communicate with it
@@ -15,9 +13,6 @@ controller:
       hostPath:
         path: /var/lib/kubelet/plugins/topolvm.io/controller
         type: DirectoryOrCreate
-
-scheduler:
-  enabled: false
 
 node:
   lvmdEmbedded: true
@@ -71,10 +66,6 @@ storageClasses:
       allowVolumeExpansion: true
       additionalParameters:
         topolvm.io/device-class: "thin"
-
-webhook:
-  podMutatingWebhook:
-    enabled: false
 
 cert-manager:
   enabled: true

--- a/e2e/manifests/values/storage-capacity.yaml
+++ b/e2e/manifests/values/storage-capacity.yaml
@@ -5,8 +5,6 @@ image:
 
 controller:
   replicaCount: 1
-  storageCapacityTracking:
-    enabled: true
   securityContext:
     enabled: false
   nodeSelector:
@@ -17,9 +15,6 @@ controller:
       hostPath:
         path: /var/lib/kubelet/plugins/topolvm.io/controller
         type: DirectoryOrCreate
-
-scheduler:
-  enabled: false
 
 lvmd:
   managed: false
@@ -36,10 +31,6 @@ storageClasses:
       allowVolumeExpansion: true
       additionalParameters:
         topolvm.io/device-class: "ssd"
-
-webhook:
-  podMutatingWebhook:
-    enabled: false
 
 cert-manager:
   enabled: true

--- a/example/Makefile
+++ b/example/Makefile
@@ -16,7 +16,6 @@ BACKING_STORE := ./build
 BUILD_IMAGE := false
 
 HELM_VALUES_FILE := values.yaml
-SCHEDULER_CONFIG := scheduler-config.yaml
 LOGICALVOLUME_GK_NAME := logicalvolume.topolvm.io
 DOMAIN_NAME := topolvm.io
 
@@ -36,7 +35,6 @@ build/topolvm.img: $(GO_FILES)
 
 .PHONY: run
 run:
-	rm -f $(TMPDIR)/scheduler/scheduler-config.yaml
 	$(MAKE) start-lvmd
 	$(MAKE) launch-kind
 	if [ "$(BUILD_IMAGE)" = "true" ]; then \
@@ -72,16 +70,12 @@ setup: $(KUBECTL)
 clean: stop-lvmd
 	rm -rf bin/ build/ $(TMPDIR)
 
-$(TMPDIR)/scheduler/scheduler-config.yaml: ../deploy/scheduler-config/$(SCHEDULER_CONFIG)
-	mkdir -p $(TMPDIR)/scheduler
-	cp $< $@
-
 $(TMPDIR)/lvmd/lvmd.yaml: ../deploy/lvmd-config/lvmd.yaml
 	mkdir -p $(TMPDIR)/lvmd
 	sed -e 's=/run/topolvm/lvmd.sock=$(TMPDIR)/lvmd/lvmd.sock=; s=spare-gb: 10=spare-gb: 1=' $< > $@
 
 .PHONY: launch-kind
-launch-kind: $(TMPDIR)/scheduler/scheduler-config.yaml
+launch-kind:
 	$(MAKE) shutdown-kind
 	$(SUDO) rm -rf $(TMPDIR)/controller $(TMPDIR)/worker*
 	sed 's/@KUBERNETES_VERSION@/$(KUBERNETES_VERSION)/; s=@TMPDIR@=$(TMPDIR)='  kind/topolvm-cluster.yaml > $(TMPDIR)/topolvm-cluster.yaml

--- a/example/kind/topolvm-cluster.yaml
+++ b/example/kind/topolvm-cluster.yaml
@@ -10,19 +10,9 @@ kubeadmConfigPatches:
   kubernetesVersion: "v@KUBERNETES_VERSION@"
   networking:
     serviceSubnet: 10.0.0.0/16
-  scheduler:
-    extraVolumes:
-      - name: "config"
-        hostPath: /mnt/host/scheduler
-        mountPath: /var/lib/scheduler
-        readOnly: true
-    extraArgs:
-      config: /var/lib/scheduler/scheduler-config.yaml
 nodes:
 - role: control-plane
   extraMounts:
-    - containerPath: /mnt/host/scheduler
-      hostPath: "@TMPDIR@/scheduler"
     - containerPath: /var/lib/kubelet
       hostPath: "@TMPDIR@/controller"
       propagation: Bidirectional


### PR DESCRIPTION
The topolvm-scheduler controls the scheduling algorithm sophisticatedly, but it is complicated to set up. To ease setup, use capacity tracking by default.