### PR TITLE
ci: run `make install-helm-docs` in create-chart-update-pr.yaml

### DIFF
--- a/.github/workflows/create-chart-update-pr.yaml
+++ b/.github/workflows/create-chart-update-pr.yaml
@@ -39,7 +39,7 @@ jobs:
           sed -r -i "s/^version: [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/version: ${{ inputs.chart-version }}/g" charts/topolvm/Chart.yaml
           sed -r -i "s/ghcr.io\/topolvm\/topolvm-with-sidecar:[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/ghcr.io\/topolvm\/topolvm-with-sidecar:${{ inputs.app-version }}/g" charts/topolvm/Chart.yaml
           sed -r -i "s/ghcr.io\/topolvm\/topolvm:[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/ghcr.io\/topolvm\/topolvm:${{ inputs.app-version }}/g" charts/topolvm/Chart.yaml
-          make generate-helm-docs
+          make install-helm-docs && make generate-helm-docs
       - name: Issue an access token
         uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
Fix a bug in #804; run `make install-helm-docs` to use `helm-docs`. [I tested this patch in my forked repo](https://github.com/ushitora-anqou/topolvm/actions/runs/7456955996/job/20288422793#step:6:41), and it should be okay.