### PR TITLE
chore: reduce GetCapacity log level

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -501,12 +501,12 @@ func (s controllerServerNoLocked) ValidateVolumeCapabilities(ctx context.Context
 func (s controllerServerNoLocked) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 	topology := req.GetAccessibleTopology()
 	capabilities := req.GetVolumeCapabilities()
-	ctrlLogger.Info("GetCapacity called",
+	ctrlLogger.V(1).Info("GetCapacity called",
 		"volume_capabilities", capabilities,
 		"parameters", req.GetParameters(),
 		"accessible_topology", topology)
 	if capabilities != nil {
-		ctrlLogger.Info("capability argument is not nil, but TopoLVM ignores it")
+		ctrlLogger.V(1).Info("capability argument is not nil, but TopoLVM ignores it")
 	}
 
 	deviceClass := req.GetParameters()[topolvm.GetDeviceClassKey()]


### PR DESCRIPTION
This reduces the log level of the GetCapacity called message and the ignored nil capability argument as they are regularly called by K8s/CSI and spam the logs without adding significant value for debugging or troubleshooting.

This will result in these messages not being logged by default but still being accessible with higher log level