### PR TITLE
Avoid disk nospace when release workflow

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,43 @@
+on:
+  workflow_call:
+    inputs:
+      topolvm_version:
+        description: "TopoLVM version"
+        default: "devel"
+        type: string
+      image_tag:
+        description: "Image tag"
+        default: "latest"
+        type: string
+      image_prefix:
+        description: "Image prefix"
+        default: ""
+        type: string
+      push:
+        description: "Push images"
+        default: "false"
+        type: string
+
+jobs:
+  build-images:
+    name: "build-images"
+    runs-on: "ubuntu-20.04"
+    strategy:
+      fail-fast: true
+      matrix:
+        image:
+          - "normal"
+          - "with-sidecar"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login registry
+        if: ${{ inputs.push == 'true' }}
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - run: make multi-platform-image-${{ matrix.image }}
+        env:
+          TOPOLVM_VERSION: ${{ inputs.topolvm_version }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_PREFIX: ${{ inputs.image_prefix }}
+          PUSH: ${{ inputs.push }}

--- a/.github/workflows/e2e-k8s-incluster-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-incluster-lvmd.yaml
@@ -30,15 +30,6 @@ jobs:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: cache go dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ hashFiles('go.sum', 'Makefile', 'versions.mk') }}
-          restore-keys: |
-            go-
       - name: cache e2e sidecar binaries
         uses: actions/cache@v4
         with:

--- a/.github/workflows/e2e-k8s-workflow.yaml
+++ b/.github/workflows/e2e-k8s-workflow.yaml
@@ -23,15 +23,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - name: cache go dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ hashFiles('go.sum', 'Makefile', 'versions.mk') }}
-          restore-keys: |
-            go-
       - uses: actions/cache/restore@v4
         with:
           path: |

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -21,15 +21,6 @@ jobs:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: cache go dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ hashFiles('go.sum', 'Makefile', 'versions.mk') }}
-          restore-keys: |
-            go-
       - name: cache e2e sidecar binaries
         uses: actions/cache@v4
         with:

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -21,16 +21,6 @@ jobs:
         with:
           go-version-file: "go.mod"
 
-      - name: cache go dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ hashFiles('go.sum', 'Makefile', 'versions.mk') }}
-          restore-keys: |
-            go-
-
       - name: "Setup Tools"
         run: |
           make tools

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,19 +22,7 @@ jobs:
 
   build-images:
     name: "build-images"
-    runs-on: "ubuntu-20.04"
-    strategy:
-      fail-fast: true
-      matrix:
-        image:
-          - "normal"
-          - "with-sidecar"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - run: make setup-docker-buildx
-      - run: make multi-platform-image-${{ matrix.image }}
+    uses: ./.github/workflows/build-images.yaml
 
   container-structure-test:
     name: "container-structure-test"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,15 +15,6 @@ jobs:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: cache go dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ hashFiles('go.sum', 'Makefile', 'versions.mk') }}
-          restore-keys: |
-            go-
       - run: make setup
       - run: make check-uncommitted
       - run: make test
@@ -77,14 +68,5 @@ jobs:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: cache go dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ hashFiles('go.sum', 'Makefile', 'versions.mk') }}
-          restore-keys: |
-            go-
       - run: make setup
       - run: make run

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,13 @@ on:
     tags:
       - "v*"
 jobs:
-  release:
-    name: "release"
-    runs-on: "ubuntu-20.04"
+  prepare:
+    name: "prepare"
+    outputs:
+      version: ${{ steps.check_version.outputs.version }}
+      prerelease: ${{ steps.check_version.outputs.prerelease }}
+      image_prefix: ${{ steps.export_image_prefix.outputs.image_prefix }}
+    runs-on: "ubuntu-latest"
     steps:
       - name: "Validate Release Version"
         id: check_version
@@ -19,26 +23,43 @@ jobs:
           if [ $(echo $VERSION | grep "-") ]; then PRERELEASE=true; else PRERELEASE=false; fi
           echo "version=${VERSION}" >> ${GITHUB_OUTPUT}
           echo "prerelease=${PRERELEASE}" >> ${GITHUB_OUTPUT}
-      - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: "Export IMAGE_PREFIX"
+        id: export_image_prefix
         run: |
           if [ "${{ secrets.IMAGE_PREFIX }}" != "" ]; then IMAGE_PREFIX=${{ secrets.IMAGE_PREFIX }}; else IMAGE_PREFIX=ghcr.io/topolvm/; fi
-          echo "IMAGE_PREFIX=${IMAGE_PREFIX}" >> $GITHUB_ENV
+          echo "IMAGE_PREFIX=${IMAGE_PREFIX}" >> ${GITHUB_OUTPUT}
+
+  build-images:
+    name: "build-images"
+    needs: prepare
+    uses: ./.github/workflows/build-images.yaml
+    with:
+      topolvm_version: ${{ needs.prepare.outputs.version }}
+      image_tag: ${{ needs.prepare.outputs.version }}
+      image_prefix: ${{ needs.prepare.outputs.image_prefix }}
+      push: "true"
+
+  release:
+    name: "release"
+    needs: [prepare, build-images]
+    runs-on: "ubuntu-20.04"
+    steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - run: make setup
-      - run: make build/lvmd TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
-      - run: tar czf lvmd-${{ steps.check_version.outputs.version }}.tar.gz -C ./build lvmd
-      - run: make multi-platform-images PUSH=true TOPOLVM_VERSION=${{ steps.check_version.outputs.version }} IMAGE_TAG=${{ steps.check_version.outputs.version }}
+      - run: make build/lvmd TOPOLVM_VERSION=${{ needs.prepare.outputs.version }}
+      - run: tar czf lvmd-${{ needs.prepare.outputs.version }}.tar.gz -C ./build lvmd
       - name: "Push branch tag"
-        if: ${{ steps.check_version.outputs.prerelease == 'false' }}
+        if: ${{ needs.prepare.outputs.prerelease == 'false' }}
         run: |
-          BRANCH=$(echo ${{ steps.check_version.outputs.version }} | cut -d "." -f 1-2)
-          make tag IMAGE_TAG=$BRANCH ORIGINAL_IMAGE_TAG=${{ steps.check_version.outputs.version }}
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          BRANCH=$(echo ${{ needs.prepare.outputs.version }} | cut -d "." -f 1-2)
+          make tag IMAGE_TAG=$BRANCH ORIGINAL_IMAGE_TAG=${{ needs.preapre.outputs.version }}
+        env:
+          IMAGE_PREFIX: ${{ needs.prepare.outputs.image_prefix }}
       - name: "Get previous tag"
         id: get_previous_tag
         run: |
@@ -69,12 +90,12 @@ jobs:
             -f tag_name="${GITHUB_REF_NAME}" \
             -f previous_tag_name="${{ steps.get_previous_tag.outputs.previous_tag }}" \
             -F draft=true \
-            -F prerelease=${{ steps.check_version.outputs.prerelease }} \
+            -F prerelease=${{ needs.prepare.outputs.prerelease }} \
             -F generate_release_notes=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Upload Release Asset"
         run: |
-          gh release upload ${GITHUB_REF_NAME} lvmd-${{ steps.check_version.outputs.version }}.tar.gz
+          gh release upload ${GITHUB_REF_NAME} lvmd-${{ needs.prepare.outputs.version }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,15 +30,6 @@ jobs:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: cache go dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ hashFiles('go.sum', 'Makefile', 'versions.mk') }}
-          restore-keys: |
-            go-
       - run: make setup
       - run: make build/lvmd TOPOLVM_VERSION=${{ steps.check_version.outputs.version }}
       - run: tar czf lvmd-${{ steps.check_version.outputs.version }}.tar.gz -C ./build lvmd


### PR DESCRIPTION
The release workflow failed because of disk no space. see https://github.com/topolvm/topolvm/actions/runs/8137581069/job/22237189098
I doubt actions runner has consumed more disk space than before. To avoid disk exhaustion, use dedicated jobs to build images.