### PR TITLE
Add pprof profiling support to all binaries.

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -25,6 +25,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v15.
 | controller.podDisruptionBudget.enabled | bool | `true` | Specify podDisruptionBudget enabled. |
 | controller.podLabels | object | `{}` | Additional labels to be set on the controller pod. |
 | controller.priorityClassName | string | `nil` | Specify priorityClassName. |
+| controller.profiling.bindAddress | string | `""` | Enables pprof profiling server. If empty, profiling is disabled. |
 | controller.prometheus.podMonitor.additionalLabels | object | `{}` | Additional labels that can be used so PodMonitor will be discovered by Prometheus. |
 | controller.prometheus.podMonitor.enabled | bool | `false` | Set this to `true` to create PodMonitor for Prometheus operator. |
 | controller.prometheus.podMonitor.interval | string | `""` | Scrape interval. If not set, the Prometheus default scrape interval is used. |
@@ -74,6 +75,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v15.
 | lvmd.nodeSelector | object | `{}` | Specify nodeSelector. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | lvmd.podLabels | object | `{}` | Additional labels to be set on the lvmd service pods. |
 | lvmd.priorityClassName | string | `nil` | Specify priorityClassName. |
+| lvmd.profiling.bindAddress | string | `""` | Enables pprof profiling server. If empty, profiling is disabled. |
 | lvmd.socketName | string | `"/run/topolvm/lvmd.sock"` | Specify socketName. |
 | lvmd.tolerations | list | `[]` | Specify tolerations. # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | lvmd.updateStrategy | object | `{}` | Specify updateStrategy. |
@@ -92,6 +94,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v15.
 | node.nodeSelector | object | `{}` | Specify nodeSelector. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | node.podLabels | object | `{}` | Additional labels to be set on the node pods. |
 | node.priorityClassName | string | `nil` | Specify priorityClassName. |
+| node.profiling.bindAddress | string | `""` | Enables pprof profiling server. if empty profiling is disabled. |
 | node.prometheus.podMonitor.additionalLabels | object | `{}` | Additional labels that can be used so PodMonitor will be discovered by Prometheus. |
 | node.prometheus.podMonitor.enabled | bool | `false` | Set this to `true` to create PodMonitor for Prometheus operator. |
 | node.prometheus.podMonitor.interval | string | `""` | Scrape interval. If not set, the Prometheus default scrape interval is used. |
@@ -128,6 +131,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v15.
 | scheduler.podDisruptionBudget.enabled | bool | `true` | Specify podDisruptionBudget enabled. |
 | scheduler.podLabels | object | `{}` | Additional labels to be set on the scheduler pods. |
 | scheduler.priorityClassName | string | `"system-cluster-critical"` | Specify priorityClassName on the Deployment or DaemonSet. |
+| scheduler.profiling.bindAddress | string | `""` | Enables pprof profiling server. If empty, profiling is disabled. |
 | scheduler.schedulerOptions | object | `{}` | Tune the Node scoring. ref: https://github.com/topolvm/topolvm/blob/master/deploy/README.md |
 | scheduler.service.clusterIP | string | `nil` | Specify Service clusterIP. |
 | scheduler.service.nodePort | int | `nil` | Specify nodePort. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -64,6 +64,9 @@ spec:
             {{- if .Values.controller.nodeFinalize.skipped }}
             - --skip-node-finalize
             {{- end }}
+            {{- if .Values.controller.profiling.bindAddress }}
+            - --profiling-bind-address={{ .Values.controller.profiling.bindAddress }}
+            {{- end }}
           {{- if or .Values.useLegacy .Values.env.topolvm_controller }}
           env:
             {{- if .Values.useLegacy }}

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -62,6 +62,9 @@ spec:
           {{- with .Values.lvmd.args }}
           args: {{ toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.lvmd.profiling.bindAddress }}
+          - --profiling-bind-address={{ .Values.lvmd.profiling.bindAddress }}
+          {{- end }}
           {{- if .Values.lvmd.env }}
           env:
           {{- toYaml .Values.lvmd.env | nindent 10 }}

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -59,6 +59,9 @@ spec:
             {{- else }}
             - --lvmd-socket={{ .Values.node.lvmdSocket }}
             {{- end }}
+            {{- if .Values.node.profiling.bindAddress }}
+            - --profiling-bind-address={{ .Values.node.profiling.bindAddress }}
+            {{- end }}
           {{- with .Values.node.args }}
           args: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/topolvm/templates/scheduler/configmap.yaml
+++ b/charts/topolvm/templates/scheduler/configmap.yaml
@@ -15,5 +15,8 @@ data:
     {{- else }}
     default-divisor: 1
     {{- end }}
+    {{- if .Values.scheduler.profiling.bindAddress }}
+    profiling-bind-address: {{ .Values.scheduler.profiling.bindAddress }}
+    {{- end }}
 ---
 {{ end }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -110,6 +110,10 @@ scheduler:
   #    ssd: 1
   #    hdd: 10
 
+  profiling:
+    # scheduler.profiling.bindAddress -- Enables pprof profiling server. If empty, profiling is disabled.
+    bindAddress: ""
+
   options:
     listen:
       # scheduler.options.listen.host -- Host used by Probe.
@@ -212,6 +216,10 @@ lvmd:
 
   # lvmd.initContainers -- Additional initContainers for the lvmd service.
   initContainers: []
+
+  profiling:
+    # lvmd.profiling.bindAddress -- Enables pprof profiling server. If empty, profiling is disabled.
+    bindAddress: ""
 
 # CSI node service
 node:
@@ -345,6 +353,10 @@ node:
   # node.labels -- Additional labels to be added to the Daemonset.
   labels: {}
 
+  profiling:
+    # node.profiling.bindAddress -- Enables pprof profiling server. if empty profiling is disabled.
+    bindAddress: ""
+
   # node.initContainers -- Additional initContainers for the node service.
   initContainers: []
 
@@ -463,6 +475,10 @@ controller:
   podLabels: {}
   # controller.labels -- Additional labels to be added to the Deployment.
   labels: {}
+
+  profiling:
+    # controller.profiling.bindAddress -- Enables pprof profiling server. If empty, profiling is disabled.
+    bindAddress: ""
 
   # controller.initContainers -- Additional initContainers for the controller service.
   initContainers: []

--- a/cmd/topolvm-controller/app/root.go
+++ b/cmd/topolvm-controller/app/root.go
@@ -48,6 +48,7 @@ var config struct {
 	skipNodeFinalize            bool
 	zapOpts                     zap.Options
 	controllerServerSettings    driver.ControllerServerSettings
+	profilingBindAddress        string
 }
 
 var rootCmd = &cobra.Command{
@@ -89,6 +90,7 @@ func init() {
 	fs.DurationVar(&config.leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second, "Duration that the acting controlplane will retry refreshing leadership before giving up. This is measured against time of last observed ack.")
 	fs.DurationVar(&config.leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second, "Duration the LeaderElector clients should wait between tries of actions.")
 	fs.BoolVar(&config.skipNodeFinalize, "skip-node-finalize", false, "skips automatic cleanup of PhysicalVolumeClaims when a Node is deleted")
+	fs.StringVar(&config.profilingBindAddress, "profiling-bind-address", "", "Bind pprof profiling to the given network address. If empty, profiling is disabled.")
 
 	driver.QuantityVar(fs, &config.controllerServerSettings.MinimumAllocationSettings.Block,
 		"minimum-allocation-block",

--- a/cmd/topolvm-controller/app/run.go
+++ b/cmd/topolvm-controller/app/run.go
@@ -86,6 +86,7 @@ func subMain() error {
 			Port:    hookPort,
 			CertDir: config.certDir,
 		}),
+		PprofBindAddress: config.profilingBindAddress,
 	})
 	if err != nil {
 		return err

--- a/cmd/topolvm-node/app/root.go
+++ b/cmd/topolvm-node/app/root.go
@@ -15,14 +15,15 @@ import (
 )
 
 var config struct {
-	csiSocket           string
-	lvmdSocket          string
-	metricsAddr         string
-	secureMetricsServer bool
-	zapOpts             zap.Options
-	embedLvmd           bool
-	lvmPath             string
-	lvmd                lvmd.Config
+	csiSocket            string
+	lvmdSocket           string
+	metricsAddr          string
+	secureMetricsServer  bool
+	zapOpts              zap.Options
+	embedLvmd            bool
+	lvmPath              string
+	lvmd                 lvmd.Config
+	profilingBindAddress string
 }
 
 var rootCmd = &cobra.Command{
@@ -61,6 +62,7 @@ func init() {
 	fs.BoolVar(&config.embedLvmd, "embed-lvmd", false, "Runs LVMD locally by embedding it instead of calling it externally via gRPC")
 	fs.StringVar(&config.lvmPath, "lvm-path", "", "lvm command path on the host OS")
 	fs.StringVar(&cfgFilePath, "config", filepath.Join("/etc", "topolvm", "lvmd.yaml"), "config file")
+	fs.StringVar(&config.profilingBindAddress, "profiling-bind-address", "", "Bind pprof profiling to the given network address. If empty, profiling is disabled.")
 
 	_ = viper.BindEnv("nodename", "NODE_NAME")
 	_ = viper.BindPFlag("nodename", fs.Lookup("nodename"))

--- a/cmd/topolvm-node/app/run.go
+++ b/cmd/topolvm-node/app/run.go
@@ -72,9 +72,10 @@ func subMain(ctx context.Context) error {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:         scheme,
-		Metrics:        metricsServerOptions,
-		LeaderElection: false,
+		Scheme:           scheme,
+		Metrics:          metricsServerOptions,
+		LeaderElection:   false,
+		PprofBindAddress: config.profilingBindAddress,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/internal/profiling/server.go
+++ b/internal/profiling/server.go
@@ -1,0 +1,23 @@
+package profiling
+
+import (
+	"net/http"
+	"net/http/pprof"
+)
+
+// NewProfilingServer creates a new HTTP server for profiling.
+func NewProfilingServer(bindAddress string) *http.Server {
+	mux := http.NewServeMux()
+	srv := http.Server{
+		Addr:    bindAddress,
+		Handler: mux,
+	}
+
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	return &srv
+}


### PR DESCRIPTION
## What is this change?

This adds the ability to expose the [pprof](https://pkg.go.dev/net/http/pprof) profiler for all of the topolvm binaries.

### Background

We are seeing a bit of memory growth over time with lvmd, and wanted to run some profiling to see if there's some sort of memory leak, but don't have that ability. This would add that functionality.