### PR TITLE
feat: Introduce minimum PVC allocation sizing by creating minimum allocation settings

### DIFF
--- a/cmd/topolvm-controller/app/run.go
+++ b/cmd/topolvm-controller/app/run.go
@@ -137,7 +137,7 @@ func subMain() error {
 	// Add gRPC server to manager.
 	grpcServer := grpc.NewServer()
 	csi.RegisterIdentityServer(grpcServer, driver.NewIdentityServer(checker.Ready))
-	controllerSever, err := driver.NewControllerServer(mgr)
+	controllerSever, err := driver.NewControllerServer(mgr, config.controllerServerSettings)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/common v0.44.0
 	github.com/pseudomuto/protoc-gen-doc v1.5.0
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.17.0
 	go.uber.org/zap v1.25.0
 	golang.org/x/sys v0.15.0
@@ -96,7 +97,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.10.0 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.9 // indirect

--- a/internal/driver/allocation_settings.go
+++ b/internal/driver/allocation_settings.go
@@ -1,0 +1,107 @@
+package driver
+
+import (
+	"reflect"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// MinimumAllocationSettings contains the minimum allocation settings for the controller.
+// It contains the default settings.
+type MinimumAllocationSettings struct {
+	Filesystem map[string]Quantity `json:"filesystem" ,yaml:"filesystem"`
+	Block      Quantity            `json:"block" ,yaml:"block"`
+}
+
+type Quantity resource.Quantity
+
+var _ pflag.Value = &Quantity{}
+
+func newQuantityValue(val resource.Quantity, p *Quantity) *Quantity {
+	*p = Quantity(val)
+	return p
+}
+
+func NewQuantityFlagVar(fs *pflag.FlagSet, name string, value resource.Quantity, usage string) Quantity {
+	p := new(Quantity)
+	fs.Var(newQuantityValue(value, p), name, usage)
+	return *p
+}
+
+func QuantityVar(fs *pflag.FlagSet, p *Quantity, name string, value resource.Quantity, usage string) {
+	fs.Var(newQuantityValue(value, p), name, usage)
+}
+
+func (q *Quantity) String() string {
+	rq := resource.Quantity(*q)
+	return rq.String()
+}
+
+func (q *Quantity) Set(s2 string) error {
+	rq, err := resource.ParseQuantity(s2)
+	if err != nil {
+		return err
+	}
+	*q = Quantity(rq)
+	return nil
+}
+
+func (q *Quantity) Type() string {
+	rq := resource.Quantity(*q)
+	return reflect.TypeOf(rq).String()
+}
+
+// MinMaxAllocationsFromSettings returns the minimum and maximum allocations based on the settings.
+// It uses the required and limit bytes from the CSI Call and the device class and capabilities from the StorageClass.
+// It then returns the minimum and maximum allocations in bytes that can be used for that context.
+func (settings MinimumAllocationSettings) MinMaxAllocationsFromSettings(
+	required, limit int64,
+	capabilities []*csi.VolumeCapability,
+) (int64, int64) {
+	minimumSize := settings.GetMinimumAllocationSize(capabilities)
+
+	if minimumSize.CmpInt64(required) > 0 {
+		ctrlLogger.Info("required size is less than minimum size, "+
+			"using minimum size as required size", "required", required, "minimum", minimumSize.Value())
+		required = minimumSize.Value()
+	}
+
+	return required, limit
+}
+
+// GetMinimumAllocationSize returns the minimum size to be allocated from the parameters derived from the StorageClass.
+// it uses either the filesystem or block key to get the minimum allocated size.
+// it determines which key to use based on the capabilities.
+// If no key is found or neither capability exists, it returns 0.
+// If the value is not a valid Quantity, it returns an error.
+func (settings MinimumAllocationSettings) GetMinimumAllocationSize(
+	capabilities []*csi.VolumeCapability,
+) resource.Quantity {
+	var quantity resource.Quantity
+
+	for _, capability := range capabilities {
+		if capability.GetBlock() != nil {
+			quantity = resource.Quantity(settings.Block)
+			break
+		}
+
+		if capability.GetMount() != nil {
+			rawQuantity, ok := settings.Filesystem[capability.GetMount().FsType]
+			if !ok {
+				break
+			}
+
+			quantity = resource.Quantity(rawQuantity)
+
+			break
+		}
+	}
+
+	if quantity.Sign() < 0 {
+		return resource.MustParse("0")
+	}
+
+	return quantity
+}

--- a/internal/driver/allocation_settings_test.go
+++ b/internal/driver/allocation_settings_test.go
@@ -1,0 +1,180 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func Test_MinimumAllocationSettings(t *testing.T) {
+	mockBlock := &csi.VolumeCapability{AccessType: &csi.VolumeCapability_Block{
+		Block: &csi.VolumeCapability_BlockVolume{},
+	}}
+	mockMount := &csi.VolumeCapability{AccessType: &csi.VolumeCapability_Mount{
+		Mount: &csi.VolumeCapability_MountVolume{FsType: "ext4"},
+	}}
+
+	type testBytes struct {
+		required, limit int64
+	}
+	testCases := []struct {
+		name string
+
+		settings MinimumAllocationSettings
+
+		capabilities []*csi.VolumeCapability
+
+		input    testBytes
+		expected testBytes
+	}{
+		{
+			name:     "no settings result in pass through",
+			settings: MinimumAllocationSettings{},
+			input: testBytes{
+				required: 1 << 30,
+				limit:    2 << 30,
+			},
+			expected: testBytes{
+				required: 1 << 30,
+				limit:    2 << 30,
+			},
+		},
+		{
+			name: "minimum should be applied for block storage",
+			settings: MinimumAllocationSettings{
+				Block: Quantity(resource.MustParse("1Gi")),
+			},
+			capabilities: []*csi.VolumeCapability{mockBlock},
+			input: testBytes{
+				required: 0,
+				limit:    2 << 30,
+			},
+			expected: testBytes{
+				required: 1 << 30,
+				limit:    2 << 30,
+			},
+		},
+		{
+			name: "negative minimum should result in no minimum",
+			settings: MinimumAllocationSettings{
+				Block: Quantity(resource.MustParse("-1")),
+			},
+			capabilities: []*csi.VolumeCapability{mockBlock},
+			input: testBytes{
+				required: 0,
+				limit:    2 << 30,
+			},
+			expected: testBytes{
+				required: 0,
+				limit:    2 << 30,
+			},
+		},
+		{
+			name: "minimum should be ignored if request is bigger",
+			settings: MinimumAllocationSettings{
+				Block: Quantity(resource.MustParse("1Gi")),
+			},
+			capabilities: []*csi.VolumeCapability{mockBlock},
+			input: testBytes{
+				required: 2 << 30,
+				limit:    2 << 30,
+			},
+			expected: testBytes{
+				required: 2 << 30,
+				limit:    2 << 30,
+			},
+		},
+		{
+			name: "minimum should be applied for filesystem storage (if fs matches)",
+			settings: MinimumAllocationSettings{
+				Filesystem: map[string]Quantity{
+					"ext4": Quantity(resource.MustParse("1Gi")),
+				},
+			},
+			capabilities: []*csi.VolumeCapability{mockMount},
+			input: testBytes{
+				required: 0,
+				limit:    2 << 30,
+			},
+			expected: testBytes{
+				required: 1 << 30,
+				limit:    2 << 30,
+			},
+		},
+		{
+			name: "unknown filesystem minimum should be ignored",
+			settings: MinimumAllocationSettings{
+				Filesystem: map[string]Quantity{
+					"foo": Quantity(resource.MustParse("1Gi")),
+				},
+			},
+			capabilities: []*csi.VolumeCapability{mockMount},
+			input: testBytes{
+				required: 0,
+				limit:    2 << 30,
+			},
+			expected: testBytes{
+				required: 0,
+				limit:    2 << 30,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			required, limit := tc.settings.MinMaxAllocationsFromSettings(
+				tc.input.required, tc.input.limit, tc.capabilities)
+
+			if required != tc.expected.required {
+				t.Errorf("expected minimum/required bytes to be %d, but got %d", tc.expected.required, required)
+			}
+			if limit != tc.expected.limit {
+				t.Errorf("expected minimum/required bytes to be %d, but got %d", tc.expected.limit, limit)
+			}
+		})
+	}
+}
+
+func TestQuantity_UnmarshalText(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected int64
+		err      bool
+	}{
+		{
+			name:     "valid Quantity",
+			input:    "1Gi",
+			expected: 1 << 30,
+		},
+		{
+			name:     "negative Quantity",
+			input:    "-1",
+			expected: -1,
+		},
+		{
+			name:     "invalid Quantity",
+			input:    "blub",
+			expected: 0,
+			err:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var q Quantity
+			err := q.Set(tc.input)
+			if tc.err && err == nil {
+				t.Errorf("expected error, but got none")
+			}
+			if !tc.err && err != nil {
+				t.Errorf("expected no error, but got %v", err)
+			}
+			resourceQuantity := resource.Quantity(q)
+			if resourceQuantity.CmpInt64(tc.expected) != 0 {
+				t.Errorf("expected %d, but got %s", tc.expected, resourceQuantity.String())
+			}
+		})
+	}
+}

--- a/internal/driver/controller_test.go
+++ b/internal/driver/controller_test.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -8,94 +9,87 @@ import (
 )
 
 func Test_convertRequestCapacityBytes(t *testing.T) {
-	_, err := convertRequestCapacityBytes(-1, 10)
-	if err == nil {
-		t.Error("should be error")
-	}
-	if err.Error() != "required capacity must not be negative" {
-		t.Error("should report invalid required capacity")
-	}
-
-	_, err = convertRequestCapacityBytes(10, -1)
-	if err == nil {
-		t.Error("should be error")
-	}
-	if err.Error() != "capacity limit must not be negative" {
-		t.Error("should report invalid capacity limit")
-	}
-
-	_, err = convertRequestCapacityBytes(20, 10)
-	if err == nil {
-		t.Error("should be error")
-	}
-	if err.Error() != "requested capacity exceeds limit capacity: request=20 limit=10" {
-		t.Error("should report capacity limit exceeded")
-	}
-
-	v, err := convertRequestCapacityBytes(0, topolvm.MinimumSectorSize-1)
-	if err == nil {
-		t.Error("should be error")
-	}
-	if err.Error() != "requested capacity is 0, because it defaulted to the limit (4095) and was rounded down to the nearest sector size (4096). specify the limit to be at least 4096 bytes" {
-		t.Errorf("should error if rounded-down limit is 0: %d", v)
-	}
-
-	v, err = convertRequestCapacityBytes(0, topolvm.MinimumSectorSize+1)
-	if err != nil {
-		t.Error("should not be error")
-	}
-	if v != topolvm.MinimumSectorSize {
-		t.Errorf("should be nearest rounded down multiple of sector size if 0 is supplied and limit is larger than sector-size: %d", v)
-	}
-
-	v, err = convertRequestCapacityBytes(0, 2<<30)
-	if err != nil {
-		t.Error("should not be error")
-	}
-	if v != 1<<30 {
-		t.Errorf("should be at least 1 Gi requested by default if 0 is supplied: %d", v)
-	}
-
-	v, err = convertRequestCapacityBytes(1, 0)
-	if err != nil {
-		t.Error("should not be error")
-	}
-	if v != topolvm.MinimumSectorSize {
-		t.Errorf("should be resolve capacities < 1Gi without error if there is no limit: %d", v)
-	}
-
-	v, err = convertRequestCapacityBytes(1<<30, 1<<30)
-	if err != nil {
-		t.Error("should not be error")
-	}
-	if v != 1<<30 {
-		t.Errorf("should be 1073741824 in byte precision: %d", v)
-	}
-
-	_, err = convertRequestCapacityBytes(1<<30+1, 1<<30+1)
-	if err == nil {
-		t.Error("should be error")
-	}
-	if err.Error() != "requested capacity rounded to nearest sector size (4096) exceeds limit capacity, either specify a lower request or a higher limit: request=1073745920 limit=1073741825" {
-		t.Error("should report capacity limit exceeded after rounding")
+	testCases := []struct {
+		requestBytes int64
+		limitBytes   int64
+		expected     int64
+		err          error
+	}{
+		{
+			requestBytes: -1,
+			limitBytes:   10,
+			err:          ErrNoNegativeRequestBytes,
+		},
+		{
+			requestBytes: 10,
+			limitBytes:   -1,
+			err:          ErrNoNegativeLimitBytes,
+		},
+		{
+			requestBytes: 20,
+			limitBytes:   10,
+			err:          ErrRequestedExceedsLimit,
+		},
+		{
+			requestBytes: 1<<30 + 1,
+			limitBytes:   1<<30 + 1,
+			err:          ErrRequestedExceedsLimit,
+		},
+		{
+			requestBytes: 0,
+			limitBytes:   topolvm.MinimumSectorSize - 1,
+			err:          ErrResultingRequestIsZero,
+		},
+		{
+			requestBytes: 0,
+			limitBytes:   topolvm.MinimumSectorSize + 1,
+			expected:     topolvm.MinimumSectorSize,
+		},
+		{
+			requestBytes: 1,
+			limitBytes:   topolvm.MinimumSectorSize * 2,
+			expected:     topolvm.MinimumSectorSize,
+		},
+		{
+			requestBytes: 0,
+			limitBytes:   2 << 30,
+			expected:     1 << 30,
+		},
+		{
+			requestBytes: 1,
+			limitBytes:   0,
+			expected:     topolvm.MinimumSectorSize,
+		},
+		{
+			requestBytes: 1 << 30,
+			limitBytes:   1 << 30,
+			expected:     1 << 30,
+		},
+		{
+			requestBytes: 0,
+			limitBytes:   0,
+			expected:     1 << 30,
+		},
 	}
 
-	v, err = convertRequestCapacityBytes(0, 0)
-	if err != nil {
-		t.Error("should not be error")
-	}
-	if v != 1<<30 {
-		t.Errorf("should be 1073741825 in byte precision: %d", v)
-	}
+	for _, tc := range testCases {
+		tcName := fmt.Sprintf("request:%d limit:%d", tc.requestBytes, tc.limitBytes)
+		if tc.err != nil {
+			tcName += fmt.Sprintf(" = %s", tc.err)
+		} else {
+			tcName += fmt.Sprintf(" = %v", tc.expected)
+		}
 
-	v, err = convertRequestCapacityBytes(1, topolvm.MinimumSectorSize*2)
-	if err != nil {
-		t.Error("should not be error")
+		t.Run(tcName, func(t *testing.T) {
+			v, err := convertRequestCapacityBytes(tc.requestBytes, tc.limitBytes)
+			if !errors.Is(err, tc.err) {
+				t.Errorf("expected error %v, but got %v", tc.err, err)
+			}
+			if v != tc.expected {
+				t.Errorf("expected %d, but got %d", tc.expected, v)
+			}
+		})
 	}
-	if v != topolvm.MinimumSectorSize {
-		t.Errorf("should be %d in byte precision: %d", topolvm.MinimumSectorSize, v)
-	}
-
 }
 
 func Test_roundUp(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -13,7 +13,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/topolvm/topolvm"
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
+	"github.com/topolvm/topolvm/cmd/topolvm-controller/app"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 //go:embed testdata/e2e/pvc-template.yaml
@@ -57,7 +59,7 @@ func testE2E() {
 
 	It("should be mounted in specified path", func() {
 		By("deploying Pod with PVC")
-		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1, "topolvm-provisioner"))
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1024, "topolvm-provisioner"))
 		podYaml := []byte(fmt.Sprintf(podVolumeMountTemplateYAML, "ubuntu", "topo-pvc"))
 
 		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
@@ -118,6 +120,100 @@ func testE2E() {
 		Eventually(func() error {
 			return checkLVIsRegisteredInLVM(pvc.Spec.VolumeName)
 		}).Should(Succeed())
+
+		By("deleting the Pod and PVC")
+		_, err = kubectlWithInput(podYaml, "delete", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = kubectlWithInput(claimYAML, "delete", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("confirming that the PV is deleted")
+		Eventually(func() error {
+			var pv corev1.PersistentVolume
+			err := getObjects(&pv, "pv", volName)
+			switch {
+			case err == ErrObjectNotFound:
+				return nil
+			case err != nil:
+				return fmt.Errorf("failed to get pv/%s. err: %w", volName, err)
+			default:
+				return fmt.Errorf("target pv exists %s", volName)
+			}
+		}).Should(Succeed())
+
+		By("confirming that the lv correspond to LogicalVolume is deleted")
+		Eventually(func() error {
+			return checkLVIsDeletedInLVM(volName)
+		}).Should(Succeed())
+	})
+
+	It("should be mounted in specified path but changed by the minimum allocation default for XFS", func() {
+		By("deploying Pod with PVC")
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 100, "topolvm-provisioner"))
+		podYaml := []byte(fmt.Sprintf(podVolumeMountTemplateYAML, "ubuntu", "topo-pvc"))
+
+		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = kubectlWithInput(podYaml, "apply", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("confirming that the specified device exists in the Pod")
+		Eventually(func() error {
+			_, err = kubectl("exec", "-n", ns, "ubuntu", "--", "mountpoint", "-d", "/test1")
+			if err != nil {
+				return fmt.Errorf("failed to check mount point. err: %w", err)
+			}
+
+			stdout, err := kubectl("exec", "-n", ns, "ubuntu", "grep", "/test1", "/proc/mounts")
+			if err != nil {
+				return err
+			}
+			fields := strings.Fields(string(stdout))
+			if fields[2] != "xfs" {
+				return errors.New("/test1 is not xfs")
+			}
+			return nil
+		}).Should(Succeed())
+
+		By("writing file under /test1")
+		writePath := "/test1/bootstrap.log"
+		_, err = kubectl("exec", "-n", ns, "ubuntu", "--", "cp", "/var/log/bootstrap.log", writePath)
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = kubectl("exec", "-n", ns, "ubuntu", "--", "sync")
+		Expect(err).ShouldNot(HaveOccurred())
+		stdout, err := kubectl("exec", "-n", ns, "ubuntu", "--", "cat", writePath)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(strings.TrimSpace(string(stdout))).ShouldNot(BeEmpty())
+
+		By("deleting the Pod, then recreating it")
+		_, err = kubectl("delete", "--now=true", "-n", ns, "pod/ubuntu")
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = kubectlWithInput(podYaml, "apply", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("confirming that the file exists")
+		Eventually(func() error {
+			stdout, err = kubectl("exec", "-n", ns, "ubuntu", "--", "cat", writePath)
+			if err != nil {
+				return fmt.Errorf("failed to cat. err: %w", err)
+			}
+			if len(strings.TrimSpace(string(stdout))) == 0 {
+				return fmt.Errorf(writePath + " is empty")
+			}
+			return nil
+		}).Should(Succeed())
+
+		By("confirming that the lv correspond to LogicalVolume resource is registered in LVM")
+		var pvc corev1.PersistentVolumeClaim
+		err = getObjects(&pvc, "pvc", "-n", ns, "topo-pvc")
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return checkLVIsRegisteredInLVM(pvc.Spec.VolumeName)
+		}).Should(Succeed())
+
+		By("confirming that the lv was successfully sized to the minimum size of the StorageClass")
+		Expect(pvc.Status.Capacity.Storage().Cmp(resource.MustParse(app.DefaultMinimumAllocationSizeXFS))).Should(Equal(0),
+			"expected: %s as minimum capacity, actual: %s", app.DefaultMinimumAllocationSizeXFS, pvc.Status.Capacity.Storage().String())
 
 		By("deleting the Pod and PVC")
 		_, err = kubectlWithInput(podYaml, "delete", "-n", ns, "-f", "-")
@@ -214,7 +310,8 @@ func testE2E() {
 
 		By("deploying ubuntu Pod with PVC to mount a block device")
 		podYAML := []byte(fmt.Sprintf(podVolumeDeviceTemplateYAML, deviceFile))
-		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Block", 1, "topolvm-provisioner"))
+
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Block", 1024, "topolvm-provisioner"))
 
 		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
@@ -293,6 +390,95 @@ func testE2E() {
 		}).Should(Succeed())
 	})
 
+	It("should create a block device for Pod but changed by the minimum allocation default for block storage", func() {
+		deviceFile := "/dev/e2etest"
+
+		By("deploying ubuntu Pod with PVC to mount a block device")
+		podYAML := []byte(fmt.Sprintf(podVolumeDeviceTemplateYAML, deviceFile))
+
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Block", 1, "topolvm-provisioner"))
+
+		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = kubectlWithInput(podYAML, "apply", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("confirming that a block device exists in ubuntu pod")
+		Eventually(func() error {
+			_, err = kubectl("exec", "-n", ns, "ubuntu", "--", "test", "-b", deviceFile)
+			if err != nil {
+				podinfo, _ := kubectl("-n", ns, "describe", "pod", "ubuntu")
+				return fmt.Errorf("failed to test. ubuntu pod info output: %s; err: %w", podinfo, err)
+			}
+			return nil
+		}).Should(Succeed())
+
+		By("writing data to a block device")
+		// /etc/hostname contains "ubuntu"
+		_, err = kubectl("exec", "-n", ns, "ubuntu", "--", "dd", "if=/etc/hostname", "of="+deviceFile)
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = kubectl("exec", "-n", ns, "ubuntu", "--", "sync")
+		Expect(err).ShouldNot(HaveOccurred())
+		stdout, err := kubectl("exec", "-n", ns, "ubuntu", "--", "dd", "if="+deviceFile, "of=/dev/stdout", "bs=6", "count=1", "status=none")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(string(stdout)).Should(Equal("ubuntu"))
+
+		By("deleting the Pod, then recreating it")
+		_, err = kubectl("delete", "--now=true", "-n", ns, "pod/ubuntu")
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = kubectlWithInput(podYAML, "apply", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("reading data from a block device")
+		Eventually(func() error {
+			stdout, err = kubectl("exec", "-n", ns, "ubuntu", "--", "dd", "if="+deviceFile, "of=/dev/stdout", "bs=6", "count=1", "status=none")
+			if err != nil {
+				return fmt.Errorf("failed to cat. err: %w", err)
+			}
+			if string(stdout) != "ubuntu" {
+				return fmt.Errorf("expected: ubuntu, actual: %s", string(stdout))
+			}
+			return nil
+		}).Should(Succeed())
+
+		By("confirming that the lv correspond to LogicalVolume resource is registered in LVM")
+		var pvc corev1.PersistentVolumeClaim
+		err = getObjects(&pvc, "pvc", "-n", ns, "topo-pvc")
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(func() error {
+			return checkLVIsRegisteredInLVM(pvc.Spec.VolumeName)
+		}).Should(Succeed())
+
+		By("confirming that the lv was successfully sized to the minimum size of the StorageClass")
+		Expect(pvc.Status.Capacity.Storage().Cmp(resource.MustParse(app.DefaultMinimumAllocationSizeBlock))).Should(Equal(0),
+			"expected: %s as minimum capacity, actual: %s", app.DefaultMinimumAllocationSizeBlock, pvc.Status.Capacity.Storage().String())
+
+		By("deleting the Pod and PVC")
+		_, err = kubectlWithInput(podYAML, "delete", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = kubectlWithInput(claimYAML, "delete", "-n", ns, "-f", "-")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("confirming that the PV is deleted")
+		Eventually(func() error {
+			var pv corev1.PersistentVolume
+			err := getObjects(&pv, "pv", volName)
+			switch {
+			case err == ErrObjectNotFound:
+				return nil
+			case err != nil:
+				return fmt.Errorf("failed to get pv/%s. err: %w", volName, err)
+			default:
+				return fmt.Errorf("target PV exists %s", volName)
+			}
+		}).Should(Succeed())
+
+		By("confirming that the lv correspond to LogicalVolume is deleted")
+		Eventually(func() error {
+			return checkLVIsDeletedInLVM(volName)
+		}).Should(Succeed())
+	})
+
 	It("should choose a node with the largest capacity when volumeBindingMode == Immediate is specified", func() {
 		skipIfStorageCapacity("Storage Capacity Tracking doesn't check Storage Capacity when volumeBindingMode == Immediate is specified")
 
@@ -336,7 +522,7 @@ func testE2E() {
 			}).Should(Succeed())
 
 			By("creating pvc")
-			claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, fmt.Sprintf("topo-pvc-%d", i), "Filesystem", 1, "topolvm-provisioner-immediate"))
+			claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, fmt.Sprintf("topo-pvc-%d", i), "Filesystem", 1024, "topolvm-provisioner-immediate"))
 			_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -368,7 +554,7 @@ func testE2E() {
 
 	It("should scheduled onto the correct node where PV exists (volumeBindingMode == Immediate)", func() {
 		By("creating pvc")
-		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1, "topolvm-provisioner-immediate"))
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1024, "topolvm-provisioner-immediate"))
 		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -549,7 +735,7 @@ func testE2E() {
 
 	It("should resize filesystem", func() {
 		By("deploying Pod with PVC")
-		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1, "topolvm-provisioner"))
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1024, "topolvm-provisioner"))
 		podYaml := []byte(fmt.Sprintf(podVolumeMountTemplateYAML, "ubuntu", "topo-pvc"))
 
 		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
@@ -563,7 +749,7 @@ func testE2E() {
 		}).Should(Succeed())
 
 		By("resizing PVC online")
-		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 2, "topolvm-provisioner"))
+		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 2*1024, "topolvm-provisioner"))
 		_, err = kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -590,7 +776,7 @@ func testE2E() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("resizing PVC offline")
-		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 3, "topolvm-provisioner"))
+		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 3*1024, "topolvm-provisioner"))
 		_, err = kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -620,7 +806,7 @@ func testE2E() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		By("resizing PVC")
-		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 4, "topolvm-provisioner"))
+		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 4*1024, "topolvm-provisioner"))
 		_, err = kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -650,7 +836,7 @@ func testE2E() {
 		Expect(err).To(BeEquivalentTo(ErrObjectNotFound))
 
 		By("resizing PVC over vg capacity")
-		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 100, "topolvm-provisioner"))
+		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 100*1024, "topolvm-provisioner"))
 		_, err = kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -679,7 +865,7 @@ func testE2E() {
 		By("deploying Pod with PVC")
 		deviceFile := "/dev/e2etest"
 		podYAML := []byte(fmt.Sprintf(podVolumeDeviceTemplateYAML, deviceFile))
-		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Block", 1, "topolvm-provisioner"))
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Block", 1024, "topolvm-provisioner"))
 
 		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
@@ -696,7 +882,7 @@ func testE2E() {
 		}).Should(Succeed())
 
 		By("resizing PVC")
-		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Block", 2, "topolvm-provisioner"))
+		claimYAML = []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Block", 2048, "topolvm-provisioner"))
 		_, err = kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -726,7 +912,7 @@ func testE2E() {
 
 	It("should delete a pod when the pvc is deleted", func() {
 		By("deploying a pod and PVC")
-		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1, "topolvm-provisioner"))
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1024, "topolvm-provisioner"))
 		podYaml := []byte(fmt.Sprintf(podVolumeMountTemplateYAML, "ubuntu", "topo-pvc"))
 
 		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")

--- a/test/e2e/lvcreate_options_test.go
+++ b/test/e2e/lvcreate_options_test.go
@@ -34,7 +34,7 @@ func testLVCreateOptions() {
 
 	It("should use lvcreate-options when creating LV", func() {
 		By("creating Pod with PVC using raid device-class")
-		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1, "topolvm-provisioner-create-option-raid1"))
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc", "Filesystem", 1024, "topolvm-provisioner-create-option-raid1"))
 		podYaml := []byte(fmt.Sprintf(podVolumeMountTemplateYAML, "ubuntu", "topo-pvc"))
 
 		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")
@@ -71,7 +71,7 @@ func testLVCreateOptions() {
 
 	It("should use lvcreate-option-classes when creating LV", func() {
 		By("creating Pod with PVC using raid1 device-class")
-		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc-raid1", "Filesystem", 1, "topolvm-provisioner-option-class-raid1"))
+		claimYAML := []byte(fmt.Sprintf(pvcTemplateYAML, "topo-pvc-raid1", "Filesystem", 1024, "topolvm-provisioner-option-class-raid1"))
 		podYaml := []byte(fmt.Sprintf(podVolumeMountTemplateYAML, "ubuntu2", "topo-pvc-raid1"))
 
 		_, err := kubectlWithInput(claimYAML, "apply", "-n", ns, "-f", "-")

--- a/test/e2e/testdata/e2e/pvc-template.yaml
+++ b/test/e2e/testdata/e2e/pvc-template.yaml
@@ -8,5 +8,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: %dGi
+      storage: %dMi
   storageClassName: %s


### PR DESCRIPTION
This PR introduces a minimum size allocation for any PVCs that are requested. It also refactors the test cases to be table driven so that its easier to modify and see whats wrong.

The limits introduced are the following:

```
const (
	// DefaultMinimumAllocationSizeBlock is the default minimum size for a block volume.
	// Derived from the usual physical extent size of 4Mi * 2 (for accommodating metadata)
	DefaultMinimumAllocationSizeBlock = "8Mi"
	// DefaultMinimumAllocationSizeXFS is the default minimum size for a filesystem volume with XFS formatting.
	// Derived from the hard XFS minimum size of 300Mi that is enforced by the XFS filesystem.
	DefaultMinimumAllocationSizeXFS = "300Mi"
	// DefaultMinimumAllocationSizeExt4 is the default minimum size for a filesystem volume with ext4 formatting.
	// Derived from the usual 4096K blocks, 1024 inode default and journaling overhead,
	// Allows for more than 80% free space after formatting, anything lower significantly reduces this percentage.
	DefaultMinimumAllocationSizeExt4 = "32Mi"
)
```

**Why?**
Since we removed the 1Gi Allocation we should set sensible defaults that allow users to still make use of our rounding but that do not go so low as to break the Mounting procedure.

**What was changed?**

The following new controller flags were introduced with the above defaults:

- `minimum-allocation-block`
- `minimum-allocation-xfs`
- `minimum-allocation-ext4`

If not set, they use the defaults so the HELM chart does not need adjusting.
Note that setting 0 or negative values in these configurations disables the allocation sizing for that configuration.


**How to reproduce?**
Create a PVC with something like 

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: simple-pvc
spec:
  storageClassName: sg1 # should be with default or explicit xfs setting
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 10Mi
```

One will notice the following error during mounting

```
Events:
  Type     Reason       Age                 From               Message
  ----     ------       ----                ----               -------
  Normal   Scheduled    2m4s                default-scheduler  Successfully assigned default/test-pod to cnv-qe-infra-23.cnvqe2.lab.eng.rdu2.redhat.com
  Warning  FailedMount  59s (x8 over 2m4s)  kubelet            MountVolume.SetUp failed for volume "pvc-1bba5d94-aa42-4f8e-a75e-fe16debdbd9a" : rpc error: code = Internal desc = mount failed: volume=17c48e86-3a9b-4ef0-83c1-698e0d6fd7b5, error=format of disk "/dev/topolvm/17c48e86-3a9b-4ef0-83c1-698e0d6fd7b5" failed: type:("xfs") target:("/var/lib/kubelet/pods/8b4ae8e7-55c0-45d5-805b-02496d66b782/volumes/kubernetes.io~csi/pvc-1bba5d94-aa42-4f8e-a75e-fe16debdbd9a/mount") options:("nouuid,defaults") errcode:(exit status 1) output:(size 3072 of data subvolume is too small, minimum 4096 blocks
....  (cut for brevity)
```

Additionally if one then increases that block amount to lets say 16 MiB one will eventually face (with a recent enough version of mkfs):

```
Events:
  Type     Reason       Age                 From               Message
  ----     ------       ----                ----               -------
  Normal   Scheduled    2m4s                default-scheduler  Successfully assigned default/test-pod to cnv-qe-infra-23.cnvqe2.lab.eng.rdu2.redhat.com
  Warning  FailedMount  59s (x8 over 2m4s)  kubelet            MountVolume.SetUp failed for volume "pvc-1bba5d94-aa42-4f8e-a75e-fe16debdbd9a" : rpc error: code = Internal desc = mount failed: volume=17c48e86-3a9b-4ef0-83c1-698e0d6fd7b5, error=format of disk "/dev/topolvm/17c48e86-3a9b-4ef0-83c1-698e0d6fd7b5" failed: type:("xfs") target:("/var/lib/kubelet/pods/8b4ae8e7-55c0-45d5-805b-02496d66b782/volumes/kubernetes.io~csi/pvc-1bba5d94-aa42-4f8e-a75e-fe16debdbd9a/mount") options:("nouuid,defaults") errcode:(exit status 1) output:(Filesystem must be larger than 300MB.)
....  (cut for brevity)
```

due to the change here: https://www.spinics.net/lists/linux-xfs/msg63099.html & https://www.spinics.net/lists/linux-xfs/msg63831.html
