### PR TITLE
docs: pin pause image version for arm64

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,7 +74,7 @@ metadata:
 spec:
   containers:
   - name: pause
-    image: registry.k8s.io/pause
+    image: registry.k8s.io/pause:3.9
     volumeMounts:
     - mountPath: /data
       name: volume


### PR DESCRIPTION
When running the example on arm64 an error may occur:

exec /pause: exec format error

The fix is identical to this:
https://github.com/apache/spark-kubernetes-operator/pull/145