### PR TITLE
Fix typo

### DIFF
--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -52,7 +52,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/e2e-k8s-workflow.yaml
     with:
-      test_scheduler_extender_type: "deamonset"
+      test_scheduler_extender_type: "daemonset"
       test_legacy: "false"
 
   scheduler-manifest:


### PR DESCRIPTION
This was introduced in 88136c1f (Dedup helm values files, 2023-12-20), it caused a regression which runs tests using storage capacity tracking rather than topolvm-scheduler.