### PR TITLE
example: mount host's /dev on the worker node

### DIFF
--- a/example/kind/topolvm-cluster.yaml
+++ b/example/kind/topolvm-cluster.yaml
@@ -23,3 +23,5 @@ nodes:
     - containerPath: /var/lib/kubelet
       hostPath: "@TMPDIR@/worker"
       propagation: Bidirectional
+    - containerPath: /dev
+      hostPath: /dev


### PR DESCRIPTION
Due to PR #930, topolvm-node now needs to access
the LVs' device files in the /dev/<vg name> directory.

In the example setting, LVs are created on the host.
Therefore, the worker node container created by Kind
should mount the host's /dev directory.

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
