### PR TITLE
Ignore non-filesystem signatures when re-mounting filesystem PVC

### DIFF
--- a/internal/driver/node.go
+++ b/internal/driver/node.go
@@ -230,7 +230,11 @@ func (s *nodeServerNoLocked) nodePublishFilesystemVolume(req *csi.NodePublishVol
 	}
 
 	if !mounted {
-		if err := s.mounter.FormatAndMount(lv.GetPath(), req.GetTargetPath(), mountOption.FsType, mountOptions); err != nil {
+		mountFunc := s.mounter.FormatAndMount
+		if len(fsType) > 0 {
+			mountFunc = s.mounter.Mount
+		}
+		if err := mountFunc(lv.GetPath(), req.GetTargetPath(), mountOption.FsType, mountOptions); err != nil {
 			return status.Errorf(codes.Internal, "mount failed: volume=%s, error=%v", req.GetVolumeId(), err)
 		}
 		if err := os.Chmod(req.GetTargetPath(), 0777|os.ModeSetgid); err != nil {

--- a/internal/filesystem/util.go
+++ b/internal/filesystem/util.go
@@ -31,7 +31,7 @@ func DetectFilesystem(device string) (string, error) {
 		return "", err
 	}
 
-	out, err := exec.Command(blkidCmd, "-c", "/dev/null", "-o", "export", device).CombinedOutput()
+	out, err := exec.Command(blkidCmd, "-p", "-u", "filesystem", "-o", "export", device).CombinedOutput()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			// blkid exists with status 2 when anything can be found


### PR DESCRIPTION
See the commit message.
