### PR TITLE
feat: controller only expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,11 +176,11 @@ image: image-normal image-with-sidecar ## Build topolvm images.
 
 .PHONY: image-normal
 image-normal:
-	docker buildx build --no-cache --load -t $(IMAGE_PREFIX)topolvm:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --target topolvm .
+	docker buildx build --load -t $(IMAGE_PREFIX)topolvm:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --target topolvm .
 
 .PHONY: image-with-sidecar
 image-with-sidecar:
-	docker buildx build --no-cache --load -t $(IMAGE_PREFIX)topolvm-with-sidecar:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --target topolvm-with-sidecar .
+	docker buildx build --load -t $(IMAGE_PREFIX)topolvm-with-sidecar:devel --build-arg TOPOLVM_VERSION=$(TOPOLVM_VERSION) --target topolvm-with-sidecar .
 
 .PHONY: container-structure-test
 container-structure-test: ## Run container-structure-test.

--- a/internal/driver/controller.go
+++ b/internal/driver/controller.go
@@ -689,6 +689,6 @@ func (s controllerServerNoLocked) ControllerExpandVolume(ctx context.Context, re
 
 	return &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         requestCapacityBytes,
-		NodeExpansionRequired: true,
+		NodeExpansionRequired: false,
 	}, nil
 }

--- a/internal/lvmd/command/lvm.go
+++ b/internal/lvmd/command/lvm.go
@@ -614,7 +614,9 @@ func (l *LogicalVolume) Resize(ctx context.Context, newSize uint64) error {
 		// If we do not find an active mountpoint, create our own temporary mount for resizing
 		if !found {
 			mountDir, err := os.MkdirTemp("", "topolvm-tmp-mount-*")
-			defer os.RemoveAll(mountDir)
+			defer func() {
+				_ = os.RemoveAll(mountDir)
+			}()
 			if err != nil {
 				return fmt.Errorf("cannot create temporary directory for temporary mount: %v", err)
 			}
@@ -625,7 +627,9 @@ func (l *LogicalVolume) Resize(ctx context.Context, newSize uint64) error {
 			if err := mounter.Mount(l.Path(), mountDir, fs, mountoptions); err != nil {
 				return fmt.Errorf("cannot mount filesystem for resize operation: %v", err)
 			}
-			defer mountutil.CleanupMountPoint(mountDir, mounter, false)
+			defer func() {
+				_ = mountutil.CleanupMountPoint(mountDir, mounter, false)
+			}()
 			if _, err := resizer.Resize(l.Path(), mountDir); err != nil {
 				return fmt.Errorf("cannot resize filesystem: %v", err)
 			}

--- a/internal/lvmd/command/lvm.go
+++ b/internal/lvmd/command/lvm.go
@@ -611,7 +611,7 @@ func (l *LogicalVolume) Resize(ctx context.Context, newSize uint64) error {
 				break
 			}
 		}
-		// If we do not find an active mountpoint
+		// If we do not find an active mountpoint, create our own temporary mount for resizing
 		if !found {
 			mountDir, err := os.MkdirTemp("", "topolvm-tmp-mount-*")
 			defer os.RemoveAll(mountDir)
@@ -629,8 +629,6 @@ func (l *LogicalVolume) Resize(ctx context.Context, newSize uint64) error {
 			if _, err := resizer.Resize(l.Path(), mountDir); err != nil {
 				return fmt.Errorf("cannot resize filesystem: %v", err)
 			}
-
-			return fmt.Errorf("filesystem not mounted, cannot resize online")
 		}
 	}
 

--- a/internal/lvmd/testutils/test_utils.go
+++ b/internal/lvmd/testutils/test_utils.go
@@ -45,7 +45,7 @@ func MakeLoopbackVG(ctx context.Context, name string, devices ...string) error {
 }
 
 func MakeLoopbackLV(ctx context.Context, name string, vg string) error {
-	args := []string{"-L1G", "-n", name, vg}
+	args := []string{"-L1G", "-y", "-n", name, vg}
 	out, err := exec.Command("lvcreate", args...).CombinedOutput()
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed lvcreate", "output", string(out))


### PR DESCRIPTION
This change is prototyping how using the native LVM device paths reported by device mapper could work together with lvm controlled filesystem resizing in order to run controller-only online/offline volume expansion.

The main benefit of this is significantly faster resizing due to not having to wait for kubelet expansion. Additionally we no longer have to maintain our own devices in /dev/topolvm. (fix #902)

~Note that the current design breaks with existing TopoLVM because it switches from using the TopoLVM device directory to using the lvm owned device paths (so TopoLVM no longer renames the devices).~ Unmounting via lvm2 provided device paths always works even if legacy paths exist.

~I want to drive a POC here so that I can further debug and showcase how much more efficient we could be regarding dealing with device paths, lvm compatibility and the CSI spec.~ I think this approach is feasible and I would like to open it for reviews

Summary of Changes:

- Change all ControllerExpandVolumeResponses to NodeExpansionRequired: false
- Extend lvmd with resize behavior instead of NodeExpansion
- Allow lvmd to temporarily do a mount for resizing of PVCs under /tmp when there is currently no mount for the filesystem, otherwise reuse the mount present. 