### PR TITLE
Use anonymous DC name in tests

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -322,7 +322,7 @@ func testE2E() {
 					if node.Name == "topolvm-e2e-control-plane" {
 						continue
 					}
-					strCap, ok := node.Annotations[topolvm.GetCapacityKeyPrefix()+"ssd"]
+					strCap, ok := node.Annotations[topolvm.GetCapacityKeyPrefix()+"dc1"]
 					if !ok {
 						return fmt.Errorf("capacity is not annotated: %s", node.Name)
 					}
@@ -515,7 +515,7 @@ func testE2E() {
 				continue
 			}
 
-			strCap, ok := node.Annotations[topolvm.GetCapacityKeyPrefix()+"ssd"]
+			strCap, ok := node.Annotations[topolvm.GetCapacityKeyPrefix()+"dc1"]
 			Expect(ok).To(Equal(true), "capacity is not annotated: "+node.Name)
 			capacity, err := strconv.Atoi(strCap)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/e2e/lvmd1.yaml
+++ b/e2e/lvmd1.yaml
@@ -1,10 +1,10 @@
 socket-name: /tmp/topolvm/lvmd1/lvmd.sock
 device-classes:
-  - name: "ssd"
+  - name: "dc1"
     volume-group: "node1-myvg1"
     default: true
     spare-gb: 1
-  - name: "hdd1"
+  - name: "dc2"
     volume-group: "node1-myvg2"
     spare-gb: 1
   - name: "raid"

--- a/e2e/lvmd2.yaml
+++ b/e2e/lvmd2.yaml
@@ -1,9 +1,9 @@
 socket-name: /tmp/topolvm/lvmd2/lvmd.sock
 device-classes:
-  - name: "ssd"
+  - name: "dc1"
     volume-group: "node2-myvg1"
     spare-gb: 1
-  - name: "hdd1"
+  - name: "dc2"
     volume-group: "node2-myvg2"
     spare-gb: 1
   - name: "raid"

--- a/e2e/lvmd3.yaml
+++ b/e2e/lvmd3.yaml
@@ -1,9 +1,9 @@
 socket-name: /tmp/topolvm/lvmd3/lvmd.sock
 device-classes:
-  - name: "ssd"
+  - name: "dc1"
     volume-group: "node3-myvg1"
     spare-gb: 1
-  - name: "hdd2"
+  - name: "dc3"
     volume-group: "node3-myvg2"
     spare-gb: 1
   - name: "raid"

--- a/e2e/manifests/values/base.yaml
+++ b/e2e/manifests/values/base.yaml
@@ -17,14 +17,14 @@ controller:
 lvmd:
   socketName: /tmp/topolvm/lvmd.sock
   deviceClasses:
-    - name: "ssd"
+    - name: "dc1"
       volume-group: "node-myvg1"
       default: true
       spare-gb: 1
-    - name: "hdd1"
+    - name: "dc2"
       volume-group: "node-myvg2"
       spare-gb: 1
-    - name: "hdd2"
+    - name: "dc3"
       volume-group: "node-myvg3"
       spare-gb: 1
     - name: "raid"
@@ -57,7 +57,7 @@ storageClasses:
       volumeBindingMode: WaitForFirstConsumer
       allowVolumeExpansion: true
       additionalParameters:
-        '{{ include "topolvm.pluginName" . }}/device-class': "ssd"
+        '{{ include "topolvm.pluginName" . }}/device-class': "dc1"
   - name: topolvm-provisioner-thin
     storageClass:
       fsType: xfs
@@ -71,19 +71,19 @@ storageClasses:
       isDefaultClass: false
       volumeBindingMode: Immediate
       additionalParameters:
-        '{{ include "topolvm.pluginName" . }}/device-class': "ssd"
+        '{{ include "topolvm.pluginName" . }}/device-class': "dc1"
   - name: topolvm-provisioner2
     storageClass:
       isDefaultClass: false
       volumeBindingMode: WaitForFirstConsumer
       additionalParameters:
-        '{{ include "topolvm.pluginName" . }}/device-class': "hdd1"
+        '{{ include "topolvm.pluginName" . }}/device-class': "dc2"
   - name: topolvm-provisioner3
     storageClass:
       isDefaultClass: false
       volumeBindingMode: WaitForFirstConsumer
       additionalParameters:
-        '{{ include "topolvm.pluginName" . }}/device-class': "hdd2"
+        '{{ include "topolvm.pluginName" . }}/device-class': "dc3"
   - name: topolvm-provisioner-default
     storageClass:
       isDefaultClass: false
@@ -95,7 +95,7 @@ storageClasses:
       volumeBindingMode: WaitForFirstConsumer
       allowVolumeExpansion: true
       additionalParameters:
-        '{{ include "topolvm.pluginName" . }}/device-class': "ssd"
+        '{{ include "topolvm.pluginName" . }}/device-class': "dc1"
       mountOptions:
         - debug
   - name: topolvm-provisioner-not-found-device

--- a/e2e/scheduling_test.go
+++ b/e2e/scheduling_test.go
@@ -107,7 +107,7 @@ func testScheduling() {
 		err = getObjects(&node, "node", nodeName)
 		Expect(err).ShouldNot(HaveOccurred())
 		size = func() string {
-			sizeStr, exists := node.Annotations[topolvm.GetCapacityKeyPrefix()+"hdd1"]
+			sizeStr, exists := node.Annotations[topolvm.GetCapacityKeyPrefix()+"dc2"]
 			if !exists {
 				Expect(errors.New("size is not found")).ShouldNot(HaveOccurred())
 			}

--- a/hook/mutate_pod_test.go
+++ b/hook/mutate_pod_test.go
@@ -203,7 +203,7 @@ var _ = Describe("pod mutation webhook", func() {
 		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests[topolvm.GetCapacityResource()]
 		limit := pod.Spec.Containers[0].Resources.Limits[topolvm.GetCapacityResource()]
-		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"ssd"]
+		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"dc1"]
 		Expect(request.Value()).Should(Equal(int64(1)))
 		Expect(limit.Value()).Should(Equal(int64(1)))
 		Expect(capacity).Should(Equal(strconv.Itoa(100 << 30)))
@@ -237,20 +237,20 @@ var _ = Describe("pod mutation webhook", func() {
 		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests[topolvm.GetCapacityResource()]
 		limit := pod.Spec.Containers[0].Resources.Limits[topolvm.GetCapacityResource()]
-		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"ssd"]
+		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"dc1"]
 		Expect(request.Value()).Should(Equal(int64(1)))
 		Expect(limit.Value()).Should(Equal(int64(1)))
 		Expect(capacity).Should(Equal(strconv.Itoa(100 << 30)))
 
 		request = pod.Spec.Containers[0].Resources.Requests[topolvm.GetCapacityResource()]
 		limit = pod.Spec.Containers[0].Resources.Limits[topolvm.GetCapacityResource()]
-		capacity = pod.Annotations[topolvm.GetCapacityKeyPrefix()+"hdd1"]
+		capacity = pod.Annotations[topolvm.GetCapacityKeyPrefix()+"dc2"]
 		Expect(request.Value()).Should(Equal(int64(1)))
 		Expect(limit.Value()).Should(Equal(int64(1)))
 		Expect(capacity).Should(Equal(strconv.Itoa(3 << 30)))
 
 		request = pod.Spec.Containers[0].Resources.Requests[topolvm.GetCapacityResource()]
-		capacity = pod.Annotations[topolvm.GetCapacityKeyPrefix()+"hdd2"]
+		capacity = pod.Annotations[topolvm.GetCapacityKeyPrefix()+"dc3"]
 		limit = pod.Spec.Containers[0].Resources.Limits[topolvm.GetCapacityResource()]
 		Expect(request.Value()).Should(Equal(int64(1)))
 		Expect(limit.Value()).Should(Equal(int64(1)))
@@ -285,7 +285,7 @@ var _ = Describe("pod mutation webhook", func() {
 		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests[topolvm.GetCapacityResource()]
 		limit := pod.Spec.Containers[0].Resources.Limits[topolvm.GetCapacityResource()]
-		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"ssd"]
+		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"dc1"]
 		Expect(request.Value()).Should(Equal(int64(1)))
 		Expect(limit.Value()).Should(Equal(int64(1)))
 		Expect(capacity).Should(Equal(strconv.Itoa(100 << 30)))
@@ -313,7 +313,7 @@ var _ = Describe("pod mutation webhook", func() {
 		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests[topolvm.GetCapacityResource()]
 		limit := pod.Spec.Containers[0].Resources.Limits[topolvm.GetCapacityResource()]
-		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"ssd"]
+		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"dc1"]
 		Expect(request.Value()).Should(Equal(int64(1)))
 		Expect(limit.Value()).Should(Equal(int64(1)))
 		Expect(capacity).Should(Equal(strconv.Itoa(100 << 30)))
@@ -376,7 +376,7 @@ var _ = Describe("pod mutation webhook", func() {
 
 		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests[topolvm.GetCapacityResource()]
-		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"ssd"]
+		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"dc1"]
 		Expect(request.Value()).Should(Equal(int64(1)))
 		Expect(capacity).Should(Equal(strconv.Itoa((100 << 30) + (2<<30 - 1))))
 	})
@@ -416,7 +416,7 @@ var _ = Describe("pod mutation webhook", func() {
 		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests[topolvm.GetCapacityResource()]
 		limit := pod.Spec.Containers[0].Resources.Limits[topolvm.GetCapacityResource()]
-		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"ssd"]
+		capacity := pod.Annotations[topolvm.GetCapacityKeyPrefix()+"dc1"]
 		Expect(request.Value()).Should(Equal(int64(1)))
 		Expect(limit.Value()).Should(Equal(int64(1)))
 		Expect(capacity).Should(Equal(strconv.Itoa(500 * mebibyte)))

--- a/hook/suite_test.go
+++ b/hook/suite_test.go
@@ -60,7 +60,7 @@ func setupCommonResources() {
 		Provisioner:       "topolvm.io",
 		VolumeBindingMode: modePtr(storagev1.VolumeBindingWaitForFirstConsumer),
 		Parameters: map[string]string{
-			topolvm.GetDeviceClassKey(): "ssd",
+			topolvm.GetDeviceClassKey(): "dc1",
 		},
 	}
 	err := k8sClient.Create(testCtx, sc)
@@ -73,7 +73,7 @@ func setupCommonResources() {
 		Provisioner:       "topolvm.io",
 		VolumeBindingMode: modePtr(storagev1.VolumeBindingWaitForFirstConsumer),
 		Parameters: map[string]string{
-			topolvm.GetDeviceClassKey(): "hdd1",
+			topolvm.GetDeviceClassKey(): "dc2",
 		},
 	}
 	err = k8sClient.Create(testCtx, sc)
@@ -86,7 +86,7 @@ func setupCommonResources() {
 		Provisioner:       "topolvm.io",
 		VolumeBindingMode: modePtr(storagev1.VolumeBindingWaitForFirstConsumer),
 		Parameters: map[string]string{
-			topolvm.GetDeviceClassKey(): "hdd2",
+			topolvm.GetDeviceClassKey(): "dc3",
 		},
 	}
 	err = k8sClient.Create(testCtx, sc)
@@ -99,7 +99,7 @@ func setupCommonResources() {
 		Provisioner:       "topolvm.io",
 		VolumeBindingMode: modePtr(storagev1.VolumeBindingImmediate),
 		Parameters: map[string]string{
-			topolvm.GetDeviceClassKey(): "ssd",
+			topolvm.GetDeviceClassKey(): "dc1",
 		},
 	}
 	err = k8sClient.Create(testCtx, sc)

--- a/lvmd/device_class_manager_test.go
+++ b/lvmd/device_class_manager_test.go
@@ -17,13 +17,13 @@ func TestValidateDeviceClasses(t *testing.T) {
 		{
 			deviceClasses: []*DeviceClass{
 				{
-					Name:        "hdd",
+					Name:        "dc1",
 					VolumeGroup: "node1-myvg1",
+					Default:     true,
 				},
 				{
-					Name:        "ssd",
+					Name:        "dc2",
 					VolumeGroup: "node1-myvg2",
-					Default:     true,
 				},
 			},
 			valid: true,
@@ -198,12 +198,12 @@ func TestValidateDeviceClasses(t *testing.T) {
 		{
 			deviceClasses: []*DeviceClass{
 				{
-					Name:        "hdd",
-					VolumeGroup: "node1-hdd",
+					Name:        "dc1",
+					VolumeGroup: "node1-myvg1",
 				},
 				{
-					Name:        "ssd",
-					VolumeGroup: "node1-ssd",
+					Name:        "dc2",
+					VolumeGroup: "node1-myvg2",
 				},
 			},
 			valid: true,
@@ -211,13 +211,13 @@ func TestValidateDeviceClasses(t *testing.T) {
 		{
 			deviceClasses: []*DeviceClass{
 				{
-					Name:        "hdd",
-					VolumeGroup: "node1-hdd",
+					Name:        "dc1",
+					VolumeGroup: "node1-myvg1",
 					Default:     true,
 				},
 				{
-					Name:        "ssd",
-					VolumeGroup: "node1-ssd",
+					Name:        "dc2",
+					VolumeGroup: "node1-myvg2",
 					Default:     true,
 				},
 			},
@@ -389,23 +389,23 @@ func TestDeviceClassManager(t *testing.T) {
 	lvcreateOptions := []string{"--mirrors=1"}
 	deviceClasses := []*DeviceClass{
 		{
-			Name:        "hdd1",
-			VolumeGroup: "hdd1-vg",
-			SpareGB:     &spare50gb,
-		},
-		{
-			Name:        "hdd2",
-			VolumeGroup: "hdd2-vg",
-			SpareGB:     &spare100gb,
-		},
-		{
-			Name:        "ssd",
-			VolumeGroup: "ssd-vg",
+			Name:        "dc1",
+			VolumeGroup: "vg1",
 			Default:     true,
 		},
 		{
+			Name:        "dc2",
+			VolumeGroup: "vg2",
+			SpareGB:     &spare50gb,
+		},
+		{
+			Name:        "dc3",
+			VolumeGroup: "vg3",
+			SpareGB:     &spare100gb,
+		},
+		{
 			Name:            "mirrors",
-			VolumeGroup:     "hdd1-vg",
+			VolumeGroup:     "vg2",
 			LVCreateOptions: lvcreateOptions,
 		},
 		{
@@ -422,12 +422,12 @@ func TestDeviceClassManager(t *testing.T) {
 	}
 	manager := NewDeviceClassManager(deviceClasses)
 
-	dc, err := manager.DeviceClass("hdd1")
+	dc, err := manager.DeviceClass("dc2")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if dc.GetSpare() != spare50gb<<30 {
-		t.Error("hdd1's spare should be 50GB")
+		t.Error("dc2's spare should be 50GB")
 	}
 
 	_, err = manager.DeviceClass("unknown")
@@ -435,12 +435,12 @@ func TestDeviceClassManager(t *testing.T) {
 		t.Error("'unknown' should not be found")
 	}
 
-	dc, err = manager.FindDeviceClassByVGName("hdd2-vg")
+	dc, err = manager.FindDeviceClassByVGName("vg3")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if dc.GetSpare() != spare100gb<<30 {
-		t.Error("hdd2's spare should be 100GB")
+		t.Error("dc3's spare should be 100GB")
 	}
 
 	_, err = manager.FindDeviceClassByVGName("unknown")
@@ -462,11 +462,11 @@ func TestDeviceClassManager(t *testing.T) {
 	if dc == nil {
 		t.Fatal("default not found")
 	}
-	if dc.Name != "ssd" {
+	if dc.Name != "dc1" {
 		t.Fatal("wrong device-class found")
 	}
 	if dc.GetSpare() != defaultSpareGB<<30 {
-		t.Error("ssd's spare should be default")
+		t.Error("dc1's spare should be default")
 	}
 	if dc.Type != TypeThick {
 		t.Error("Default type should be TypeThick")

--- a/lvmd/embed_test.go
+++ b/lvmd/embed_test.go
@@ -16,13 +16,13 @@ func TestNewEmbeddedServiceClients(t *testing.T) {
 
 		{"volumegroup", []*DeviceClass{
 			{
-				Name:        "ssd",
+				Name:        "dc",
 				VolumeGroup: "test_vgservice",
 			}},
 		},
 		{"thinpool", []*DeviceClass{
 			{
-				Name:        "ssd",
+				Name:        "dc",
 				VolumeGroup: "test_vgservice",
 				Type:        TypeThin,
 				ThinPoolConfig: &ThinPoolConfig{

--- a/lvmd/lvcreate_option_class_manager_test.go
+++ b/lvmd/lvcreate_option_class_manager_test.go
@@ -13,10 +13,10 @@ func TestLvcreateOptionClassManager(t *testing.T) {
 	}{
 		{
 			found: true,
-			name:  "ssd",
+			name:  "option",
 			lvcreateOptionClasses: []*LvcreateOptionClass{
 				{
-					Name:    "ssd",
+					Name:    "option",
 					Options: []string{"--type=raid1"},
 				},
 			},
@@ -26,7 +26,7 @@ func TestLvcreateOptionClassManager(t *testing.T) {
 			name:  "not-found",
 			lvcreateOptionClasses: []*LvcreateOptionClass{
 				{
-					Name:    "ssd",
+					Name:    "option",
 					Options: []string{"--type=raid1"},
 				},
 			},

--- a/lvmd/vgservice_test.go
+++ b/lvmd/vgservice_test.go
@@ -61,13 +61,13 @@ func testWatch(t *testing.T) {
 
 		{"volumegroup", []*DeviceClass{
 			{
-				Name:        "ssd",
+				Name:        "dc",
 				VolumeGroup: "test_vgservice",
 			}},
 		},
 		{"thinpool", []*DeviceClass{
 			{
-				Name:        "ssd",
+				Name:        "dc",
 				VolumeGroup: "test_vgservice",
 				Type:        TypeThin,
 				ThinPoolConfig: &ThinPoolConfig{

--- a/scheduler/predicate_test.go
+++ b/scheduler/predicate_test.go
@@ -17,9 +17,9 @@ func testNode(name string, cap1Gb, cap2Gb, cap3Gb int64) corev1.Node {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				topolvm.GetCapacityKeyPrefix() + "ssd":  fmt.Sprintf("%d", cap1Gb<<30),
-				topolvm.GetCapacityKeyPrefix() + "hdd1": fmt.Sprintf("%d", cap2Gb<<30),
-				topolvm.GetCapacityKeyPrefix() + "hdd2": fmt.Sprintf("%d", cap3Gb<<30),
+				topolvm.GetCapacityKeyPrefix() + "dc1": fmt.Sprintf("%d", cap1Gb<<30),
+				topolvm.GetCapacityKeyPrefix() + "dc2": fmt.Sprintf("%d", cap2Gb<<30),
+				topolvm.GetCapacityKeyPrefix() + "dc3": fmt.Sprintf("%d", cap3Gb<<30),
 			},
 		},
 	}
@@ -45,14 +45,14 @@ func TestFilterNodes(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "10.1.1.4",
 							Annotations: map[string]string{
-								topolvm.GetCapacityKeyPrefix() + "ssd": "foo",
+								topolvm.GetCapacityKeyPrefix() + "dc1": "foo",
 							},
 						},
 					},
 				},
 			},
 			requested: map[string]int64{
-				"ssd": 2 << 30,
+				"dc1": 2 << 30,
 			},
 			expect: ExtenderFilterResult{
 				Nodes: &corev1.NodeList{
@@ -76,9 +76,9 @@ func TestFilterNodes(t *testing.T) {
 				},
 			},
 			requested: map[string]int64{
-				"ssd":  5 << 30,
-				"hdd1": 10 << 30,
-				"hdd2": 20 << 30,
+				"dc1": 5 << 30,
+				"dc2": 10 << 30,
+				"dc3": 20 << 30,
 			},
 			expect: ExtenderFilterResult{
 				Nodes: &corev1.NodeList{
@@ -99,7 +99,7 @@ func TestFilterNodes(t *testing.T) {
 				},
 			},
 			requested: map[string]int64{
-				"ssd": 0,
+				"dc1": 0,
 			},
 			expect: ExtenderFilterResult{
 				Nodes: &corev1.NodeList{
@@ -139,7 +139,7 @@ func TestExtractRequestedSize(t *testing.T) {
 			input: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						topolvm.GetCapacityKeyPrefix() + "ssd": strconv.Itoa(5 << 30),
+						topolvm.GetCapacityKeyPrefix() + "dc1": strconv.Itoa(5 << 30),
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -168,14 +168,14 @@ func TestExtractRequestedSize(t *testing.T) {
 				},
 			},
 			expected: map[string]int64{
-				"ssd": 5 << 30,
+				"dc1": 5 << 30,
 			},
 		},
 		{
 			input: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						topolvm.GetCapacityKeyPrefix() + "ssd": strconv.Itoa(3 << 30),
+						topolvm.GetCapacityKeyPrefix() + "dc1": strconv.Itoa(3 << 30),
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -191,7 +191,7 @@ func TestExtractRequestedSize(t *testing.T) {
 				},
 			},
 			expected: map[string]int64{
-				"ssd": 3 << 30,
+				"dc1": 3 << 30,
 			},
 		},
 	}

--- a/scheduler/prioritize_test.go
+++ b/scheduler/prioritize_test.go
@@ -43,9 +43,9 @@ func TestScoreNodes(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				topolvm.GetCapacityKeyPrefix() + "ssd":  "64",
-				topolvm.GetCapacityKeyPrefix() + "hdd1": "64",
-				topolvm.GetCapacityKeyPrefix() + "hdd2": "64",
+				topolvm.GetCapacityKeyPrefix() + "dc1": "64",
+				topolvm.GetCapacityKeyPrefix() + "dc2": "64",
+				topolvm.GetCapacityKeyPrefix() + "dc3": "64",
 			},
 		},
 	}
@@ -60,7 +60,7 @@ func TestScoreNodes(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "10.1.1.3",
 				Annotations: map[string]string{
-					topolvm.GetCapacityKeyPrefix() + "ssd": "foo",
+					topolvm.GetCapacityKeyPrefix() + "dc1": "foo",
 				},
 			},
 		},
@@ -82,8 +82,8 @@ func TestScoreNodes(t *testing.T) {
 
 	defaultDivisor := 2.0
 	divisors := map[string]float64{
-		"ssd":  4,
-		"hdd1": 10,
+		"dc1": 4,
+		"dc2": 10,
 	}
 	result := scoreNodes(pod, input, defaultDivisor, divisors)
 	if !reflect.DeepEqual(result, expected) {

--- a/scheduler/route_test.go
+++ b/scheduler/route_test.go
@@ -19,7 +19,7 @@ var extenderArgs = ExtenderArgs{
 	Pod: &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				topolvm.GetCapacityKeyPrefix() + "ssd": strconv.Itoa(3 << 30),
+				topolvm.GetCapacityKeyPrefix() + "dc1": strconv.Itoa(3 << 30),
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -46,7 +46,7 @@ func testPredicate(t *testing.T) {
 	t.Parallel()
 
 	handler, err := NewHandler(1, map[string]float64{
-		"ssd": 1,
+		"dc1": 1,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -93,7 +93,7 @@ func testPrioritize(t *testing.T) {
 	t.Parallel()
 
 	handler, err := NewHandler(1, map[string]float64{
-		"ssd": 1,
+		"dc1": 1,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
We used ssd or hdd for device-class name in tests, but it is not related to actual backend. To express it is meaningless, use anonymouse name.