### PR TITLE
Introduce distclean targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,11 @@ groupname-test: ## Run unit tests that depends on the groupname.
 	TEST_LEGACY=true go test -count=1 -race -v --timeout=60s ./constants*.go
 
 .PHONY: clean
-clean: ## Clean working directory.
+clean: ## Clean built files on the working directory.
 	rm -rf build/
+
+.PHONY: distclean
+distclean: clean ## Clean all on the working directory.
 	rm -rf bin/
 	rm -rf include/
 	rm -rf testbin/

--- a/example/Makefile
+++ b/example/Makefile
@@ -66,9 +66,13 @@ setup: $(KUBECTL)
 	$(CURL) https://get.helm.sh/helm-v$(HELM_VERSION)-linux-amd64.tar.gz \
 	  | tar xvz -C $(BINDIR) --strip-components 1 linux-amd64/helm
 
-.PHONY: stop-lvmd
+.PHONY: clean
 clean: stop-lvmd
-	rm -rf bin/ build/ $(TMPDIR)
+	rm -rf build/ $(TMPDIR)
+
+.PHONY: distclean
+distclean: clean
+	rm -rf bin/
 
 $(TMPDIR)/lvmd/lvmd.yaml: ../deploy/lvmd-config/lvmd.yaml
 	mkdir -p $(TMPDIR)/lvmd

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -126,6 +126,10 @@ clean: stop-lvmd
 		tmpbin/ \
 		/tmp/topolvm/scheduler/scheduler-config.yaml
 
+.PHONY: distclean
+distclean: clean
+	rm -rf bin/
+
 .PHONY: setup
 setup:
 	$(MAKE) $(GINKGO)


### PR DESCRIPTION
The clean target used to remove not only built files but also downloaded dependencies. This was undesirable for the development and testing process, as we need to download necessary binaries many times. To avoid this, don't remove them by the clean, and do it by the new distclean target, known as the standard target[1].

[1]: https://www.gnu.org/prep/standards/html_node/Standard-Targets.html

fix:  #483