### PR TITLE
support cached volumes, fixes #1003

### DIFF
--- a/internal/lvmd/command/lvm.go
+++ b/internal/lvmd/command/lvm.go
@@ -474,7 +474,7 @@ func (l *LogicalVolume) Origin(ctx context.Context) (*LogicalVolume, error) {
 
 // IsThin checks if the volume is thin volume or not.
 func (l *LogicalVolume) IsThin() bool {
-	return l.pool != nil
+	return l.attr[0] == byte(VolumeTypeThinVolume)
 }
 
 // Pool returns thin pool if this is a thin pool, or nil if not.

--- a/internal/lvmd/command/lvm_lv_attr.go
+++ b/internal/lvmd/command/lvm_lv_attr.go
@@ -32,6 +32,7 @@ var (
 type VolumeType rune
 
 const (
+	VolumeTypeCached                     VolumeType = 'C'
 	VolumeTypeMirrored                   VolumeType = 'm'
 	VolumeTypeMirroredNoInitialSync      VolumeType = 'M'
 	VolumeTypeOrigin                     VolumeType = 'o'
@@ -114,6 +115,7 @@ const (
 type OpenTarget rune
 
 const (
+	OpenTargetCache    OpenTarget = 'C'
 	OpenTargetMirror   OpenTarget = 'm'
 	OpenTargetRaid     OpenTarget = 'r'
 	OpenTargetSnapshot OpenTarget = 's'

--- a/internal/lvmd/command/lvm_lv_attr_test.go
+++ b/internal/lvmd/command/lvm_lv_attr_test.go
@@ -81,6 +81,23 @@ func TestParsedLVAttr(t *testing.T) {
 			},
 			noError,
 		},
+		{
+			"Cache",
+			args{raw: "Cwi-aoC---"},
+			LVAttr{
+				VolumeType:       VolumeTypeCached,
+				Permissions:      PermissionsWriteable,
+				AllocationPolicy: AllocationPolicyInherited,
+				Minor:            MinorFalse,
+				State:            StateActive,
+				Open:             OpenTrue,
+				OpenTarget:       OpenTargetCache,
+				Zero:             ZeroFalse,
+				VolumeHealth:     VolumeHealthOK,
+				SkipActivation:   SkipActivationFalse,
+			},
+			noError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
* add `C` to VolumeType and OpenTarget consts
* `lv.IsThin` should check LV attrs for thin (e.g., cached LVs have a pool but are not necessarily thin)
* add tests for cached LVs