### PR TITLE
fix: pin setup-envtest to go 1.20 before TopoLVM migrates to go 1.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,8 +269,7 @@ install-helm-docs: | $(BINDIR)
 tools: install-kind install-container-structure-test install-helm install-helm-docs | $(BINDIR) ## Install development tools.
 	GOBIN=$(BINDIR) go install honnef.co/go/tools/cmd/staticcheck@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(GOLANGCI_LINT_VERSION)
-	# Follow the official documentation to install the `latest` version, because explicitly specifying the version will get an error.
-	GOBIN=$(BINDIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(BINDIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 	GOBIN=$(BINDIR) go install sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONTROLLER_TOOLS_VERSION)
 
 	$(CURL) -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-linux-x86_64.zip

--- a/versions.mk
+++ b/versions.mk
@@ -29,6 +29,9 @@ MINIKUBE_VERSION := v1.32.0
 # https://github.com/protocolbuffers/protobuf/releases
 PROTOC_VERSION :=  25.2
 
+# https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest
+# Usually on latest, but might need to be pinned from time to time
+ENVTEST_VERSION := bf15e44028f908c790721fc8fe67c7bf2d06a611
 ENVTEST_KUBERNETES_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f 1-2)
 
 # Tools versions which are defined in go.mod


### PR DESCRIPTION
Attempts to temporarily fix #864 by pinning envtest to a version that didnt have the x.y.z syntax