### PR TITLE
revert node-driver-registrar version to v2.10.1

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -46,7 +46,7 @@ EXTERNAL_PROVISIONER_VERSION := 5.0.1
 EXTERNAL_RESIZER_VERSION := 1.11.1
 EXTERNAL_SNAPSHOTTER_VERSION := 8.0.1
 LIVENESSPROBE_VERSION := 2.13.0
-NODE_DRIVER_REGISTRAR_VERSION := 2.11.0
+NODE_DRIVER_REGISTRAR_VERSION := 2.10.1
 
 # The container version of kind must be with the digest.
 # ref. https://github.com/kubernetes-sigs/kind/releases


### PR DESCRIPTION
issue: https://github.com/topolvm/topolvm/issues/934

Because v2.11.0 contains a following bug,
I revert to the previous version.
https://github.com/kubernetes-csi/node-driver-registrar/issues/425

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
