### PR TITLE
fix: use stricter not found matching for lvm calls

### DIFF
--- a/internal/lvmd/command/lvm.go
+++ b/internal/lvmd/command/lvm.go
@@ -578,9 +578,7 @@ func (l *LogicalVolume) Resize(ctx context.Context, newSize uint64) error {
 func (vg *VolumeGroup) RemoveVolume(ctx context.Context, name string) error {
 	err := callLVM(ctx, "lvremove", "-f", fullName(name, vg))
 
-	if lvmErr, ok := AsLVMError(err); ok && lvmErr.ExitCode() == 5 {
-		// lvremove returns 5 if the volume does not exist, so we can convert this to ErrNotFound
-		// join it to the original error so that the caller can still see the stderr output.
+	if IsLVMNotFound(err) {
 		return errors.Join(ErrNotFound, err)
 	}
 

--- a/internal/lvmd/command/lvm_command.go
+++ b/internal/lvmd/command/lvm_command.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -114,48 +113,4 @@ func (p commandReadCloser) Close() error {
 		}
 	}
 	return nil
-}
-
-// AsLVMError returns the LVMError from the error if it exists and a bool indicating if is an LVMError or not.
-func AsLVMError(err error) (LVMError, bool) {
-	var lvmErr LVMError
-	ok := errors.As(err, &lvmErr)
-	return lvmErr, ok
-}
-
-// LVMError is an error that wraps the original error and the stderr output of the lvm command if found.
-// It also provides an exit code if present that can be used to determine the type of error from LVM.
-// Regular inaccessible errors will have an exit code of 5.
-type LVMError interface {
-	error
-	ExitCode() int
-	Unwrap() error
-}
-
-type lvmErr struct {
-	err    error
-	stderr []byte
-}
-
-func (e *lvmErr) Error() string {
-	if e.stderr != nil {
-		return fmt.Sprintf("%v: %v", e.err, string(bytes.TrimSpace(e.stderr)))
-	}
-	return e.err.Error()
-}
-
-func (e *lvmErr) Unwrap() error {
-	return e.err
-}
-
-func (e *lvmErr) ExitCode() int {
-	type exitError interface {
-		ExitCode() int
-		error
-	}
-	var err exitError
-	if errors.As(e.err, &err) {
-		return err.ExitCode()
-	}
-	return -1
 }

--- a/internal/lvmd/command/lvm_error.go
+++ b/internal/lvmd/command/lvm_error.go
@@ -1,0 +1,71 @@
+package command
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+var (
+	// NotFoundPattern is a regular expression that matches the error message when a volume group or logical volume is not found.
+	// The volume group might not be present or the logical volume might not be present in the volume group.
+	NotFoundPattern = regexp.MustCompile(`Volume group "(.*?)" not found|Failed to find logical volume "(.*?)"`)
+)
+
+// IsLVMNotFound returns true if the error is a LVM recognized error and it determined that either
+// the underlying volume group or logical volume is not found.
+func IsLVMNotFound(err error) bool {
+	lvmErr, ok := AsLVMError(err)
+
+	// If the exit code is not 5, it is guaranteed that the error is not a not found error.
+	if !ok || lvmErr.ExitCode() != 5 {
+		return false
+	}
+
+	return NotFoundPattern.Match([]byte(lvmErr.Error()))
+}
+
+// AsLVMError returns the LVMError from the error if it exists and a bool indicating if is an LVMError or not.
+func AsLVMError(err error) (LVMError, bool) {
+	var lvmErr LVMError
+	ok := errors.As(err, &lvmErr)
+	return lvmErr, ok
+}
+
+// LVMError is an error that wraps the original error and the stderr output of the lvm command if found.
+// It also provides an exit code if present that can be used to determine the type of error from LVM.
+// Regular inaccessible errors will have an exit code of 5.
+type LVMError interface {
+	error
+	ExitCode() int
+	Unwrap() error
+}
+
+type lvmErr struct {
+	err    error
+	stderr []byte
+}
+
+func (e *lvmErr) Error() string {
+	if e.stderr != nil {
+		return fmt.Sprintf("%v: %v", e.err, string(bytes.TrimSpace(e.stderr)))
+	}
+	return e.err.Error()
+}
+
+func (e *lvmErr) Unwrap() error {
+	return e.err
+}
+
+func (e *lvmErr) ExitCode() int {
+	type exitError interface {
+		ExitCode() int
+		error
+	}
+	var err exitError
+	if errors.As(e.err, &err) {
+		return err.ExitCode()
+	}
+	return -1
+}

--- a/internal/lvmd/command/lvm_lvs.go
+++ b/internal/lvmd/command/lvm_lvs.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strconv"
 	"strings"
 )
@@ -124,10 +125,8 @@ func getLVReport(ctx context.Context, name string) (map[string]lv, error) {
 	}
 	err := callLVMInto(ctx, res, args...)
 
-	if lvmErr, ok := AsLVMError(err); ok && lvmErr.ExitCode() == 5 {
-		// lvs returns 5 if the volume does not exist, so we can convert this to ErrNotFound
-		// join it to the original error so that the caller can still see the stderr output.
-		return nil, ErrNotFound
+	if IsLVMNotFound(err) {
+		return nil, errors.Join(ErrNotFound, err)
 	}
 
 	if err != nil {


### PR DESCRIPTION
fix #889 by changing the simple exitcode==5 check to a check that also verifies the returned stderr for the regex `Volume group "(.*?)" not found|Failed to find logical volume "(.*?)` so that errors that have exit code 5 but are not about the volume not being present do not cause TopoLVM to ignore the volume.

Since the lvm error handling got a bit too big for my taste I moved it into a separate file. I also added a test case to cover this regex style parsing.