### PR TITLE
feat: Support Startup taints

### DIFF
--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -108,9 +108,12 @@ spec:
             path: {{ dir .Values.lvmd.socketName }}
             type: DirectoryOrCreate
         {{- end }}
-      {{- with $lvmd.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      tolerations:
+        {{- with $lvmd.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - key: "topolvm.io/agent-not-ready"
+          operator: "Exists"
       {{- with $lvmd.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -235,9 +235,12 @@ spec:
         {{- end }}
         {{- end }}
 
-      {{- with .Values.node.tolerations }}
-      tolerations: {{ toYaml . | nindent 8 }}
-      {{- end }}
+      tolerations:
+        {{- with .Values.node.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        - key: "topolvm.io/agent-not-ready"
+          operator: "Exists"          
       {{- with .Values.node.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,6 +44,12 @@ Finally, check if TopoLVM is running. All TopoLVM pods should be running.
 kubectl get pod -n topolvm-system
 ```
 
+## Configure node startup taint
+
+There are potential race conditions on node startup (especially when a node is first joining the cluster) where pods/processes that rely on the a CSI Driver can act on a node before the CSI Driver is able to startup up and become fully ready. To combat this, the TopoLVM contains a feature to automatically remove a taint from the node on startup. Users can taint their nodes when they join the cluster and/or on startup, to prevent other pods from running and/or being scheduled on the node prior to the CSI Driver becoming ready.
+
+This feature is activated by default, and cluster administrators should use the taint `topolvm.io/agent-not-ready:NoExecute` (any effect will work, but `NoExecute` is recommended).
+
 ## Usage
 
 You can create PersistentVolumes (PV) by TopoLVM after installation succeeded.


### PR DESCRIPTION
I common practice with csi and cni ds is to set a startup taints so that workload pods will not schedule until the ds is ready indicated by removal of the taint. This is optional the defined taint removal will be completed only if it exists. #809