### PR TITLE
add docker/setup-qemu-action to build-images.yaml

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -30,6 +30,8 @@ jobs:
           - "with-sidecar"
     steps:
       - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login registry


### PR DESCRIPTION
In the build-images process, apt install of libc-bin fails in the arm64 environment. The following is a response to a similar issue, and qemu version is expected to be the cause.
https://github.com/docker/buildx/issues/314#issuecomment-1877537571 
Looking at the setup-buildx-action documentation, it appears that qemu is installed using setup-qemu-action, so I will add a similar process.