### PR TITLE
bump node-driver-registrar version to v2.11.1

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -46,7 +46,7 @@ EXTERNAL_PROVISIONER_VERSION := 5.0.1
 EXTERNAL_RESIZER_VERSION := 1.11.1
 EXTERNAL_SNAPSHOTTER_VERSION := 8.0.1
 LIVENESSPROBE_VERSION := 2.13.0
-NODE_DRIVER_REGISTRAR_VERSION := 2.10.1
+NODE_DRIVER_REGISTRAR_VERSION := 2.11.1
 
 # The container version of kind must be with the digest.
 # ref. https://github.com/kubernetes-sigs/kind/releases


### PR DESCRIPTION
node-driver-registrar v2.11.0 or higher
depends on k8s 1.30 libraries.
Because v2.11.0 contains a serious bug,
I upgrade it to v2.11.1.

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
