### PR TITLE
Fix node name for minikube

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -11,7 +11,7 @@ TEST_LVMD_TYPE ?= systemd-service
 BINDIR := $(shell pwd)/bin
 SUDO := sudo
 CURL := curl -sSLf
-KIND_CLUSTER_NAME := topolvm-e2e
+CLUSTER_NAME := topolvm-e2e
 KIND := ../bin/kind
 KUBECTL := $(BINDIR)/kubectl-$(KUBERNETES_VERSION)
 HELM := ../bin/helm
@@ -82,11 +82,11 @@ apply-certmanager-crds: $(KUBECTL)
 launch-kind: /tmp/topolvm/scheduler/scheduler-config.yaml $(KIND)
 	$(SUDO) rm -rf /tmp/topolvm/controller /tmp/topolvm/worker*
 	sed -e "s|@KUBERNETES_VERSION@|$(KUBERNETES_VERSION)|" $(KIND_CONFIG) > /tmp/$(KIND_CONFIG)
-	$(KIND) create cluster --name=$(KIND_CLUSTER_NAME) --config /tmp/$(KIND_CONFIG) --image $(KIND_NODE_IMAGE)
+	$(KIND) create cluster --name=$(CLUSTER_NAME) --config /tmp/$(KIND_CONFIG) --image $(KIND_NODE_IMAGE)
 
 .PHONY: shutdown-kind
 shutdown-kind: $(KIND)
-	$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME) || true
+	$(KIND) delete cluster --name=$(CLUSTER_NAME) || true
 	sleep 2
 	for d in $$($(SUDO) find /tmp/topolvm -type d); do \
 		if $(SUDO) mountpoint -q $$d; then \
@@ -117,13 +117,12 @@ stop-lvmd:
 	done
 
 .PHONY: create-cluster
-create-cluster: HELM_VALUES_FILES += manifests/values/kind.yaml
 create-cluster: topolvm.img $(HELM) $(KIND) $(KUBECTL)
 	$(MAKE) shutdown-kind
 	$(MAKE) launch-kind
 	$(MAKE) apply-certmanager-crds
 	$(MAKE) prepare-namespace
-	$(KIND) load image-archive --name=$(KIND_CLUSTER_NAME) $<
+	$(KIND) load image-archive --name=$(CLUSTER_NAME) $<
 	$(HELM) repo add jetstack https://charts.jetstack.io
 	$(HELM) repo update
 	$(HELM) dependency build ../charts/topolvm/
@@ -143,13 +142,11 @@ prepare-test: $(KUBECTL)
 
 .PHONY: run-test
 run-test: GINKGO_FLAGS =
-run-test: DAEMONSET_LVMD =
 run-test: $(GINKGO)
 	$(SUDO) -E env \
 	PATH=${PATH} \
 	E2ETEST=1 \
 	KUBECTL=$(KUBECTL) \
-	DAEMONSET_LVMD=$(DAEMONSET_LVMD) \
 	STORAGE_CAPACITY=$(STORAGE_CAPACITY) \
 	USE_LEGACY=$(USE_LEGACY) \
 	$(GINKGO) --fail-fast -v $(GINKGO_FLAGS) .
@@ -229,6 +226,8 @@ incluster-lvmd/launch-minikube:
 		--vm-driver=none \
 		--kubernetes-version=v$(KUBERNETES_VERSION) \
 		--extra-config=kubelet.read-only-port=10255 \
+		--extra-config=kubeadm.node-name=$(CLUSTER_NAME)-worker \
+		--extra-config=kubelet.hostname-override=$(CLUSTER_NAME)-worker \
 		--feature-gates=$(MINIKUBE_FEATURE_GATES) \
 		--cni=calico
 	$(SUDO) chown -R $$USER $$HOME/.kube $(MINIKUBE_HOME)/.minikube
@@ -259,7 +258,7 @@ incluster-lvmd/test: topolvm.img $(GINKGO) $(HELM) $(KUBECTL)
 	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system -l="app.kubernetes.io/component=controller,app.kubernetes.io/name=topolvm" pod
 	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system certificate/topolvm-mutatingwebhook
 	$(MAKE) prepare-test
-	$(MAKE) run-test DAEMONSET_LVMD=true
+	$(MAKE) run-test
 
 .PHONY: incluster-lvmd/clean
 incluster-lvmd/clean: incluster-lvmd/delete-minikube incluster-lvmd/remove-vg

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -8,16 +8,21 @@ TEST_LEGACY ?= false
 # systemd-service/daemonset/embedded
 TEST_LVMD_TYPE ?= systemd-service
 
+BACKING_STORE := ./build
 BINDIR := $(shell pwd)/bin
-SUDO := sudo
-CURL := curl -sSLf
 CLUSTER_NAME := topolvm-e2e
-KIND := ../bin/kind
-KUBECTL := $(BINDIR)/kubectl-$(KUBERNETES_VERSION)
-HELM := ../bin/helm
+CURL := curl -sSLf
 GINKGO := $(BINDIR)/ginkgo-$(GINKGO_VERSION)
-
+GINKGO_FLAGS :=
+GO_FILES := $(shell find .. -path ../e2e -prune -o -name '*.go' -print)
+HELM := ../bin/helm
+KIND := ../bin/kind
+KIND_CONFIG := topolvm-cluster.yaml
+KUBECTL := $(BINDIR)/kubectl-$(KUBERNETES_VERSION)
+MINIKUBE_FEATURE_GATES="ReadWriteOncePod=true"
 MINIKUBE_HOME = $(BINDIR)
+SUDO := sudo
+
 export MINIKUBE_HOME
 
 DOMAIN_NAME := topolvm.io
@@ -47,12 +52,6 @@ else ifeq ($(TEST_LVMD_TYPE),embedded)
 HELM_VALUES_FILES += manifests/values/embedded-lvmd.yaml
 endif
 
-KIND_CONFIG="topolvm-cluster.yaml"
-MINIKUBE_FEATURE_GATES="ReadWriteOncePod=true"
-
-GO_FILES := $(shell find .. -path ../e2e -prune -o -name '*.go' -print)
-BACKING_STORE := ./build
-
 topolvm.img: $(GO_FILES)
 	mkdir -p tmpbin
 	CGO_ENABLED=0 go build -o tmpbin/hypertopolvm ../pkg/hypertopolvm
@@ -67,16 +66,6 @@ ifeq ($(TEST_SCHEDULER_EXTENDER_TYPE),deployment)
 else
 	cp $< $@
 endif
-
-.PHONY: prepare-namespace
-prepare-namespace: $(KUBECTL)
-	$(KUBECTL) create namespace topolvm-system
-	$(KUBECTL) label namespace topolvm-system $(DOMAIN_NAME)/webhook=ignore
-	$(KUBECTL) label namespace kube-system $(DOMAIN_NAME)/webhook=ignore
-
-.PHONY: apply-certmanager-crds
-apply-certmanager-crds: $(KUBECTL)
-	$(KUBECTL) apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.crds.yaml
 
 .PHONY: launch-kind
 launch-kind: /tmp/topolvm/scheduler/scheduler-config.yaml $(KIND)
@@ -117,45 +106,16 @@ stop-lvmd:
 	done
 
 .PHONY: create-cluster
-create-cluster: topolvm.img $(HELM) $(KIND) $(KUBECTL)
+create-cluster: topolvm.img $(KIND)
 	$(MAKE) shutdown-kind
 	$(MAKE) launch-kind
-	$(MAKE) apply-certmanager-crds
-	$(MAKE) prepare-namespace
 	$(KIND) load image-archive --name=$(CLUSTER_NAME) $<
-	$(HELM) repo add jetstack https://charts.jetstack.io
-	$(HELM) repo update
-	$(HELM) dependency build ../charts/topolvm/
-	$(HELM) install --namespace=topolvm-system topolvm ../charts/topolvm/ $(patsubst %,-f %,$(HELM_VALUES_FILES))
-	$(KUBECTL) wait --for=condition=available --timeout=120s -n topolvm-system deployments/topolvm-controller
-	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system -l="app.kubernetes.io/component=controller,app.kubernetes.io/name=topolvm" pod
-	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system certificate/topolvm-mutatingwebhook
-
-.PHONY: prepare-test
-prepare-test: $(KUBECTL)
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
-	sed 's/@DOMAIN_NAME@/$(DOMAIN_NAME)/' manifests/volumesnapshotclass_tpl.yaml | $(KUBECTL) apply -f -
-
-.PHONY: run-test
-run-test: GINKGO_FLAGS =
-run-test: $(GINKGO)
-	$(SUDO) -E env \
-	PATH=${PATH} \
-	E2ETEST=1 \
-	KUBECTL=$(KUBECTL) \
-	STORAGE_CAPACITY=$(STORAGE_CAPACITY) \
-	USE_LEGACY=$(USE_LEGACY) \
-	$(GINKGO) --fail-fast -v $(GINKGO_FLAGS) .
+	$(MAKE) common/setup-components
 
 .PHONY: test
 test:
 	$(MAKE) create-cluster
-	$(MAKE) prepare-test
-	$(MAKE) run-test
+	$(MAKE) common/test
 
 .PHONY: clean
 clean: stop-lvmd
@@ -239,7 +199,8 @@ incluster-lvmd/delete-minikube:
 	$(SUDO) -E $(BINDIR)/minikube delete || true
 
 .PHONY: incluster-lvmd/test
-incluster-lvmd/test: topolvm.img $(GINKGO) $(HELM) $(KUBECTL)
+# topolvm.img is to trigger the build of docker image
+incluster-lvmd/test: topolvm.img
 	@if [ "$(TEST_SCHEDULER_EXTENDER_TYPE)" != none ]; then \
 		echo "Using the scheduler extender is not supported"; \
 		exit 1; \
@@ -248,17 +209,8 @@ incluster-lvmd/test: topolvm.img $(GINKGO) $(HELM) $(KUBECTL)
 		echo "Running LVMd as systemd-service is not supported"; \
 		exit 1; \
 	fi
-	$(MAKE) apply-certmanager-crds
-	$(MAKE) prepare-namespace
-	$(HELM) repo add jetstack https://charts.jetstack.io
-	$(HELM) repo update
-	$(HELM) dependency build ../charts/topolvm/
-	$(HELM) install --namespace=topolvm-system topolvm ../charts/topolvm/ $(patsubst %,-f %,$(HELM_VALUES_FILES))
-	$(KUBECTL) wait --for=condition=available --timeout=120s -n topolvm-system deployments/topolvm-controller
-	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system -l="app.kubernetes.io/component=controller,app.kubernetes.io/name=topolvm" pod
-	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system certificate/topolvm-mutatingwebhook
-	$(MAKE) prepare-test
-	$(MAKE) run-test
+	$(MAKE) common/setup-components
+	$(MAKE) common/test
 
 .PHONY: incluster-lvmd/clean
 incluster-lvmd/clean: incluster-lvmd/delete-minikube incluster-lvmd/remove-vg
@@ -299,3 +251,38 @@ common/remove-vg:
 		$(SUDO) losetup -d $$($(SUDO) losetup -j $(BACKING_STORE)/backing_store$(ID)_$${i} | cut -d: -f1); \
 		rm -f $(BACKING_STORE)/backing_store$(ID)_$${i}; \
 	done
+
+.PHONY: common/setup-components
+common/setup-components: $(HELM) $(KUBECTL)
+	@echo apply certmanager CRDs
+	$(KUBECTL) apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.crds.yaml
+
+	@echo install TopoLVM
+	$(KUBECTL) create namespace topolvm-system
+	$(KUBECTL) label namespace topolvm-system $(DOMAIN_NAME)/webhook=ignore
+	$(KUBECTL) label namespace kube-system $(DOMAIN_NAME)/webhook=ignore
+	$(HELM) repo add jetstack https://charts.jetstack.io
+	$(HELM) repo update
+	$(HELM) dependency build ../charts/topolvm/
+	$(HELM) install --namespace=topolvm-system topolvm ../charts/topolvm/ $(patsubst %,-f %,$(HELM_VALUES_FILES))
+	$(KUBECTL) wait --for=condition=available --timeout=120s -n topolvm-system deployments/topolvm-controller
+	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system -l="app.kubernetes.io/component=controller,app.kubernetes.io/name=topolvm" pod
+	$(KUBECTL) wait --for=condition=ready --timeout=120s -n topolvm-system certificate/topolvm-mutatingwebhook
+
+	@echo apply VolumeSnapshot manifests
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v$(EXTERNAL_SNAPSHOTTER_VERSION)/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+	sed 's/@DOMAIN_NAME@/$(DOMAIN_NAME)/' manifests/volumesnapshotclass_tpl.yaml | $(KUBECTL) apply -f -
+
+.PHONY: common/test
+common/test: $(GINKGO)
+	$(SUDO) -E env \
+	PATH=${PATH} \
+	E2ETEST=1 \
+	KUBECTL=$(KUBECTL) \
+	STORAGE_CAPACITY=$(STORAGE_CAPACITY) \
+	USE_LEGACY=$(USE_LEGACY) \
+	$(GINKGO) --fail-fast -v $(GINKGO_FLAGS) .

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -36,8 +36,7 @@ make create-cluster
 Then, you can test specific suite.
 
 ```bash
-make prepare-test
-make run-test GINKGO_FLAGS="--focus hook"
+make common/test GINKGO_FLAGS="--focus hook"
 ```
 
 You can cleanup test environment as follows:

--- a/e2e/clone_test.go
+++ b/e2e/clone_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
-	"github.com/topolvm/topolvm"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -40,15 +39,11 @@ func testPVCClone() {
 	It("should create a PVC Clone", func() {
 		By("deploying Pod with PVC")
 
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
 		thinPvcYAML := []byte(fmt.Sprintf(thinPVCTemplateYAML, volName, pvcSize))
 		_, err := kubectlWithInput(thinPvcYAML, "apply", "-n", nsCloneTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName))
 		_, err = kubectlWithInput(thinPodYAML, "apply", "-n", nsCloneTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 		By("confirming if the source PVC is created")
@@ -81,7 +76,7 @@ func testPVCClone() {
 		_, err = kubectlWithInput(thinPVCCloneYAML, "apply", "-n", nsCloneTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodCloneYAML := []byte(fmt.Sprintf(thinPodCloneTemplateYAML, thinClonePodName, thinClonePVCName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodCloneYAML := []byte(fmt.Sprintf(thinPodCloneTemplateYAML, thinClonePodName, thinClonePVCName))
 		_, err = kubectlWithInput(thinPodCloneYAML, "apply", "-n", nsCloneTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -130,17 +125,12 @@ func testPVCClone() {
 	})
 
 	It("validate if the cloned PVC is standalone", func() {
-
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
 		By("creating a PVC")
 		thinPvcYAML := []byte(fmt.Sprintf(thinPVCTemplateYAML, volName, pvcSize))
 		_, err := kubectlWithInput(thinPvcYAML, "apply", "-n", nsCloneTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName))
 		_, err = kubectlWithInput(thinPodYAML, "apply", "-n", nsCloneTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(func() error {
@@ -160,7 +150,7 @@ func testPVCClone() {
 		_, err = kubectlWithInput(thinPVCCloneYAML, "apply", "-n", nsCloneTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodCloneYAML := []byte(fmt.Sprintf(thinPodCloneTemplateYAML, thinClonePodName, thinClonePVCName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodCloneYAML := []byte(fmt.Sprintf(thinPodCloneTemplateYAML, thinClonePodName, thinClonePVCName))
 		_, err = kubectlWithInput(thinPodCloneYAML, "apply", "-n", nsCloneTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 

--- a/e2e/manifests/values/base.yaml
+++ b/e2e/manifests/values/base.yaml
@@ -4,6 +4,8 @@ image:
   pullPolicy: Never
 
 controller:
+  nodeSelector:
+    kubernetes.io/hostname: topolvm-e2e-worker
   replicaCount: 1
   securityContext:
     enabled: false

--- a/e2e/manifests/values/kind.yaml
+++ b/e2e/manifests/values/kind.yaml
@@ -1,3 +1,0 @@
-controller:
-  nodeSelector:
-    kubernetes.io/hostname: topolvm-e2e-worker

--- a/e2e/multiple_vg_test.go
+++ b/e2e/multiple_vg_test.go
@@ -33,11 +33,7 @@ func testMultipleVolumeGroups() {
 
 	It("should use the specified device-class", func() {
 		By("deploying Pod with PVC")
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
-		manifest := fmt.Sprintf(multipleVGPodPVCTemplateYAML, "topo-pvc-dc", "topolvm-provisioner2", "pause-dc", "topo-pvc-dc", nodeName)
+		manifest := fmt.Sprintf(multipleVGPodPVCTemplateYAML, "topo-pvc-dc", "topolvm-provisioner2", "pause-dc", "topo-pvc-dc")
 		_, err := kubectlWithInput([]byte(manifest), "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -70,11 +66,7 @@ func testMultipleVolumeGroups() {
 
 	It("should not schedule a pod because there are no nodes that have specified device-classes", func() {
 		By("deploying Pod with PVC")
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
-		manifest := fmt.Sprintf(multipleVGPodPVCTemplateYAML, "topo-pvc-not-found-dc", "topolvm-provisioner-not-found-device", "pause-not-found-dc", "topo-pvc-not-found-dc", nodeName)
+		manifest := fmt.Sprintf(multipleVGPodPVCTemplateYAML, "topo-pvc-not-found-dc", "topolvm-provisioner-not-found-device", "pause-not-found-dc", "topo-pvc-not-found-dc")
 		_, err := kubectlWithInput([]byte(manifest), "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -102,11 +94,7 @@ func testMultipleVolumeGroups() {
 
 	It("should run a pod using the default device-class", func() {
 		By("deploying Pod with PVC")
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
-		manifest := fmt.Sprintf(multipleVGPodPVCTemplateYAML, "topo-pvc-default", "topolvm-provisioner-default", "pause-default", "topo-pvc-default", nodeName)
+		manifest := fmt.Sprintf(multipleVGPodPVCTemplateYAML, "topo-pvc-default", "topolvm-provisioner-default", "pause-default", "topo-pvc-default")
 		_, err := kubectlWithInput([]byte(manifest), "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 

--- a/e2e/node_delete_test.go
+++ b/e2e/node_delete_test.go
@@ -92,7 +92,7 @@ func testNodeDelete() {
 			}
 		}
 
-		By("deleting Node topolvm-e2e-worker3")
+		By("deleting Node " + targetNode)
 		_, err = kubectl("delete", "node", targetNode, "--wait=true")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -123,7 +123,7 @@ func testNodeDelete() {
 		}).Should(Succeed())
 
 		By("cleaning up LVMs that the deleted node had")
-		_, err = execAtLocal("docker", nil, "stop", "topolvm-e2e-worker3")
+		_, err = execAtLocal("docker", nil, "stop", targetNode)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		for _, lv := range targetLVs {

--- a/e2e/scheduling_test.go
+++ b/e2e/scheduling_test.go
@@ -32,9 +32,6 @@ func testScheduling() {
 	It("should schedule a pod with a PVC if a node has enough capacity", func() {
 		name := "pod-pvc"
 		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
 
 		By("checking the pod with a PVC is running if a node capacity is sufficient")
 		var node corev1.Node
@@ -49,7 +46,7 @@ func testScheduling() {
 			return strconv.Itoa(s)
 		}()
 
-		lvYaml := buildPodPVCTemplateYAML(name, size, "topolvm-provisioner", nodeName)
+		lvYaml := buildPodPVCTemplateYAML(name, size, "topolvm-provisioner")
 		_, err = kubectlWithInput(lvYaml, "apply", "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(func() error {
@@ -71,7 +68,7 @@ func testScheduling() {
 		By("checking the pod with a PVC is not scheduled if a node capacity is not enough")
 		name2 := name + "2"
 
-		lvYaml2 := buildPodPVCTemplateYAML(name2, size, "topolvm-provisioner", nodeName)
+		lvYaml2 := buildPodPVCTemplateYAML(name2, size, "topolvm-provisioner")
 		_, err = kubectlWithInput(lvYaml2, "apply", "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(func() error {
@@ -117,7 +114,7 @@ func testScheduling() {
 			return strconv.Itoa(s)
 		}()
 
-		lvYaml3 := buildPodPVCTemplateYAML(name3, size, "topolvm-provisioner2", nodeName)
+		lvYaml3 := buildPodPVCTemplateYAML(name3, size, "topolvm-provisioner2")
 		_, err = kubectlWithInput(lvYaml3, "apply", "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 		Eventually(func() error {
@@ -138,6 +135,6 @@ func testScheduling() {
 	})
 }
 
-func buildPodPVCTemplateYAML(name, size, sc, node string) []byte {
-	return []byte(fmt.Sprintf(podPVCTemplateYAML, name, nsSchedulingTest, size, sc, name, nsSchedulingTest, name, topolvm.GetTopologyNodeKey(), node))
+func buildPodPVCTemplateYAML(name, size, sc string) []byte {
+	return []byte(fmt.Sprintf(podPVCTemplateYAML, name, nsSchedulingTest, size, sc, name, nsSchedulingTest, name))
 }

--- a/e2e/snapshot_test.go
+++ b/e2e/snapshot_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
-	"github.com/topolvm/topolvm"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -58,15 +57,11 @@ func testSnapRestore() {
 	It("should create a thin-snap with size equal to source", func() {
 		By("deploying Pod with PVC")
 
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
 		thinPvcYAML := []byte(fmt.Sprintf(thinPVCTemplateYAML, volName, pvcSize))
 		_, err := kubectlWithInput(thinPvcYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName))
 		_, err = kubectlWithInput(thinPodYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -120,7 +115,7 @@ func testSnapRestore() {
 		_, err = kubectlWithInput(thinPVCRestoreYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPVCRestorePodYAML := []byte(fmt.Sprintf(thinRestorePodTemplateYAML, restorePodName, restorePVCName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPVCRestorePodYAML := []byte(fmt.Sprintf(thinRestorePodTemplateYAML, restorePodName, restorePVCName))
 		_, err = kubectlWithInput(thinPVCRestorePodYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -171,15 +166,11 @@ func testSnapRestore() {
 	It("should create a thin-snap with size greater than source", func() {
 		By("deploying Pod with PVC")
 
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
 		thinPvcYAML := []byte(fmt.Sprintf(thinPVCTemplateYAML, volName, pvcSize))
 		_, err := kubectlWithInput(thinPvcYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName))
 		_, err = kubectlWithInput(thinPodYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -233,7 +224,7 @@ func testSnapRestore() {
 		_, err = kubectlWithInput(thinPVCRestoreYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPVCRestorePodYAML := []byte(fmt.Sprintf(thinRestorePodTemplateYAML, restorePodName, restorePVCName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPVCRestorePodYAML := []byte(fmt.Sprintf(thinRestorePodTemplateYAML, restorePodName, restorePVCName))
 		_, err = kubectlWithInput(thinPVCRestorePodYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -316,17 +307,12 @@ func testSnapRestore() {
 	It("validating if the restored PVCs are standalone", func() {
 		By("deleting the source PVC")
 
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
-
 		By("creating a PVC and application")
 		thinPvcYAML := []byte(fmt.Sprintf(thinPVCTemplateYAML, volName, pvcSize))
 		_, err := kubectlWithInput(thinPvcYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", volName))
 		_, err = kubectlWithInput(thinPodYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 		By("verifying if the PVC is created")
@@ -365,7 +351,7 @@ func testSnapRestore() {
 		_, err = kubectlWithInput(thinPVCRestoreYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPVCRestorePodYAML := []byte(fmt.Sprintf(thinRestorePodTemplateYAML, restorePodName, restorePVCName, topolvm.GetTopologyNodeKey(), nodeName))
+		thinPVCRestorePodYAML := []byte(fmt.Sprintf(thinRestorePodTemplateYAML, restorePodName, restorePVCName))
 		_, err = kubectlWithInput(thinPVCRestorePodYAML, "apply", "-n", nsSnapTest, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -69,10 +69,6 @@ func waitKindnet(g Gomega) {
 	}
 }
 
-func isDaemonsetLvmdEnvSet() bool {
-	return os.Getenv("DAEMONSET_LVMD") != ""
-}
-
 func isStorageCapacity() bool {
 	return os.Getenv("STORAGE_CAPACITY") == "true"
 }
@@ -91,14 +87,6 @@ func skipIfSingleNode() {
 	if nonControlPlaneNodeCount == 0 {
 		Skip("This test requires multiple nodes")
 	}
-}
-
-func getDaemonsetLvmdNodeName() string {
-	var nodes corev1.NodeList
-	err := getObjects(&nodes, "nodes")
-	Expect(err).ShouldNot(HaveOccurred())
-	Expect(nodes.Items).Should(HaveLen(1))
-	return nodes.Items[0].Name
 }
 
 //go:embed testdata/pause-pod.yaml

--- a/e2e/testdata/cloning/clone-pod-template.yaml
+++ b/e2e/testdata/cloning/clone-pod-template.yaml
@@ -24,4 +24,4 @@ spec:
       persistentVolumeClaim:
         claimName: %s
   nodeSelector:
-    %s: %s
+    kubernetes.io/hostname: topolvm-e2e-worker

--- a/e2e/testdata/multiple_vg/pod-pvc-template.yaml
+++ b/e2e/testdata/multiple_vg/pod-pvc-template.yaml
@@ -28,4 +28,4 @@ spec:
       persistentVolumeClaim:
         claimName: %s
   nodeSelector:
-    kubernetes.io/hostname: %s
+    kubernetes.io/hostname: topolvm-e2e-worker

--- a/e2e/testdata/scheduling/pvc-pod-template.yaml
+++ b/e2e/testdata/scheduling/pvc-pod-template.yaml
@@ -30,4 +30,4 @@ spec:
       persistentVolumeClaim:
         claimName: %s
   nodeSelector:
-    %s: %s
+    kubernetes.io/hostname: topolvm-e2e-worker

--- a/e2e/testdata/snapshot_restore/restore-pod-template.yaml
+++ b/e2e/testdata/snapshot_restore/restore-pod-template.yaml
@@ -24,4 +24,4 @@ spec:
       persistentVolumeClaim:
         claimName: %s
   nodeSelector:
-    %s: %s
+    kubernetes.io/hostname: topolvm-e2e-worker

--- a/e2e/testdata/thin_provisioning/pod-template.yaml
+++ b/e2e/testdata/thin_provisioning/pod-template.yaml
@@ -24,4 +24,4 @@ spec:
       persistentVolumeClaim:
         claimName: %s
   nodeSelector:
-    %s: %s
+    kubernetes.io/hostname: topolvm-e2e-worker

--- a/e2e/thin_provisioning_test.go
+++ b/e2e/thin_provisioning_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
-	"github.com/topolvm/topolvm"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -40,16 +39,11 @@ func testThinProvisioning() {
 	It("should thin provision a PV", func() {
 		By("deploying Pod with PVC")
 
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
-
 		thinPvcYAML := []byte(fmt.Sprintf(thinPVCTemplateYAML, "thinvol", "1"))
 		_, err := kubectlWithInput(thinPvcYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", "thinvol", topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", "thinvol"))
 		_, err = kubectlWithInput(thinPodYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -102,17 +96,13 @@ func testThinProvisioning() {
 		By("deploying multiple PVCS with total size < thinpoolsize * overprovisioning")
 		// The actual thinpool size is 4 GB . With an overprovisioning limit of 5, it should allow
 		// PVCs totalling upto 20 GB for each node
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
 		for i := 0; i < 5; i++ {
 			num := strconv.Itoa(i)
 			thinPvcYAML := []byte(fmt.Sprintf(thinPVCTemplateYAML, "thinvol"+num, "3"))
 			_, err := kubectlWithInput(thinPvcYAML, "apply", "-n", ns, "-f", "-")
 			Expect(err).ShouldNot(HaveOccurred())
 
-			thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod"+num, "thinvol"+num, topolvm.GetTopologyNodeKey(), nodeName))
+			thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod"+num, "thinvol"+num))
 			_, err = kubectlWithInput(thinPodYAML, "apply", "-n", ns, "-f", "-")
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -185,16 +175,11 @@ func testThinProvisioning() {
 	It("should check overprovision limits", func() {
 		By("Deploying a PVC to use up the available thinpoolsize * overprovisioning")
 
-		nodeName := "topolvm-e2e-worker"
-		if isDaemonsetLvmdEnvSet() {
-			nodeName = getDaemonsetLvmdNodeName()
-		}
-
 		thinPvcYAML := []byte(fmt.Sprintf(thinPVCTemplateYAML, "thinvol", "18"))
 		_, err := kubectlWithInput(thinPvcYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", "thinvol", topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodYAML := []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod", "thinvol"))
 		_, err = kubectlWithInput(thinPodYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -221,7 +206,7 @@ func testThinProvisioning() {
 		_, err = kubectlWithInput(thinPvcYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		thinPodYAML = []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod2", "thinvol2", topolvm.GetTopologyNodeKey(), nodeName))
+		thinPodYAML = []byte(fmt.Sprintf(thinPodTemplateYAML, "thinpod2", "thinvol2"))
 		_, err = kubectlWithInput(thinPodYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
Previously, we obtained the node name to schedule a pod to that node.
However, this can be avoided thanks to using the minikube option.