### PR TITLE
chore: expose controller server settings for external use

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -4,4 +4,10 @@ import (
 	internalDriver "github.com/topolvm/topolvm/internal/driver"
 )
 
+// NewControllerServer is a externally consumable wrapper.
+// It allows starting a new controller server even without access to the package internals.
 var NewControllerServer = internalDriver.NewControllerServer
+
+// ControllerServerSettings is a externally consumable wrapper.
+// It is used to configure the controller server.
+type ControllerServerSettings = internalDriver.ControllerServerSettings


### PR DESCRIPTION
This exposes the new controller settings so that the controller server can still be started externally. This was previously forgotten.