### PR TITLE
Fix deviceClasses typo in Values.lvmd.additionalConfigs

### DIFF
--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -196,7 +196,7 @@ lvmd:
   additionalConfigs: []
   #  - tolerations: []
   #      nodeSelector: {}
-  #      device-classes:
+  #      deviceClasses:
   #        - name: ssd
   #          volume-group: myvg2
   #          default: true


### PR DESCRIPTION
Fix deviceClasses typo in Values.lvmd.additionalConfigs. As for now it spelled `device-classes` which is incorrect and misleading.