### PR TITLE
fix: allow building with go1.21 or higher via GOTOOLCHAIN=auto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/topolvm/topolvm
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/container-storage-interface/spec v1.9.0


### PR DESCRIPTION
Since Go 1.21 one can supply a toolchain version string for the minimum required version of Go in their go.mod file (e.g. go 1.21.4). From practical point of view it makes no difference whether you declare your requirement as go 1.21 or go 1.21.0 in the go.mod file because in both cases any Go 1.21+ family toolchain will be able to build your project successfully. However, the former makes it impossible for 1.21 toolchains to automatically download a toolchain from e.g. 1.22 language family (via the means of the GOTOOLCHAIN variable), because "1.22" as a string literal doesn't denote a toolchain (while 1.22.0 does).

To reproduce a build environment like this, one can use the following adjustment to the existing Dockerfile:

```
# Build topolvm
FROM --platform=$BUILDPLATFORM golang:1.21-bullseye AS build-topolvm

ENV GOTOOLCHAIN=auto

# Get argument
ARG TOPOLVM_VERSION
ARG TARGETARCH

COPY . /workdir
WORKDIR /workdir

RUN touch pkg/lvmd/proto/*.go
RUN make build-topolvm TOPOLVM_VERSION=${TOPOLVM_VERSION} GOARCH=${TARGETARCH}
```

Examples in other projects:
    [grafana](https://github.com/grafana/grafana/blob/88a2485cc260eb5b2976ee67f201e591c56cf771/go.mod#L3)
    [syft](https://github.com/anchore/syft/blob/fe0b78b7fe73b92ad76deed288d3b9b091a14d27/go.mod#L3)
    [kubernetes](https://github.com/kubernetes/kubernetes/commit/e54f2296ed34fab6bdf260d20145c478eef9362b)