### PR TITLE
Update the URL for cert-manager CRD

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,8 @@ helm install --namespace=topolvm-system topolvm topolvm/topolvm
 If you want to install cert-manager together, use the following command instead.
 
 ```sh
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/${VERSION}/cert-manager.crds.yaml
+CERT_MANAGER_VERSION=v1.15.1
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.crds.yaml
 
 helm install --namespace=topolvm-system topolvm topolvm/topolvm --set cert-manager.enabled=true
 ```

--- a/versions.mk
+++ b/versions.mk
@@ -1,5 +1,6 @@
 # https://github.com/docker/buildx/releases
 BUILDX_VERSION := 0.15.1
+# If you update the version, you also need to update getting-started.md.
 # https://github.com/cert-manager/cert-manager/releases
 CERT_MANAGER_VERSION := v1.15.1
 # https://github.com/helm/chart-testing/releases


### PR DESCRIPTION
Since the repository was moved, update the download URL. This also describes the cert-manager version to make it easy to install it.

fix: #952 