### PR TITLE
Fix indentation level of lvmd daemonset profiling options.

### DIFF
--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
           args: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.lvmd.profiling.bindAddress }}
-          - --profiling-bind-address={{ .Values.lvmd.profiling.bindAddress }}
+            - --profiling-bind-address={{ .Values.lvmd.profiling.bindAddress }}
           {{- end }}
           {{- if .Values.lvmd.env }}
           env:


### PR DESCRIPTION
There was an indentation issue in the pprof profiling changes Helm chart.

Test values:
```
❯ cat test-values.yaml 
controller:
  profiling:
    bindAddress: ":6060"
scheduler:
  profiling:
    bindAddress: ":6060"
lvmd:
  profiling:
    bindAddress: ":6060"
```

```
❯ gcheck main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

❯ helm template topolvm . -f test-values.y❯ gcheck fix-helm-chart-bug-profiling-lvmd
Switched to branch 'fix-helm-chart-bug-profiling-lvmd'
aml -s templates/lvmd/daemonset.yaml
Error: YAML parse error on topolvm/templates/lvmd/daemonset.yaml: error converting YAML to JSON: yaml: line 38: did not find expected key

Use --debug flag to render out invalid YAML

❯ gcheck fix-helm-chart-bug-profiling-lvmd
Switched to branch 'fix-helm-chart-bug-profiling-lvmd'

❯ helm template topolvm . -f test-values.yaml -s templates/lvmd/daemonset.yaml | yq '.spec.template.spec.containers[0].command'
- /lvmd
- --profiling-bind-address=:6060

```