### PR TITLE
Introduce prometheus metrics for lvmd process.

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -72,10 +72,19 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v15.
 | lvmd.labels | object | `{}` | Additional labels to be added to the Daemonset. |
 | lvmd.lvcreateOptionClasses | list | `[]` | Specify the lvcreate-option-class settings. |
 | lvmd.managed | bool | `true` | If true, set up lvmd service with DaemonSet. |
+| lvmd.metrics.annotations | object | `{"prometheus.io/port":"metrics"}` | Annotations for Scrape used by Prometheus. |
+| lvmd.metrics.enabled | bool | `true` | If true, enable scraping of metrics by Prometheus. |
 | lvmd.nodeSelector | object | `{}` | Specify nodeSelector. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | lvmd.podLabels | object | `{}` | Additional labels to be set on the lvmd service pods. |
 | lvmd.priorityClassName | string | `nil` | Specify priorityClassName. |
 | lvmd.profiling.bindAddress | string | `""` | Enables pprof profiling server. If empty, profiling is disabled. |
+| lvmd.prometheus.podMonitor.additionalLabels | object | `{}` | Additional labels that can be used so PodMonitor will be discovered by Prometheus. |
+| lvmd.prometheus.podMonitor.enabled | bool | `false` | Set this to `true` to create PodMonitor for Prometheus operator. |
+| lvmd.prometheus.podMonitor.interval | string | `""` | Scrape interval. If not set, the Prometheus default scrape interval is used. |
+| lvmd.prometheus.podMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion. |
+| lvmd.prometheus.podMonitor.namespace | string | `""` | Optional namespace in which to create PodMonitor. |
+| lvmd.prometheus.podMonitor.relabelings | list | `[]` | RelabelConfigs to apply to samples before scraping. |
+| lvmd.prometheus.podMonitor.scrapeTimeout | string | `""` | Scrape timeout. If not set, the Prometheus default scrape timeout is used. |
 | lvmd.socketName | string | `"/run/topolvm/lvmd.sock"` | Specify socketName. |
 | lvmd.tolerations | list | `[]` | Specify tolerations. # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | lvmd.updateStrategy | object | `{}` | Specify updateStrategy. |

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -36,6 +36,11 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/lvmd/configmap.yaml") . | sha256sum }}
+        {{- if .Values.lvmd.metrics.enabed }}
+        {{- with .Values.lvmd.metrics.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.lvmd.priorityClassName }}
       priorityClassName: {{ . }}
@@ -86,6 +91,10 @@ spec:
             {{- with .Values.livenessProbe.lvmd.periodSeconds }}
             periodSeconds: {{ . }}
             {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
           {{- with .Values.resources.lvmd }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/topolvm/templates/lvmd/podmonitor.yaml
+++ b/charts/topolvm/templates/lvmd/podmonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.lvmd.prometheus.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "topolvm.fullname" . }}-lvmd
+  namespace: {{ .Values.lvmd.prometheus.podMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "topolvm.labels" . | nindent 4 }}
+    {{- with .Values.lvmd.prometheus.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: lvmd
+      {{ include "topolvm.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+    {{- with .Values.lvmd.prometheus.podMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.lvmd.prometheus.podMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.lvmd.prometheus.podMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.lvmd.prometheus.podMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -221,6 +221,46 @@ lvmd:
     # lvmd.profiling.bindAddress -- Enables pprof profiling server. If empty, profiling is disabled.
     bindAddress: ""
 
+  metrics:
+    # lvmd.metrics.enabled -- If true, enable scraping of metrics by Prometheus.
+    enabled: true
+    # lvmd.metrics.annotations -- Annotations for Scrape used by Prometheus.
+    annotations:
+      prometheus.io/port: metrics
+
+  prometheus:
+    podMonitor:
+      # lvmd.prometheus.podMonitor.enabled -- Set this to `true` to create PodMonitor for Prometheus operator.
+      enabled: false
+
+      # lvmd.prometheus.podMonitor.additionalLabels -- Additional labels that can be used so PodMonitor will be discovered by Prometheus.
+      additionalLabels: {}
+
+      # lvmd.prometheus.podMonitor.namespace -- Optional namespace in which to create PodMonitor.
+      namespace: ""
+
+      # lvmd.prometheus.podMonitor.interval -- Scrape interval. If not set, the Prometheus default scrape interval is used.
+      interval: ""
+
+      # lvmd.prometheus.podMonitor.scrapeTimeout -- Scrape timeout. If not set, the Prometheus default scrape timeout is used.
+      scrapeTimeout: ""
+
+      # lvmd.prometheus.podMonitor.relabelings -- RelabelConfigs to apply to samples before scraping.
+      relabelings: []
+      # - sourceLabels: [__meta_kubernetes_service_label_cluster]
+      #   targetLabel: cluster
+      #   regex: (.*)
+      #   replacement: ${1}
+      #   action: replace
+
+      # lvmd.prometheus.podMonitor.metricRelabelings -- MetricRelabelConfigs to apply to samples before ingestion.
+      metricRelabelings: []
+      # - sourceLabels: [__meta_kubernetes_service_label_cluster]
+      #   targetLabel: cluster
+      #   regex: (.*)
+      #   replacement: ${1}
+      #   action: replace
+
 # CSI node service
 node:
   # node.lvmdEmbedded -- Specify whether to embed lvmd in the node container.


### PR DESCRIPTION
## What is this change?

This is a bit of a follow-up to #931 , as we're wanting the `go_memstats*` information from prometheus for the lvmd pods to compare to some pprof dumps that we are analyzing, but found that the lvmd pods weren't exposing any metrics, in comparison to the other processes, which all expose these metrics (controller/node/etc).

### Open Question

Would your team prefer these flags to be similar to the other processes, such as `lvmd.metrics.enabled: bool`? I didn't do it this way as lvmd isn't using `controller-runtime`, so I wasn't sure if this made more sense. Let me know as I'll be happy to update it.