### PR TITLE
doc: state the reason to build csi-sidecars

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -78,6 +78,9 @@ Edit the following files.
 
 #### CSI Sidecars
 
+> [!NOTE]
+> TopoLVM builds csi-sidecars for the cases that we want to use own-patched binaries (e.g. can't wait official binaries in case of emergency.)
+
 TopoLVM does not use all the sidecars listed [here](https://kubernetes-csi.github.io/docs/sidecar-containers.html).
 Have a look at `csi-sidecars.mk` first and understand what sidecars are actually being used.
 


### PR DESCRIPTION
We build csi-sidecars in our own. It's convenient for developers to clarify why we do so.

Fixes: https://github.com/topolvm/topolvm/issues/822