### PR TITLE
lvmd: don't call Close() for stdout

### DIFF
--- a/internal/lvmd/command/lvm_command.go
+++ b/internal/lvmd/command/lvm_command.go
@@ -95,11 +95,9 @@ type commandReadCloser struct {
 	stderr io.ReadCloser
 }
 
+// Close closes stdout and stderr and waits for the command to exit. Close
+// should not be called before all reads from stdout have completed.
 func (p commandReadCloser) Close() error {
-	if err := p.ReadCloser.Close(); err != nil {
-		return err
-	}
-
 	// Read the stderr output after the read has finished since we are sure by then the command must have run.
 	stderr, err := io.ReadAll(p.stderr)
 	if err != nil {


### PR DESCRIPTION
The Go's reference of `StdoutPipe` says:

> Wait will close the pipe after seeing the command exit, so most callers
> need not close the pipe themselves. It is thus incorrect to call Wait
> before all reads from the pipe have completed.

https://pkg.go.dev/os/exec#Cmd.StdoutPipe

So, io.ReadAll should be called instead of Close.