### PR TITLE
Fix: forcing certificates duration to h:m:s to prevent stuck in out-of-sync status in ArgoCD

### DIFF
--- a/charts/topolvm/templates/certificates/certificates.yaml
+++ b/charts/topolvm/templates/certificates/certificates.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "topolvm.labels" . | nindent 4 }}
 spec:
   secretName: {{ template "topolvm.fullname" . }}-webhook-ca
-  duration: 87600h # 10y
+  duration: 87600h0m0s # 10y
   issuerRef:
     group: cert-manager.io
     kind: Issuer
@@ -34,7 +34,7 @@ metadata:
     {{- include "topolvm.labels" . | nindent 4 }}
 spec:
   secretName: {{ template "topolvm.fullname" . }}-mutatingwebhook
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     {{- with .Values.webhook.existingCertManagerIssuer }}
     {{- toYaml . | nindent 4 -}}


### PR DESCRIPTION
```
Resource: cert-manager.io/Certificate/topolvm/topolvm-mutatingwebhook

     - topolvm-controller.topolvm
     - topolvm-controller.topolvm.svc
-  duration: 8760h0m0s
+  duration: 8760h
   issuerRef:
     group: cert-manager.io

Resource: cert-manager.io/Certificate/topolvm/topolvm-webhook-ca

spec:
   commonName: ca.webhook.topolvm
-  duration: 87600h0m0s
+  duration: 87600h
   isCA: true
   issuerRef:
```