### PR TITLE
chore: optimize node watches and controller to only watch metadata and no spec

### DIFF
--- a/driver/identity.go
+++ b/driver/identity.go
@@ -30,7 +30,7 @@ type identityServer struct {
 }
 
 func (s identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
-	idLogger.Info("GetPluginInfo", "req", req.String())
+	idLogger.V(2).Info("GetPluginInfo", "req", req.String())
 	return &csi.GetPluginInfoResponse{
 		Name:          topolvm.GetPluginName(),
 		VendorVersion: topolvm.Version,
@@ -38,7 +38,7 @@ func (s identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInf
 }
 
 func (s identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
-	idLogger.Info("GetPluginCapabilities", "req", req.String())
+	idLogger.V(2).Info("GetPluginCapabilities", "req", req.String())
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{
@@ -74,7 +74,7 @@ func (s identityServer) GetPluginCapabilities(ctx context.Context, req *csi.GetP
 }
 
 func (s identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
-	idLogger.Info("Probe", "req", req.String())
+	idLogger.V(2).Info("Probe", "req", req.String())
 	ok, err := s.ready()
 	if err != nil {
 		idLogger.Error(err, "probe failed")

--- a/driver/internal/k8s/node_service.go
+++ b/driver/internal/k8s/node_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/topolvm/topolvm"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -25,8 +26,9 @@ func NewNodeService(r client.Reader) *NodeService {
 	return &NodeService{reader: r}
 }
 
-func (s NodeService) getNodes(ctx context.Context) (*corev1.NodeList, error) {
-	nl := new(corev1.NodeList)
+func (s NodeService) getNodes(ctx context.Context) (*v1.PartialObjectMetadataList, error) {
+	nl := new(v1.PartialObjectMetadataList)
+	nl.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NodeList"))
 	err := s.reader.List(ctx, nl)
 	if err != nil {
 		return nil, err
@@ -34,7 +36,7 @@ func (s NodeService) getNodes(ctx context.Context) (*corev1.NodeList, error) {
 	return nl, nil
 }
 
-func (s NodeService) extractCapacityFromAnnotation(node *corev1.Node, deviceClass string) (int64, error) {
+func (s NodeService) extractCapacityFromAnnotation(node *v1.PartialObjectMetadata, deviceClass string) (int64, error) {
 	if deviceClass == topolvm.DefaultDeviceClassName {
 		deviceClass = topolvm.DefaultDeviceClassAnnotationName
 	}
@@ -47,7 +49,8 @@ func (s NodeService) extractCapacityFromAnnotation(node *corev1.Node, deviceClas
 
 // GetCapacityByName returns VG capacity of specified node by name.
 func (s NodeService) GetCapacityByName(ctx context.Context, name, deviceClass string) (int64, error) {
-	n := new(corev1.Node)
+	n := new(v1.PartialObjectMetadata)
+	n.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Node"))
 	err := s.reader.Get(ctx, client.ObjectKey{Name: name}, n)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This PR has 2 changes:

- includes a small Memory Optimization for the TopoLVM node controller. It makes use of the OnlyMetadata watch and cachebuilder from https://github.com/kubernetes-sigs/controller-runtime/blob/v0.16.3/pkg/builder/options.go#L102-L133 as the controllers in topolvm do not need to interact with Pod Spec / Status, only with annotations or labels
- It reduces the verbosity of GetPluginInfo and GetPluginCapabilities as they are regularly called by k8s and do not need to log a message every time
