### PR TITLE
Set lvmd log verbosity based on state modification or reporting

### DIFF
--- a/internal/lvmd/command/lvm_command_test.go
+++ b/internal/lvmd/command/lvm_command_test.go
@@ -23,7 +23,7 @@ func Test_lvm_command(t *testing.T) {
 	}
 	t.Run("simple lvm version should succeed with stream", func(t *testing.T) {
 		ctx := log.IntoContext(context.Background(), testr.New(t))
-		dataStream, err := callLVMStreamed(ctx, "version")
+		dataStream, err := callLVMStreamed(ctx, verbosityLVMStateNoUpdate, "version")
 		if err != nil {
 			t.Fatal(err, "version should succeed")
 		}
@@ -79,7 +79,7 @@ func Test_lvm_command(t *testing.T) {
 		fakeDeviceName := "/dev/does-not-exist"
 
 		ctx := log.IntoContext(context.Background(), testr.New(t))
-		dataStream, err := callLVMStreamed(ctx, "vgcreate", "test-vg", fakeDeviceName)
+		dataStream, err := callLVMStreamed(ctx, verbosityLVMStateUpdate, "vgcreate", "test-vg", fakeDeviceName)
 		if err != nil {
 			t.Fatal(err, "vgcreate should not fail instantly as read didn't finish")
 		}

--- a/internal/lvmd/command/lvm_lvs.go
+++ b/internal/lvmd/command/lvm_lvs.go
@@ -123,7 +123,7 @@ func getLVReport(ctx context.Context, name string) (map[string]lv, error) {
 		"--reportformat",
 		"json",
 	}
-	err := callLVMInto(ctx, res, args...)
+	err := callLVMInto(ctx, res, verbosityLVMStateNoUpdate, args...)
 
 	if IsLVMNotFound(err) {
 		return nil, errors.Join(ErrNotFound, err)

--- a/internal/lvmd/command/lvm_state_json.go
+++ b/internal/lvmd/command/lvm_state_json.go
@@ -46,7 +46,7 @@ func getLVMState(ctx context.Context) ([]vg, []lv, error) {
 		"--configreport", "pvseg", "-o,",
 		"--configreport", "seg", "-o,",
 	}
-	streamed, err := callLVMStreamed(ctx, append([]string{"fullreport"}, args...)...)
+	streamed, err := callLVMStreamed(ctx, verbosityLVMStateNoUpdate, append([]string{"fullreport"}, args...)...)
 	defer func() {
 		// this will wait for the process to be released.
 		if err := streamed.Close(); err != nil {

--- a/internal/lvmd/command/lvm_vgs.go
+++ b/internal/lvmd/command/lvm_vgs.go
@@ -53,7 +53,7 @@ func getVGReport(ctx context.Context, name string) (vg, error) {
 	args := []string{
 		"vgs", name, "-o", "vg_uuid,vg_name,vg_size,vg_free", "--units", "b", "--nosuffix", "--reportformat", "json",
 	}
-	err := callLVMInto(ctx, res, args...)
+	err := callLVMInto(ctx, res, verbosityLVMStateNoUpdate, args...)
 
 	if IsLVMNotFound(err) {
 		return vg{}, errors.Join(ErrNotFound, err)


### PR DESCRIPTION
This commit adds verbosity to invoking command log. 

Fix #941. (edited by @ushitora-anqou )