### PR TITLE
docs: remove unnecessary version check

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -112,9 +112,6 @@ The following tools depend on kubernetes, use appropriate version associating to
 - [kind](https://github.com/kubernetes-sigs/kind/releases)
 - [minikube](https://github.com/kubernetes/minikube/releases)
 
-In `.github/workflows/e2e-k8s-incluster-lvmd.yaml`, minikube depends on some other tools,
-so please check if these tools are also needed to be upgraded.
-
 #### Depending Modules
 
 Read [kubernetes go.mod](https://github.com/kubernetes/kubernetes/blob/master/go.mod), and update the `prometheus/*` and `grpc` modules.


### PR DESCRIPTION
The file `.github/workflows/e2e-k8s-incluster-lvmd.yaml` currently
does not include the steps for tool installation.
These steps were removed in the following PR,
and the versions of those tools are now managed in versions.mk.
https://github.com/topolvm/topolvm/pull/781

Therefore, I'm removing the check for this file
in the tools upgrade procedure.

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
