### PR TITLE
e2e: mention known issues of kind in README

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -27,6 +27,9 @@ When tests fail, use `kubectl` to inspect the Kubernetes cluster.
 make test
 ```
 
+> [!NOTE]
+> If launching kind failed, please check [the known issues](https://kind.sigs.k8s.io/docs/user/known-issues).
+
 You can also start a cluster without running tests by the following command.
 
 ```bash


### PR DESCRIPTION
Sometimes launching kind fails and then kind doesn't show the link to known issues in the error message. Adding a mention to this page helps e2e test users.

Closes: https://github.com/topolvm/topolvm/issues/896