### PR TITLE
Introduce 4096 byte Sector Size Minimum for Rounding LV Sizes on Creation and Resizing

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -94,6 +94,13 @@ const DefaultSizeGb = 1
 // DefaultSize is DefaultSizeGb in bytes
 const DefaultSize = int64(DefaultSizeGb << 30)
 
+// MinimumSectorSize is the minimum size in bytes for volumes (PVC or generic ephemeral volumes).
+// It is derived from the usual sector size of 512,1024 or 4096 bytes for logical volumes.
+// While Sector Sizes of 512 are common, using 4096 is safe
+// As it also aligns with 512 and 1024 byte sectors, and is the default for most modern disks.
+// Going lower than this size will cause validation issues on volume creation for the user.
+const MinimumSectorSize = int64(4096)
+
 // Label key that indicates The controller/user who created this resource
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
 const CreatedbyLabelKey = "app.kubernetes.io/created-by"

--- a/internal/lvmd/command/lvm_command_test.go
+++ b/internal/lvmd/command/lvm_command_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,9 @@ import (
 
 	"github.com/go-logr/logr/funcr"
 	"github.com/go-logr/logr/testr"
+	"github.com/topolvm/topolvm"
+	"github.com/topolvm/topolvm/internal/lvmd/testutils"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -112,5 +116,49 @@ func Test_lvm_command(t *testing.T) {
 		if !stdoutExistsInLogs {
 			t.Fatalf("version from stdout was not logged, existing logs: %v", messages)
 		}
+	})
+
+	t.Run("lv creation", func(t *testing.T) {
+		ctx := ctrl.LoggerInto(context.Background(), testr.New(t))
+		vgName := "lvm_command_test"
+		loop, err := testutils.MakeLoopbackDevice(ctx, vgName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = testutils.MakeLoopbackVG(ctx, vgName, loop)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer testutils.CleanLoopbackVG(vgName, []string{loop}, []string{vgName})
+
+		vg, err := FindVolumeGroup(ctx, vgName)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Run("create volume with multiple of Sector Size is fine", func(t *testing.T) {
+			err = vg.CreateVolume(ctx, "test1", uint64(topolvm.MinimumSectorSize), []string{"tag"}, 0, "", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			vol, err := vg.FindVolume(ctx, "test1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if vol.Size()%uint64(topolvm.MinimumSectorSize) != 0 {
+				t.Fatalf("expected size to be multiple of sector size %d, got %d", uint64(topolvm.MinimumSectorSize), vol.Size())
+			}
+			if err := vg.RemoveVolume(ctx, "test1"); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("create volume with size not multiple of sector Size to get rejected", func(t *testing.T) {
+			err = vg.CreateVolume(ctx, "test1", uint64(topolvm.MinimumSectorSize)+1, []string{"tag"}, 0, "", nil)
+			if !errors.Is(err, ErrNoMultipleOfSectorSize) {
+				t.Fatalf("expected error to be %v, got %v", ErrNoMultipleOfSectorSize, err)
+			}
+		})
 	})
 }


### PR DESCRIPTION
This PR adds a 4096 Minimum Size limitation for all Logical Volumes that are created. The reason is that if one decides to use byte level precision on a PVC, that byte amount is now passed through to lvcreate. However if this byte-amount is not a multiple of the sector size (for most machines either 512, 1024 or 4096) then LVM will throw an error like

```
Size is not a multiple of 512. Try using 221920768 or 221921280.
  Invalid argument for --virtualsize: 221920847b 
```

In this case, we should round down in order to allow for a PVC creation with slightly different Size than the one requested as this is much better than getting rejected the PVC scheduling. 

The code is now changed to automatically round down or up (based on wether the limit or the request bytes are used and which one is larger). For edge cases during rounding we introduce new error cases.

Note that even though the 4KiB limit here is important for validation, the size might in the end still be rounded up to the nearest physical extent size (4MiB by default)