### PR TITLE
Change a way to mark pods as critical add-on

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -127,13 +127,13 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v14.
 | scheduler.options.listen.port | int | `9251` | Listen port. |
 | scheduler.podDisruptionBudget.enabled | bool | `true` | Specify podDisruptionBudget enabled. |
 | scheduler.podLabels | object | `{}` | Additional labels to be set on the scheduler pods. |
-| scheduler.priorityClassName | string | `nil` | Specify priorityClassName on the Deployment or DaemonSet. |
+| scheduler.priorityClassName | string | `"system-cluster-critical"` | Specify priorityClassName on the Deployment or DaemonSet. |
 | scheduler.schedulerOptions | object | `{}` | Tune the Node scoring. ref: https://github.com/topolvm/topolvm/blob/master/deploy/README.md |
 | scheduler.service.clusterIP | string | `nil` | Specify Service clusterIP. |
 | scheduler.service.nodePort | int | `nil` | Specify nodePort. |
 | scheduler.service.type | string | `"LoadBalancer"` | Specify Service type. |
 | scheduler.terminationGracePeriodSeconds | int | `nil` | Specify terminationGracePeriodSeconds on the Deployment or DaemonSet. |
-| scheduler.tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"}]` | Specify tolerations on the Deployment or DaemonSet. # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
+| scheduler.tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"}]` | Specify tolerations on the Deployment or DaemonSet. # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | scheduler.type | string | `"daemonset"` | If you run with a managed control plane (such as GKE, AKS, etc), topolvm-scheduler should be deployed as Deployment and Service. topolvm-scheduler should otherwise be deployed as DaemonSet in unmanaged (i.e. bare metal) deployments. possible values:  daemonset/deployment |
 | scheduler.updateStrategy | object | `{}` | Specify updateStrategy on the Deployment or DaemonSet. |
 | securityContext.runAsGroup | int | `10000` | Specify runAsGroup. |

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -92,8 +92,6 @@ scheduler:
   # scheduler.tolerations -- Specify tolerations on the Deployment or DaemonSet.
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
     - key: node-role.kubernetes.io/control-plane
       effect: NoSchedule
 
@@ -102,7 +100,7 @@ scheduler:
   nodeSelector: {}
 
   # scheduler.priorityClassName -- Specify priorityClassName on the Deployment or DaemonSet.
-  priorityClassName:
+  priorityClassName: system-cluster-critical
 
   # scheduler.schedulerOptions -- Tune the Node scoring.
   # ref: https://github.com/topolvm/topolvm/blob/master/deploy/README.md


### PR DESCRIPTION
The CriticalAddonsOnly taint had been deprecated [1]. Critical add-on pods should use higher priority class now [2].

[1]: https://github.com/kubernetes/website/pull/10733
[2]: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/

Fix: #912