### PR TITLE
feat: add "additionalVolumes" for lvmd and node ds

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -62,6 +62,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v14.
 | livenessProbe.topolvm_node | object | `{"failureThreshold":null,"initialDelaySeconds":10,"periodSeconds":60,"timeoutSeconds":3}` | Specify resources. # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | livenessProbe.topolvm_scheduler | object | `{"failureThreshold":null,"initialDelaySeconds":10,"periodSeconds":60,"timeoutSeconds":3}` | Specify livenessProbe. # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | lvmd.additionalConfigs | list | `[]` | Define additional LVM Daemon configs if you have additional types of nodes. Please ensure nodeSelectors are non overlapping. |
+| lvmd.additionalVolumes | list | `[]` | Specify additional volumes without conflicting with default volumes most useful for initContainers but available to all containers in the pod. |
 | lvmd.affinity | object | `{}` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | lvmd.args | list | `[]` | Arguments to be passed to the command. |
 | lvmd.deviceClasses | list | `[{"default":true,"name":"ssd","spare-gb":10,"volume-group":"myvg1"}]` | Specify the device-class settings. |
@@ -78,6 +79,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v14.
 | lvmd.updateStrategy | object | `{}` | Specify updateStrategy. |
 | lvmd.volumeMounts | list | `[]` | Specify volumeMounts. |
 | lvmd.volumes | list | `[]` | Specify volumes. |
+| node.additionalVolumes | list | `[]` | Specify additional volumes without conflicting with default volumes most useful for initContainers but available to all containers in the pod. |
 | node.affinity | object | `{}` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | node.args | list | `[]` | Arguments to be passed to the command. |
 | node.initContainers | list | `[]` | Additional initContainers for the node service. |

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -108,6 +108,9 @@ spec:
             path: {{ dir .Values.lvmd.socketName }}
             type: DirectoryOrCreate
         {{- end }}
+        {{- with .Values.lvmd.additionalVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with $lvmd.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -234,6 +234,9 @@ spec:
             type: Directory
         {{- end }}
         {{- end }}
+        {{- with .Values.node.additionalVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 
       {{- with .Values.node.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -175,6 +175,15 @@ lvmd:
   #  - name: lvmd-socket-dir
   #    mountPath: /run/topolvm
 
+  # lvmd.additionalVolumes -- Specify additional volumes without conflicting with default volumes
+  # most useful for initContainers but available to all containers in the pod.
+  additionalVolumes: []
+  #  - name: custom-config-map
+  #    configMap:
+  # # Provide the name of the ConfigMap containing the files you want
+  # # to add to the container
+  # name: special-config
+
   # lvmd.env -- extra environment variables
   env: []
   #  - name: LVM_SYSTEM_DIR
@@ -302,6 +311,15 @@ node:
   #    hostPath:
   #      path: /run/topolvm
   #      type: Directory
+
+  # node.additionalVolumes -- Specify additional volumes without conflicting with default volumes
+  # most useful for initContainers but available to all containers in the pod.
+  additionalVolumes: []
+  #  - name: custom-config-map
+  #    configMap:
+  # # Provide the name of the ConfigMap containing the files you want
+  # # to add to the container
+  # name: special-config
 
   volumeMounts:
     # node.volumeMounts.topolvmNode -- Specify volumes.


### PR DESCRIPTION
Additional volumes simplifies configuration for init pods in the data sets by allowing additional volumes without changing the required topolvm volumes