### PR TITLE
fix: use correct ErrNotFound from command package

### DIFF
--- a/internal/lvmd/device_class_manager.go
+++ b/internal/lvmd/device_class_manager.go
@@ -9,8 +9,8 @@ import (
 	lvmdTypes "github.com/topolvm/topolvm/pkg/lvmd/types"
 )
 
-// ErrNotFound is returned when a VG or LV is not found.
-var ErrNotFound = errors.New("device-class not found")
+// ErrDeviceClassNotFound is returned when a VG or LV is not found.
+var ErrDeviceClassNotFound = errors.New("device-class not found")
 
 const (
 	defaultSpareGB = 10
@@ -148,7 +148,7 @@ func (m DeviceClassManager) DeviceClass(dcName string) (*lvmdTypes.DeviceClass, 
 	if v, ok := m.deviceClassByName[dcName]; ok {
 		return v, nil
 	}
-	return nil, ErrNotFound
+	return nil, ErrDeviceClassNotFound
 }
 
 // FindDeviceClassByVGName returns the device-class with the volume group name
@@ -156,7 +156,7 @@ func (m DeviceClassManager) FindDeviceClassByVGName(vgName string) (*lvmdTypes.D
 	if v, ok := m.deviceClassByVGName[vgName]; ok {
 		return v, nil
 	}
-	return nil, ErrNotFound
+	return nil, ErrDeviceClassNotFound
 }
 
 // FindDeviceClassByThinPoolName returns the device-class with volume group and pool combination
@@ -165,5 +165,5 @@ func (m DeviceClassManager) FindDeviceClassByThinPoolName(vgName string, poolNam
 	if v, ok := m.deviceClassByThinPoolName[name]; ok {
 		return v, nil
 	}
-	return nil, ErrNotFound
+	return nil, ErrDeviceClassNotFound
 }

--- a/internal/lvmd/device_class_manager_test.go
+++ b/internal/lvmd/device_class_manager_test.go
@@ -433,7 +433,7 @@ func TestDeviceClassManager(t *testing.T) {
 	}
 
 	_, err = manager.DeviceClass("unknown")
-	if err != ErrNotFound {
+	if err != ErrDeviceClassNotFound {
 		t.Error("'unknown' should not be found")
 	}
 
@@ -446,7 +446,7 @@ func TestDeviceClassManager(t *testing.T) {
 	}
 
 	_, err = manager.FindDeviceClassByVGName("unknown")
-	if err != ErrNotFound {
+	if err != ErrDeviceClassNotFound {
 		t.Error("'unknown' should not be found")
 	}
 

--- a/internal/lvmd/lvservice.go
+++ b/internal/lvmd/lvservice.go
@@ -159,14 +159,14 @@ func (s *lvService) RemoveLV(ctx context.Context, req *proto.RemoveLVRequest) (*
 	}
 
 	vg, err := command.FindVolumeGroup(ctx, dc.VolumeGroup)
-	if errors.Is(err, ErrNotFound) {
+	if errors.Is(err, command.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "%s: %s", err.Error(), req.DeviceClass)
 	} else if err != nil {
 		logger.Error(err, "failed to get volume group", "name", dc.VolumeGroup)
 		return nil, err
 	}
 
-	if err := vg.RemoveVolume(ctx, req.GetName()); errors.Is(err, ErrNotFound) {
+	if err := vg.RemoveVolume(ctx, req.GetName()); errors.Is(err, command.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "%s: %s", err.Error(), req.DeviceClass)
 	} else if err != nil {
 		logger.Error(err, "failed to remove volume", "name", req.GetName())

--- a/internal/lvmd/vgservice.go
+++ b/internal/lvmd/vgservice.go
@@ -163,8 +163,8 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 
 		for _, pool := range pools {
 			dc, err := s.dcManager.FindDeviceClassByThinPoolName(vg.Name(), pool.Name())
-			// we either get nil or ErrNotFound
-			if errors.Is(err, ErrNotFound) {
+			// we either get nil or ErrDeviceClassNotFound
+			if errors.Is(err, ErrDeviceClassNotFound) {
 				continue
 			}
 
@@ -203,7 +203,7 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 		}
 
 		dc, err := s.dcManager.FindDeviceClassByVGName(vg.Name())
-		if errors.Is(err, ErrNotFound) {
+		if errors.Is(err, ErrDeviceClassNotFound) {
 			continue
 		}
 


### PR DESCRIPTION
addresses the issue reported by #861 where the wrong ErrNotFound Code was used.