### PR TITLE
Remove declaration of port 9808 from the livenessprobe container

### DIFF
--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -236,9 +236,6 @@ spec:
             - /livenessprobe
             - --csi-address=/run/topolvm/csi-topolvm.sock
             - --http-endpoint=:9808
-          ports:
-            - containerPort: 9808
-              name: livenessprobe
           volumeMounts:
             - name: socket-dir
               mountPath: /run/topolvm

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -186,9 +186,6 @@ spec:
             - /livenessprobe
             - --csi-address={{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/csi-topolvm.sock
             - --http-endpoint=:9808
-          ports:
-            - containerPort: 9808
-              name: livenessprobe
           {{- with .Values.resources.liveness_probe }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
Following the guidance of the livenessprobe repo, the port should be declared only on the controller.