### PR TITLE
  Very old version of cert-manager in the subchart - updated to v1.12  Update for Issue. #983

### DIFF
--- a/charts/topolvm/Chart.lock
+++ b/charts/topolvm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.7.0
-digest: sha256:2d72eb34ee783a5a3e710366d7c50cdaaf9197613b3904907798e7a13dd39f0f
-generated: "2022-01-28T07:01:39.942953089Z"
+  version: v1.12.13
+digest: sha256:92b3de762998e5b933e95852d94dda91d998eb7b8bd4fef45bbdfd4ec344940c
+generated: "2024-11-06T09:47:35.354991961+01:00"

--- a/charts/topolvm/Chart.yaml
+++ b/charts/topolvm/Chart.yaml
@@ -12,7 +12,7 @@ sources:
 dependencies:
   - name: cert-manager
     repository: https://charts.jetstack.io
-    version: 1.7.0
+    version: ~1.12.x
     condition: cert-manager.enabled
 
 annotations:


### PR DESCRIPTION
This replaces #984

Very old version of cert-manager in the subchart - updated to v1.16.1

Update for Issue. https://github.com/topolvm/topolvm/issues/983