### PR TITLE
fix: CVE-2023-47108 & CVE-2023-45142

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,3 +108,8 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+exclude (
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.35.0 // to fix CVE-2023-47108
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.35.1 // to fix CVE-2023-45142
+)


### PR DESCRIPTION
This PR fixes CVE-2023-47108 & CVE-2023-45142 by excluding otelhttp and otelgrpc dependencies that are not used by TopoLVM. 

`otelhttp` exclude can be removed once TopoLVM updates to the latest version of `apiextensions-apiserver`. 

However, to remove `otelgrpc` exclude, `apiextensions-apiserver` should first update to the `v0.46.0` of `otelgrpc`.  