### PR TITLE
feat: allow disabling leader election in topolvm-controller

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -18,6 +18,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v13.
 | controller.args | list | `[]` | Arguments to be passed to the command. |
 | controller.initContainers | list | `[]` | Additional initContainers for the controller service. |
 | controller.labels | object | `{}` | Additional labels to be added to the Deployment. |
+| controller.leaderElection.enabled | bool | `true` | Enable leader election for controller and all sidecars. |
 | controller.minReadySeconds | int | `nil` | Specify minReadySeconds. |
 | controller.nodeFinalize.skipped | bool | `false` | Skip automatic cleanup of PhysicalVolumeClaims when a Node is deleted. |
 | controller.nodeSelector | object | `{}` | Specify nodeSelector. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -51,7 +51,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           command:
             - /topolvm-controller
+            {{ if not .Values.controller.leaderElection.enabled }}
+            - --leader-election=false
+            {{ else }}
             - --leader-election-namespace={{ .Release.Namespace }}
+            {{ end }}
             {{- if or .Values.webhook.podMutatingWebhook.enabled .Values.webhook.pvcMutatingWebhook.enabled }}
             - --cert-dir=/certs
             {{- else }}
@@ -140,8 +144,10 @@ spec:
             - /csi-provisioner
             - --csi-address=/run/topolvm/csi-topolvm.sock
             - --feature-gates=Topology=true
+            {{ if .Values.controller.leaderElection.enabled }}
             - --leader-election
             - --leader-election-namespace={{ .Release.Namespace }}
+            {{ end }}
             - --http-endpoint=:9809
             {{- with .Values.controller.storageCapacityTracking.enabled }}
             - --enable-capacity
@@ -183,8 +189,10 @@ spec:
           command:
             - /csi-resizer
             - --csi-address=/run/topolvm/csi-topolvm.sock
+            {{ if .Values.controller.leaderElection.enabled }}
             - --leader-election
             - --leader-election-namespace={{ .Release.Namespace }}
+            {{ end }}
             - --http-endpoint=:9810
           ports:
             - containerPort: 9810
@@ -212,8 +220,10 @@ spec:
           command:
             - /csi-snapshotter
             - --csi-address=/run/topolvm/csi-topolvm.sock
+            {{ if .Values.controller.leaderElection.enabled }}
             - --leader-election
             - --leader-election-namespace={{ .Release.Namespace }}
+            {{ end }}
             - --http-endpoint=:9811
           ports:
             - containerPort: 9811

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -357,6 +357,10 @@ controller:
     # controller.nodeFinalize.skipped -- Skip automatic cleanup of PhysicalVolumeClaims when a Node is deleted.
     skipped: false
 
+  leaderElection:
+    # controller.leaderElection.enabled -- Enable leader election for controller and all sidecars.
+    enabled: true
+
   prometheus:
     podMonitor:
       # controller.prometheus.podMonitor.enabled -- Set this to `true` to create PodMonitor for Prometheus operator.
@@ -402,6 +406,10 @@ controller:
   #  rollingUpdate:
   #    maxSurge: 50%
   #    maxUnavailable: 50%
+  #
+  # For non-leader-election mode, you can use this non-HA non-conflicting strategy:
+  #  type: Recreate
+
 
   # controller.minReadySeconds -- (int) Specify minReadySeconds.
   minReadySeconds:  # 0

--- a/pkg/topolvm-controller/cmd/root.go
+++ b/pkg/topolvm-controller/cmd/root.go
@@ -19,6 +19,7 @@ var config struct {
 	enableWebhooks              bool
 	webhookAddr                 string
 	certDir                     string
+	leaderElection              bool
 	leaderElectionID            string
 	leaderElectionNamespace     string
 	leaderElectionLeaseDuration time.Duration
@@ -58,6 +59,7 @@ func init() {
 	fs.StringVar(&config.webhookAddr, "webhook-addr", ":9443", "Listen address for the webhook endpoint")
 	fs.BoolVar(&config.enableWebhooks, "enable-webhooks", true, "Enable webhooks")
 	fs.StringVar(&config.certDir, "cert-dir", "", "certificate directory")
+	fs.BoolVar(&config.leaderElection, "leader-election", true, "Enables leader election. This field is required to be set to true if concurrency is greater than 1 at any given point in time during rollouts.")
 	fs.StringVar(&config.leaderElectionID, "leader-election-id", "topolvm", "ID for leader election by controller-runtime")
 	fs.StringVar(&config.leaderElectionNamespace, "leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
 	fs.DurationVar(&config.leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second, "Duration that non-leader candidates will wait to force acquire leadership. This is measured against time of last observed ack.")

--- a/pkg/topolvm-controller/cmd/run.go
+++ b/pkg/topolvm-controller/cmd/run.go
@@ -64,7 +64,7 @@ func subMain() error {
 		Scheme:                  scheme,
 		MetricsBindAddress:      config.metricsAddr,
 		HealthProbeBindAddress:  config.healthAddr,
-		LeaderElection:          true,
+		LeaderElection:          config.leaderElection,
 		LeaderElectionID:        config.leaderElectionID,
 		LeaderElectionNamespace: config.leaderElectionNamespace,
 		RenewDeadline:           &config.leaderElectionRenewDeadline,


### PR DESCRIPTION
This allows disabling leader election for TopoLVM controller. This is important because all sidecars support it and we should offer running TopoLVM in a non-HA controller configuration for CPU/Memory Savings and to avoid surges. This is especially used in the edge context and will not affect existing Helm Charts or Datacenter deployments.

New helm chart version has a new flag for leader election in the controller section that triggers it for topolvm-controller and all sidecars. Flag is set to true by default if omitted.

Also gives an example of a Recreate Deployment strategy that will not impact the controller cache synchronization but is non-HA