### PR TITLE
test: don't skip tests using root unless SKIP_TESTS_USING_ROOT is set

### DIFF
--- a/internal/filesystem/util_test.go
+++ b/internal/filesystem/util_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/topolvm/topolvm/internal/testutils"
 )
 
 func createDevice() (string, error) {
@@ -36,9 +38,7 @@ func createDevice() (string, error) {
 }
 
 func TestDetectFilesystem(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("run as root")
-	}
+	testutils.RequireRoot(t)
 
 	dev, err := createDevice()
 	if err != nil {

--- a/internal/lvmd/command/lvm_command_test.go
+++ b/internal/lvmd/command/lvm_command_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -19,9 +18,8 @@ import (
 )
 
 func Test_lvm_command(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("run as root")
-	}
+	testutils.RequireRoot(t)
+
 	t.Run("simple lvm version should succeed with stream", func(t *testing.T) {
 		ctx := log.IntoContext(context.Background(), testr.New(t))
 		dataStream, err := callLVMStreamed(ctx, verbosityLVMStateNoUpdate, "version")

--- a/internal/lvmd/command/lvm_state_json_test.go
+++ b/internal/lvmd/command/lvm_state_json_test.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"io"
-	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -289,10 +288,7 @@ func TestLvmJSONBad(t *testing.T) {
 
 func TestLvmRetrieval(t *testing.T) {
 	ctx := ctrl.LoggerInto(context.Background(), testr.New(t))
-	uid := os.Getuid()
-	if uid != 0 {
-		t.Skip("run as root")
-	}
+	testutils.RequireRoot(t)
 
 	vgName := "test_lvm_json"
 	lvName := "test_lvm_json_lv"

--- a/internal/lvmd/lvservice_test.go
+++ b/internal/lvmd/lvservice_test.go
@@ -3,7 +3,6 @@ package lvmd
 import (
 	"context"
 	"errors"
-	"os"
 	"os/exec"
 	"testing"
 
@@ -23,10 +22,7 @@ func TestLVService(t *testing.T) {
 		testTag2 = "testtag2"
 	)
 
-	uid := os.Getuid()
-	if uid != 0 {
-		t.Skip("run as root")
-	}
+	testutils.RequireRoot(t)
 	ctx := ctrl.LoggerInto(context.Background(), testr.New(t))
 
 	vgName := "test_lvservice"

--- a/internal/lvmd/testutils/test_utils.go
+++ b/internal/lvmd/testutils/test_utils.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"testing"
 
+	"github.com/topolvm/topolvm/internal/testutils"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -76,4 +78,8 @@ func CleanLoopbackVG(name string, loops []string, files []string) error {
 	}
 
 	return nil
+}
+
+func RequireRoot(t *testing.T) {
+	testutils.RequireRoot(t)
 }

--- a/internal/lvmd/vgservice_test.go
+++ b/internal/lvmd/vgservice_test.go
@@ -3,7 +3,6 @@ package lvmd
 import (
 	"context"
 	"math"
-	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -421,10 +420,7 @@ func testVGService(t *testing.T, vg *command.VolumeGroup) {
 
 func TestVGService(t *testing.T) {
 	ctx := ctrl.LoggerInto(context.Background(), testr.New(t))
-	uid := os.Getuid()
-	if uid != 0 {
-		t.Skip("run as root")
-	}
+	testutils.RequireRoot(t)
 
 	vgName := "test_vgservice"
 	loop1, err := testutils.MakeLoopbackDevice(ctx, vgName+"1")

--- a/internal/testutils/test_utils.go
+++ b/internal/testutils/test_utils.go
@@ -1,0 +1,22 @@
+package testutils
+
+import (
+	"os"
+	"testing"
+)
+
+const (
+	envSkipTestsUsingRoot = "SKIP_TESTS_USING_ROOT"
+)
+
+func RequireRoot(t *testing.T) {
+	t.Helper()
+
+	if os.Getuid() == 0 {
+		return
+	}
+	if os.Getenv(envSkipTestsUsingRoot) == "1" {
+		t.Skipf("this test requires root but %s is set to 1", envSkipTestsUsingRoot)
+	}
+	t.Fatalf("run as root or set environment variable %s to 1", envSkipTestsUsingRoot)
+}


### PR DESCRIPTION
Related to #999

In the current implementation, some tests are skipped when they run without root privilege, so developers can overlook them easily.

This commit resolves the problem above by introducing SKIP_TESTS_USING_ROOT environment variable. The behaviour of the tests is changed as follows:

- If the tests are started with root privilege, they will run.
- If the tests are started without root privilege and without SKIP_TESTS_USING_ROOT=1, they will fail.
- If the tests are started without root privilege but with SKIP_TESTS_USING_ROOT=1, they will be skipped.