### PR TITLE
chore: optimized `lvm.go` fetching and parsing

### DIFF
--- a/lvmd/command/lvm_command.go
+++ b/lvmd/command/lvm_command.go
@@ -1,0 +1,161 @@
+package command
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var Containerized = false
+
+// callLVM calls lvm sub-commands and prints the output to the log.
+func callLVM(ctx context.Context, args ...string) error {
+	return callLVMInto(ctx, nil, args...)
+}
+
+// callLVMInto calls lvm sub-commands and decodes the output via JSON into the provided struct pointer.
+// if the struct pointer is nil, the output will be printed to the log instead.
+func callLVMInto(ctx context.Context, into any, args ...string) error {
+	output, err := callLVMStreamed(ctx, args...)
+	if err != nil {
+		return fmt.Errorf("failed to execute command: %v", err)
+	}
+
+	// if we don't decode the output into a struct, we can still log the command results from stdout.
+	if into == nil {
+		scanner := bufio.NewScanner(output)
+		for scanner.Scan() {
+			log.FromContext(ctx).Info(strings.TrimSpace(scanner.Text()))
+		}
+		err = scanner.Err()
+	} else {
+		err = json.NewDecoder(output).Decode(&into)
+	}
+	closeErr := output.Close()
+
+	return errors.Join(closeErr, err)
+}
+
+// callLVMStreamed calls lvm sub-commands and returns the output as a ReadCloser.
+// The caller is responsible for closing the ReadCloser, which will cause the command to complete.
+// Not calling close on this method will result in a resource leak.
+func callLVMStreamed(ctx context.Context, args ...string) (io.ReadCloser, error) {
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithCallDepth(1))
+	cmd := wrapExecCommand(lvm, args...)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "LC_ALL=C")
+	return runCommand(ctx, cmd)
+}
+
+// wrapExecCommand calls cmd with args but wrapped to run on the host with nsenter if Containerized is true.
+func wrapExecCommand(cmd string, args ...string) *exec.Cmd {
+	if Containerized {
+		args = append([]string{"-m", "-u", "-i", "-n", "-p", "-t", "1", cmd}, args...)
+		cmd = nsenter
+	}
+	c := exec.Command(cmd, args...)
+	return c
+}
+
+// runCommand runs the command and returns the stdout as a ReadCloser that also Waits for the command to finish.
+// After the Close command is called the cmd is closed and the resources are released.
+// Not calling close on this method will result in a resource leak.
+func runCommand(ctx context.Context, cmd *exec.Cmd) (io.ReadCloser, error) {
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	log.FromContext(ctx).Info("invoking command", "args", cmd.Args)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	// Return a read closer that will wait for the command to finish when closed to release all resources.
+	return commandReadCloser{cmd: cmd, ReadCloser: stdout, stderr: stderr}, nil
+}
+
+// commandReadCloser is a ReadCloser that calls the Wait function of the command when Close is called.
+// This is used to wait for the command the pipe before waiting for the command to finish.
+type commandReadCloser struct {
+	cmd *exec.Cmd
+	io.ReadCloser
+	stderr io.ReadCloser
+}
+
+func (p commandReadCloser) Close() error {
+	if err := p.ReadCloser.Close(); err != nil {
+		return err
+	}
+
+	// Read the stderr output after the read has finished since we are sure by then the command must have run.
+	stderr, err := io.ReadAll(p.stderr)
+	if err != nil {
+		return err
+	}
+
+	if err := p.cmd.Wait(); err != nil {
+		// wait can result in an exit code error
+		return &lvmErr{
+			err:    err,
+			stderr: stderr,
+		}
+	}
+	return nil
+}
+
+// AsLVMError returns the LVMError from the error if it exists and a bool indicating if is an LVMError or not.
+func AsLVMError(err error) (LVMError, bool) {
+	var lvmErr LVMError
+	ok := errors.As(err, &lvmErr)
+	return lvmErr, ok
+}
+
+// LVMError is an error that wraps the original error and the stderr output of the lvm command if found.
+// It also provides an exit code if present that can be used to determine the type of error from LVM.
+// Regular inaccessible errors will have an exit code of 5.
+type LVMError interface {
+	error
+	ExitCode() int
+	Unwrap() error
+}
+
+type lvmErr struct {
+	err    error
+	stderr []byte
+}
+
+func (e *lvmErr) Error() string {
+	if e.stderr != nil {
+		return fmt.Sprintf("%v: %v", e.err, string(bytes.TrimSpace(e.stderr)))
+	}
+	return e.err.Error()
+}
+
+func (e *lvmErr) Unwrap() error {
+	return e.err
+}
+
+func (e *lvmErr) ExitCode() int {
+	type exitError interface {
+		ExitCode() int
+		error
+	}
+	var err exitError
+	if errors.As(e.err, &err) {
+		return err.ExitCode()
+	}
+	return -1
+}

--- a/lvmd/command/lvm_command_test.go
+++ b/lvmd/command/lvm_command_test.go
@@ -1,0 +1,116 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/go-logr/logr/testr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func Test_lvm_command(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("run as root")
+	}
+	t.Run("simple lvm version should succeed with stream", func(t *testing.T) {
+		ctx := log.IntoContext(context.Background(), testr.New(t))
+		dataStream, err := callLVMStreamed(ctx, "version")
+		if err != nil {
+			t.Fatal(err, "version should succeed")
+		}
+
+		data, err := io.ReadAll(dataStream)
+		if err != nil {
+			t.Fatal(err, "data should be readable from io stream")
+		}
+		if err := dataStream.Close(); err != nil {
+			t.Fatal(err, "data stream should close without problems")
+		}
+		if !strings.Contains(string(data), "LVM version") {
+			t.Fatal("LVM version not found in output")
+		}
+	})
+
+	t.Run("simple lvm vgcreate with non existing device should fail and show logs", func(t *testing.T) {
+		// fakeDeviceName is a string that does not exist on the system (or rather is highly unlikely to exist)
+		// it is used to test the error handling of the callLVMStreamed function
+		fakeDeviceName := "/dev/does-not-exist"
+
+		ctx := log.IntoContext(context.Background(), testr.New(t))
+		dataStream, err := callLVMStreamed(ctx, "vgcreate", "test-vg", fakeDeviceName)
+		if err != nil {
+			t.Fatal(err, "vgcreate should not fail instantly as read didn't finish")
+		}
+		data, err := io.ReadAll(dataStream)
+		if err != nil {
+			t.Fatal(err, "data should be readable from io stream")
+		}
+		if len(data) != 0 {
+			t.Fatal("data should be empty as the command should fail")
+		}
+		err = dataStream.Close()
+		if err != nil {
+			t.Fatal(err, "data stream should fail during close")
+		}
+
+		lvmErr, ok := AsLVMError(err)
+		if !ok {
+			t.Fatal("error should be a LVM error")
+		}
+		if lvmErr == nil {
+			t.Fatal("error should not be nil")
+		}
+		if lvmErr.ExitCode() != 5 {
+			t.Fatalf("exit code should be 5, got %d", lvmErr.ExitCode())
+		}
+		if !strings.Contains(lvmErr.Error(), "exit status 5") {
+			t.Fatal("exit status 5 not contained in error")
+		}
+		if !strings.Contains(lvmErr.Error(), fmt.Sprintf("No device found for %s", fakeDeviceName)) {
+			t.Fatal("No device found message not contained in error")
+		}
+		if dataStream != nil {
+			t.Fatal("data stream should be nil")
+		}
+	})
+
+	t.Run("callLVM should succeed for non-json based calls", func(t *testing.T) {
+		var messages []string
+		funcLog := funcr.New(func(_, args string) {
+			messages = append(messages, args)
+		}, funcr.Options{
+			Verbosity: 9,
+		})
+
+		ctx := log.IntoContext(context.Background(), funcLog)
+		err := callLVM(ctx, "version")
+		if err != nil {
+			t.Fatal(err, "version should succeed")
+		}
+
+		if len(messages) == 0 {
+			t.Fatal("no messages logged")
+		}
+
+		if !strings.Contains(messages[0], `"args"=["/sbin/lvm","version"]`) {
+			t.Fatal("command log was not found")
+		}
+
+		// check if the version message was logged
+		stdoutExistsInLogs := false
+		for _, m := range messages[1:] {
+			if strings.Contains(m, "LVM version") {
+				stdoutExistsInLogs = true
+				break
+			}
+		}
+		if !stdoutExistsInLogs {
+			t.Fatalf("version from stdout was not logged, existing logs: %v", messages)
+		}
+	})
+}

--- a/lvmd/command/lvm_state_json.go
+++ b/lvmd/command/lvm_state_json.go
@@ -1,0 +1,60 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func parseFullReportResult(data io.ReadCloser) ([]vg, []lv, error) {
+	type fullReportResult struct {
+		Report []struct {
+			VG []vg `json:"vg"`
+			LV []lv `json:"lv"`
+		} `json:"report"`
+	}
+
+	var result fullReportResult
+	if err := json.NewDecoder(data).Decode(&result); err != nil {
+		return nil, nil, err
+	}
+
+	var vgs []vg
+	var lvs []lv
+	for _, report := range result.Report {
+		vgs = append(vgs, report.VG...)
+		lvs = append(lvs, report.LV...)
+	}
+	return vgs, lvs, nil
+}
+
+// Issue single lvm command that retrieves everything we need in one call and get the output as JSON
+func getLVMState(ctx context.Context) ([]vg, []lv, error) {
+	args := []string{
+		"--reportformat", "json",
+		"--units", "b", "--nosuffix",
+		"--configreport", "vg", "-o", "vg_name,vg_uuid,vg_size,vg_free",
+		"--configreport", "lv", "-o", "lv_uuid,lv_name,lv_full_name,lv_path,lv_size," +
+			"lv_kernel_major,lv_kernel_minor,origin,origin_size,pool_lv,lv_tags," +
+			"lv_attr,vg_name,data_percent,metadata_percent,pool_lv",
+		// fullreport doesn't have an option to omit an entire section, so we
+		// omit all fields instead.
+		"--configreport", "pv", "-o,",
+		"--configreport", "pvseg", "-o,",
+		"--configreport", "seg", "-o,",
+	}
+	streamed, err := callLVMStreamed(ctx, append([]string{"fullreport"}, args...)...)
+	defer func() {
+		// this will wait for the process to be released.
+		if err := streamed.Close(); err != nil {
+			log.FromContext(ctx).Error(err, "failed to run command")
+		}
+	}()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to execute command: %v", err)
+	}
+	return parseFullReportResult(streamed)
+}

--- a/lvmd/command/lvm_state_json_test.go
+++ b/lvmd/command/lvm_state_json_test.go
@@ -2,7 +2,9 @@ package command
 
 import (
 	"context"
+	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
@@ -60,7 +62,7 @@ func TestLvmJSON(t *testing.T) {
 		]
 	  }
 	`
-	vgs, lvs, err := parseFullReportResult([]byte(goodJSON))
+	vgs, lvs, err := parseFullReportResult(io.NopCloser(strings.NewReader(goodJSON)))
 
 	if err != nil {
 		t.Fatal(err)
@@ -216,7 +218,7 @@ func TestLvmInactiveMajorMinor(t *testing.T) {
 	  ]
 	}
   `
-	vgs, lvs, err := parseFullReportResult([]byte(inactiveMajorMinor))
+	vgs, lvs, err := parseFullReportResult(io.NopCloser(strings.NewReader(inactiveMajorMinor)))
 
 	if err != nil {
 		t.Fatal(err)
@@ -268,7 +270,7 @@ func TestLvmJSONBad(t *testing.T) {
 			],
 			"lv": [
 	`
-	vgs, lvs, err := parseFullReportResult([]byte(truncatedJSON))
+	vgs, lvs, err := parseFullReportResult(io.NopCloser(strings.NewReader(truncatedJSON)))
 
 	if vgs != nil {
 		t.Fatal("Expected vgs to be nil!")

--- a/lvmd/command/lvm_vgs.go
+++ b/lvmd/command/lvm_vgs.go
@@ -1,0 +1,75 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+)
+
+type vg struct {
+	name string
+	uuid string
+	size uint64
+	free uint64
+}
+
+func (u *vg) UnmarshalJSON(data []byte) error {
+	type vgInternal struct {
+		Name string `json:"vg_name"`
+		UUID string `json:"vg_uuid"`
+		Size string `json:"vg_size"`
+		Free string `json:"vg_free"`
+	}
+
+	var temp vgInternal
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	u.name = temp.Name
+	u.uuid = temp.UUID
+
+	var convErr error
+	u.size, convErr = strconv.ParseUint(temp.Size, 10, 64)
+	if convErr != nil {
+		return convErr
+	}
+	u.free, convErr = strconv.ParseUint(temp.Free, 10, 64)
+	if convErr != nil {
+		return convErr
+	}
+
+	return nil
+}
+
+func getVGReport(ctx context.Context, name string) (vg, error) {
+	type vgReport struct {
+		Report []struct {
+			VG []vg `json:"vg"`
+		} `json:"report"`
+	}
+	res := new(vgReport)
+	args := []string{
+		"vgs", name, "-o", "vg_uuid,vg_name,vg_size,vg_free", "--units", "b", "--nosuffix", "--reportformat", "json",
+	}
+	err := callLVMInto(ctx, res, args...)
+
+	if lvmErr, ok := AsLVMError(err); ok && lvmErr.ExitCode() == 5 {
+		// vgs returns 5 if the volume group does not exist, so we can convert this to ErrNotFound
+		// join it to the original error so that the caller can still see the stderr output.
+		return vg{}, ErrNotFound
+	}
+	if err != nil {
+		return vg{}, err
+	}
+
+	for _, report := range res.Report {
+		for _, vg := range report.VG {
+			if vg.name == name {
+				return vg, nil
+			}
+		}
+	}
+
+	return vg{}, ErrNotFound
+}

--- a/lvmd/lvservice_test.go
+++ b/lvmd/lvservice_test.go
@@ -2,6 +2,7 @@ package lvmd
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"testing"
@@ -108,7 +109,7 @@ func TestLVService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lv, err := vg.FindVolume("test1")
+	lv, err := vg.FindVolume(ctx, "test1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +149,7 @@ func TestLVService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lv, err = vg.FindVolume("test1")
+	lv, err = vg.FindVolume(ctx, "test1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,8 +184,8 @@ func TestLVService(t *testing.T) {
 	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
-	_, err = vg.FindVolume("test1")
-	if err != command.ErrNotFound {
+	_, err = vg.FindVolume(ctx, "test1")
+	if !errors.Is(err, command.ErrNotFound) {
 		t.Error("unexpected error: ", err)
 	}
 
@@ -221,7 +222,7 @@ func TestLVService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lv, err = pool.FindVolume("testp1")
+	lv, err = pool.FindVolume(ctx, "testp1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +262,7 @@ func TestLVService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lv, err = pool.FindVolume("testp1")
+	lv, err = pool.FindVolume(ctx, "testp1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,8 +284,8 @@ func TestLVService(t *testing.T) {
 	if err := vg.Update(ctx); err != nil {
 		t.Fatal(err)
 	}
-	_, err = pool.FindVolume("test1")
-	if err != command.ErrNotFound {
+	_, err = pool.FindVolume(ctx, "test1")
+	if !errors.Is(err, command.ErrNotFound) {
 		t.Error("unexpected error: ", err)
 	}
 
@@ -324,7 +325,7 @@ func TestLVService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lv, err = pool.FindVolume("sourceVol")
+	lv, err = pool.FindVolume(ctx, "sourceVol")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -380,7 +381,7 @@ func TestLVService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lv, err = pool.FindVolume("snap1")
+	lv, err = pool.FindVolume(ctx, "snap1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +433,7 @@ func TestLVService(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lv, err = pool.FindVolume("restoredsnap1")
+	lv, err = pool.FindVolume(ctx, "restoredsnap1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lvmd/vgservice_test.go
+++ b/lvmd/vgservice_test.go
@@ -188,7 +188,7 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	)
 
 	// thick lvs
-	res, err := vgService.GetLVList(context.Background(), &proto.GetLVListRequest{DeviceClass: thickdev})
+	res, err := vgService.GetLVList(ctx, &proto.GetLVListRequest{DeviceClass: thickdev})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	}
 
 	// thin lvs
-	res, err = vgService.GetLVList(context.Background(), &proto.GetLVListRequest{DeviceClass: thindev})
+	res, err = vgService.GetLVList(ctx, &proto.GetLVListRequest{DeviceClass: thindev})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,13 +210,12 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 
 	// create thick volume
 	testtag := "testtag"
-	_, err = vg.CreateVolume(ctx, "test1", 1<<30, []string{testtag}, 0, "", nil)
-	if err != nil {
+	if err := vg.CreateVolume(ctx, "test1", 1<<30, []string{testtag}, 0, "", nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// thick lv validation
-	res, err = vgService.GetLVList(context.Background(), &proto.GetLVListRequest{DeviceClass: thickdev})
+	res, err = vgService.GetLVList(ctx, &proto.GetLVListRequest{DeviceClass: thickdev})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,13 +239,12 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	}
 
 	// create thin volume
-	_, err = pool.CreateVolume(ctx, "testp1", 1<<30, []string{testtag}, 0, "", nil)
-	if err != nil {
+	if err = pool.CreateVolume(ctx, "testp1", 1<<30, []string{testtag}, 0, "", nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// thin lv validation
-	res, err = vgService.GetLVList(context.Background(), &proto.GetLVListRequest{DeviceClass: thindev})
+	res, err = vgService.GetLVList(ctx, &proto.GetLVListRequest{DeviceClass: thindev})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,13 +272,18 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	}
 
 	// thick lv creation
-	_, err = vg.CreateVolume(ctx, "test2", 1<<30, nil, 0, "", nil)
-	if err != nil {
+
+	if err = vg.CreateVolume(ctx, "test2", 1<<30, nil, 0, "", nil); err != nil {
 		t.Fatal(err)
 	}
 
 	// thin lv creation, within overprovision limit (10G)
-	testp2, err := pool.CreateVolume(ctx, "testp2", 1<<30, nil, 0, "", nil)
+
+	if err := pool.CreateVolume(ctx, "testp2", 1<<30, nil, 0, "", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	testp2, err := pool.FindVolume(ctx, "testp2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +301,7 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	}
 
 	// thick lv validation
-	res, err = vgService.GetLVList(context.Background(), &proto.GetLVListRequest{DeviceClass: thickdev})
+	res, err = vgService.GetLVList(ctx, &proto.GetLVListRequest{DeviceClass: thickdev})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,7 +311,7 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	}
 
 	// thick lv validation
-	res, err = vgService.GetLVList(context.Background(), &proto.GetLVListRequest{DeviceClass: thickdev})
+	res, err = vgService.GetLVList(ctx, &proto.GetLVListRequest{DeviceClass: thickdev})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +321,7 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	}
 
 	// thick lv size validations
-	res2, err := vgService.GetFreeBytes(context.Background(), &proto.GetFreeBytesRequest{DeviceClass: thickdev})
+	res2, err := vgService.GetFreeBytes(ctx, &proto.GetFreeBytesRequest{DeviceClass: thickdev})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,11 +340,11 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	}
 
 	// thin lv size validations
-	res2, err = vgService.GetFreeBytes(context.Background(), &proto.GetFreeBytesRequest{DeviceClass: thindev})
+	res2, err = vgService.GetFreeBytes(ctx, &proto.GetFreeBytesRequest{DeviceClass: thindev})
 	if err != nil {
 		t.Fatal(err)
 	}
-	tpu, err := pool.Free()
+	tpu, err := pool.Free(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,22 +356,29 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 	}
 
 	// Creation of thick volumes
-	test3Vol, err := vg.CreateVolume(ctx, "test3", 1<<30, nil, 2, "4k", nil)
+
+	if err := vg.CreateVolume(ctx, "test3", 1<<30, nil, 2, "4k", nil); err != nil {
+		t.Fatal(err)
+	}
+	test3Vol, err := vg.FindVolume(ctx, "test3")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	test4Vol, err := vg.CreateVolume(ctx, "test4", 1<<30, nil, 2, "4M", nil)
+	if err := vg.CreateVolume(ctx, "test4", 1<<30, nil, 2, "4M", nil); err != nil {
+		t.Fatal(err)
+	}
+	test4Vol, err := vg.FindVolume(ctx, "test4")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Remove volumes to make room for a raid volume
-	test3Vol.Remove(ctx)
-	test4Vol.Remove(ctx)
+	_ = vg.RemoveVolume(ctx, test3Vol.Name())
+	_ = vg.RemoveVolume(ctx, test4Vol.Name())
 
 	// Remove one of the thin lvs
-	testp2.Remove(ctx)
+	_ = vg.RemoveVolume(ctx, testp2.Name())
 
 	t.Run("thinpool-stripe-raid", func(t *testing.T) {
 		t.Skip("investigate support of striped and raid for thinlvs")
@@ -376,31 +386,35 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 		// 1. confirm that stripe, stripesize and raid isn't possible on thin lv
 		// 2. if above is true, enforce some sensible defaults during validation of deviceclass
 		// thick lv with raid
-		_, err = vg.CreateVolume(ctx, "test5", 1<<30, nil, 0, "", []string{"--type=raid1"})
-		if err != nil {
+		if err := vg.CreateVolume(ctx, "test5", 1<<30, nil, 0, "", []string{"--type=raid1"}); err != nil {
 			t.Fatal(err)
 		}
 
 		// thin lv with stripe, stripesize and raid options
-		testp3Vol, err := pool.CreateVolume(ctx, "test3", 1<<30, nil, 2, "4k", nil)
+		if err := pool.CreateVolume(ctx, "test3", 1<<30, nil, 2, "4k", nil); err != nil {
+			t.Fatal(err)
+		}
+		testp3Vol, err := vg.FindVolume(ctx, "test3")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		testp4Vol, err := pool.CreateVolume(ctx, "test4", 1<<30, nil, 2, "4M", nil)
+		if err := pool.CreateVolume(ctx, "test4", 1<<30, nil, 2, "4M", nil); err != nil {
+			t.Fatal(err)
+		}
+		testp4Vol, err := vg.FindVolume(ctx, "test4")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// thin lv with raid
-		_, err = pool.CreateVolume(ctx, "test5", 1<<30, nil, 0, "", []string{"--type=raid1"})
-		if err != nil {
+		if err = pool.CreateVolume(ctx, "test5", 1<<30, nil, 0, "", []string{"--type=raid1"}); err != nil {
 			t.Fatal(err)
 		}
 
 		// Remove thin volumes
-		testp3Vol.Remove(ctx)
-		testp4Vol.Remove(ctx)
+		_ = vg.RemoveVolume(ctx, testp3Vol.Name())
+		_ = vg.RemoveVolume(ctx, testp4Vol.Name())
 
 	})
 }

--- a/pkg/lvmd/cmd/root.go
+++ b/pkg/lvmd/cmd/root.go
@@ -73,7 +73,7 @@ func subMain(ctx context.Context) error {
 		}
 
 		if dc.Type == lvmd.TypeThin {
-			_, err = vg.FindPool(dc.ThinPoolConfig.Name)
+			_, err = vg.FindPool(ctx, dc.ThinPoolConfig.Name)
 			if err != nil {
 				logger.Error(err, "Thin pool not found:", "thinpool", dc.ThinPoolConfig.Name)
 				return err


### PR DESCRIPTION
attempts to fix #800 by reworking the lvm subsystem in topolvm with the following priorities:

- Become stateless by loosing lvs view in vg except for lvm state
- Run IO stream based decoders for JSON decodes to avoid wasting allocations and CPU cycles
- Avoid Refreshes of the VG by lvm.go as the updated data is never used inside vgservice and lvservice
- remove return values of pointers after create commands so that they can be fetched in the services for more fine grained access control over lvm
- replace lvmstate calls with targeted vgs and lvs calls that have the same output but require less parsing and less fetching on the lvm side