### PR TITLE
fix the kubectl binary download site

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -26,7 +26,7 @@ endif
 
 $(KUBECTL):
 	mkdir -p $(BINDIR)
-	$(CURL) https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl -o $(KUBECTL)
+	$(CURL) https://dl.k8s.io/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl -o $(KUBECTL)
 	chmod 755 $(KUBECTL)
 
 build/topolvm.img: $(GO_FILES)

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -150,7 +150,7 @@ $(KIND):
 	$(MAKE) -C ../.. install-kind
 
 $(KUBECTL): | $(BINDIR)
-	$(CURL) -o $@ https://storage.googleapis.com/kubernetes-release/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl
+	$(CURL) -o $@ https://dl.k8s.io/release/v$(KUBERNETES_VERSION)/bin/linux/amd64/kubectl
 	chmod a+x $@
 
 .PHONY: incluster-lvmd/create-vg


### PR DESCRIPTION
Currently, kubectl is downloaded from storage.googleapis.com.
However, it does not provide the latest kubectl binary (v1.31.1).

According to the following document,
we should access dl.k8s.io to download kubectl.
https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/

Signed-off-by: Shinya Hayashi <shinya-hayashi@cybozu.co.jp>
