### PR TITLE
chore: use exposed controller functions in topolvm controllers

### DIFF
--- a/cmd/topolvm-controller/app/root.go
+++ b/cmd/topolvm-controller/app/root.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/topolvm/topolvm"
-	"github.com/topolvm/topolvm/internal/driver"
+	"github.com/topolvm/topolvm/pkg/driver"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"

--- a/cmd/topolvm-controller/app/run.go
+++ b/cmd/topolvm-controller/app/run.go
@@ -11,10 +11,10 @@ import (
 	topolvmlegacyv1 "github.com/topolvm/topolvm/api/legacy/v1"
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
 	clientwrapper "github.com/topolvm/topolvm/internal/client"
-	"github.com/topolvm/topolvm/internal/controller"
-	"github.com/topolvm/topolvm/internal/driver"
 	"github.com/topolvm/topolvm/internal/hook"
 	"github.com/topolvm/topolvm/internal/runners"
+	"github.com/topolvm/topolvm/pkg/controller"
+	"github.com/topolvm/topolvm/pkg/driver"
 	"google.golang.org/grpc"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -106,14 +106,12 @@ func subMain() error {
 	}
 
 	// register controllers
-	nodecontroller := controller.NewNodeReconciler(client, config.skipNodeFinalize)
-	if err := nodecontroller.SetupWithManager(mgr); err != nil {
+	if err := controller.SetupNodeReconciler(mgr, client, config.skipNodeFinalize); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Node")
 		return err
 	}
 
-	pvccontroller := controller.NewPersistentVolumeClaimReconciler(client, apiReader)
-	if err := pvccontroller.SetupWithManager(mgr); err != nil {
+	if err := controller.SetupPersistentVolumeClaimReconciler(mgr, client, apiReader); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PersistentVolumeClaim")
 		return err
 	}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -4,10 +4,26 @@ import (
 	internalDriver "github.com/topolvm/topolvm/internal/driver"
 )
 
-// NewControllerServer is a externally consumable wrapper.
+// NewControllerServer is an externally consumable wrapper.
 // It allows starting a new controller server even without access to the package internals.
 var NewControllerServer = internalDriver.NewControllerServer
 
-// ControllerServerSettings is a externally consumable wrapper.
+// ControllerServerSettings is an externally consumable wrapper.
 // It is used to configure the controller server.
 type ControllerServerSettings = internalDriver.ControllerServerSettings
+
+// MinimumAllocationSettings is an externally consumable wrapper.
+// It contains the minimum allocation settings for the controller inside controller server settings.
+type MinimumAllocationSettings = internalDriver.MinimumAllocationSettings
+
+// Quantity is an externally consumable wrapper.
+// It is used to represent a quantity of a resource.
+type Quantity = internalDriver.Quantity
+
+// NewQuantityFlagVar is an externally consumable wrapper.
+// It is used to create a new quantity flag variable.
+var NewQuantityFlagVar = internalDriver.NewQuantityFlagVar
+
+// QuantityVar is an externally consumable wrapper.
+// It is used to create a new quantity variable.
+var QuantityVar = internalDriver.QuantityVar


### PR DESCRIPTION
In retrospect of https://github.com/topolvm/topolvm/pull/875 I noticed that everytime we add a field, we also have to export all embedded fields with it to work correctly outside of the topolvm package. This makes going back and forth for every field extremely tedious.

I thus changed the current command runners in TopoLVM to use the pkg variants of the runners. This will not change any logic (we were already using the same logic just with internal imports) but will let us know via compiler error whenever we have a field change that needs to be exported as well.