### PR TITLE
fix: typo blocking lvmd.metrics.annotation inclusion in rendered file

### DIFF
--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/lvmd/configmap.yaml") . | sha256sum }}
-        {{- if .Values.lvmd.metrics.enabed }}
+        {{- if .Values.lvmd.metrics.enabled }}
         {{- with .Values.lvmd.metrics.annotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Issue

The helm chart does not render annotations in the lvmd daemonset correctly. 

After rendering the chart `topolvm/lvmd/daemonset.yaml` just contains the checksum/config and no annotations.
```yaml
spec:
  template:
    metadata:
      annotations:
        checksum/config: cc62eb215d763753a7d1634237874f8f800b927ee004e0ac49462902c1ae61dd
```


## Solution

Fixed typo `enabed` to `enabled` in the respective template file. 

Now the annotations are rendered correctly in `topolvm/lvmd/daemonset.yaml`:
```yaml
spec:
  template:
    metadata:
      annotations:
        checksum/config: cc62eb215d763753a7d1634237874f8f800b927ee004e0ac49462902c1ae61dd
        prometheus.io/port: metrics
```