### PR TITLE
Helm Chart: allow additional containers to be defined in the chart

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -14,6 +14,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v15.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cert-manager.enabled | bool | `false` | Install cert-manager together. # ref: https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm |
+| controller.additionalContainers | list | `[]` | Define extra containers to add to the Deployment. Please ensure not to use any existing container names. |
 | controller.affinity | string | `"podAntiAffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n    - labelSelector:\n        matchExpressions:\n          - key: app.kubernetes.io/component\n            operator: In\n            values:\n              - controller\n          - key: app.kubernetes.io/name\n            operator: In\n            values:\n              - {{ include \"topolvm.name\" . }}\n      topologyKey: kubernetes.io/hostname\n"` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | controller.args | list | `[]` | Arguments to be passed to the command. |
 | controller.initContainers | list | `[]` | Additional initContainers for the controller service. |
@@ -63,6 +64,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v15.
 | livenessProbe.topolvm_node | object | `{"failureThreshold":null,"initialDelaySeconds":10,"periodSeconds":60,"timeoutSeconds":3}` | Specify resources. # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | livenessProbe.topolvm_scheduler | object | `{"failureThreshold":null,"initialDelaySeconds":10,"periodSeconds":60,"timeoutSeconds":3}` | Specify livenessProbe. # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | lvmd.additionalConfigs | list | `[]` | Define additional LVM Daemon configs if you have additional types of nodes. Please ensure nodeSelectors are non overlapping. |
+| lvmd.additionalContainers | list | `[]` | Define extra containers to add to the Daemonset. Please ensure not to use any existing container names. |
 | lvmd.additionalVolumes | list | `[]` | Specify additional volumes without conflicting with default volumes most useful for initContainers but available to all containers in the pod. |
 | lvmd.affinity | object | `{}` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | lvmd.args | list | `[]` | Arguments to be passed to the command. |
@@ -91,6 +93,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v15.
 | lvmd.updateStrategy | object | `{}` | Specify updateStrategy. |
 | lvmd.volumeMounts | list | `[]` | Specify volumeMounts. |
 | lvmd.volumes | list | `[]` | Specify volumes. |
+| node.additionalContainers | list | `[]` | Define extra containers to add to the Daemonset. Please ensure not to use any existing container names. |
 | node.additionalVolumes | list | `[]` | Specify additional volumes without conflicting with default volumes most useful for initContainers but available to all containers in the pod. |
 | node.affinity | object | `{}` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | node.args | list | `[]` | Arguments to be passed to the command. |
@@ -130,6 +133,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v15.
 | resources.topolvm_controller | object | `{}` | Specify resources. # ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | resources.topolvm_node | object | `{}` | Specify resources. # ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | resources.topolvm_scheduler | object | `{}` | Specify resources. # ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| scheduler.additionalContainers | list | `[]` | Define extra containers to add to the Daemonset. Please ensure not to use any existing container names. |
 | scheduler.affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]}]}}}` | Specify affinity on the Deployment or DaemonSet. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | scheduler.args | list | `[]` | Arguments to be passed to the command. |
 | scheduler.deployment.replicaCount | int | `2` | Number of replicas for Deployment. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -258,6 +258,10 @@ spec:
           {{- with .Values.env.liveness_probe }}
           env: {{ toYaml . | nindent 12 }}
           {{- end }}
+
+        {{- with .Values.controller.additionalContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         {{- if or .Values.webhook.podMutatingWebhook.enabled .Values.webhook.pvcMutatingWebhook.enabled }}
         - name: certs

--- a/charts/topolvm/templates/lvmd/daemonset.yaml
+++ b/charts/topolvm/templates/lvmd/daemonset.yaml
@@ -110,6 +110,10 @@ spec:
             - name: lvmd-socket-dir
               mountPath: {{ dir .Values.lvmd.socketName }}
             {{- end }}
+
+        {{- with .Values.lvmd.additionalContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         - name: devices-dir
           hostPath:

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -201,6 +201,9 @@ spec:
             - name: node-plugin-dir
               mountPath: {{ .Values.node.kubeletWorkDirectory }}/plugins/{{ include "topolvm.pluginName" . }}/node/
 
+        {{- with .Values.node.additionalContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         {{- if .Values.node.volumes }}
         {{- toYaml .Values.node.volumes | nindent 8 }}

--- a/charts/topolvm/templates/scheduler/daemonset.yaml
+++ b/charts/topolvm/templates/scheduler/daemonset.yaml
@@ -96,6 +96,10 @@ spec:
           {{- with .Values.resources.topolvm_scheduler }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+
+        {{- with .Values.scheduler.additionalContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       hostNetwork: true
       volumes:
         - name: {{ template "topolvm.fullname" . }}-scheduler-options

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -110,6 +110,10 @@ scheduler:
   #    ssd: 1
   #    hdd: 10
 
+  # scheduler.additionalContainers -- Define extra containers to add to the Daemonset.
+  # Please ensure not to use any existing container names.
+  additionalContainers: []
+
   profiling:
     # scheduler.profiling.bindAddress -- Enables pprof profiling server. If empty, profiling is disabled.
     bindAddress: ""
@@ -221,6 +225,10 @@ lvmd:
 
   # lvmd.initContainers -- Additional initContainers for the lvmd service.
   initContainers: []
+
+  # lvmd.additionalContainers -- Define extra containers to add to the Daemonset.
+  # Please ensure not to use any existing container names.
+  additionalContainers: []
 
   profiling:
     # lvmd.profiling.bindAddress -- Enables pprof profiling server. If empty, profiling is disabled.
@@ -409,6 +417,10 @@ node:
   # node.initContainers -- Additional initContainers for the node service.
   initContainers: []
 
+  # node.additionalContainers -- Define extra containers to add to the Daemonset.
+  # Please ensure not to use any existing container names.
+  additionalContainers: []
+
 # CSI controller service
 controller:
   # controller.replicaCount -- Number of replicas for CSI controller service.
@@ -531,6 +543,10 @@ controller:
 
   # controller.initContainers -- Additional initContainers for the controller service.
   initContainers: []
+
+  # controller.additionalContainers -- Define extra containers to add to the Deployment.
+  # Please ensure not to use any existing container names.
+  additionalContainers: []
 
 resources:
   # resources.topolvm_node -- Specify resources.


### PR DESCRIPTION
The PR allows for additional containers to be added to all DaemonSets and Deployments in the chart.