### PR TITLE
lvmd: enable command-line options for klog and zap

### DIFF
--- a/cmd/lvmd/app/root.go
+++ b/cmd/lvmd/app/root.go
@@ -199,9 +199,11 @@ func init() {
 	fs.StringVar(&profilingBindAddress, "profiling-bind-address", "", "bind address to expose pprof profiling. If empty, profiling is disabled")
 	fs.StringVar(&metricsBindAddress, "metrics-bind-address", ":8080", "bind address to expose prometheus metrics. If empty, metrics are disabled")
 
-	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(goflags)
-	zapOpts.BindFlags(goflags)
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	fs.AddGoFlagSet(klogFlags)
 
-	fs.AddGoFlagSet(goflags)
+	zapFlags := flag.NewFlagSet("zap", flag.ExitOnError)
+	zapOpts.BindFlags(zapFlags)
+	fs.AddGoFlagSet(zapFlags)
 }

--- a/cmd/topolvm-controller/app/root.go
+++ b/cmd/topolvm-controller/app/root.go
@@ -108,9 +108,11 @@ func init() {
 			fmt.Sprintf("Minimum Allocation Sizing for volumes with the %s filesystem. Logical Volumes will always be at least this big.", filesystem))
 	}
 
-	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(goflags)
-	config.zapOpts.BindFlags(goflags)
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	fs.AddGoFlagSet(klogFlags)
 
-	fs.AddGoFlagSet(goflags)
+	zapFlags := flag.NewFlagSet("zap", flag.ExitOnError)
+	config.zapOpts.BindFlags(zapFlags)
+	fs.AddGoFlagSet(zapFlags)
 }

--- a/cmd/topolvm-node/app/root.go
+++ b/cmd/topolvm-node/app/root.go
@@ -67,9 +67,11 @@ func init() {
 	_ = viper.BindEnv("nodename", "NODE_NAME")
 	_ = viper.BindPFlag("nodename", fs.Lookup("nodename"))
 
-	goflags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(goflags)
-	config.zapOpts.BindFlags(goflags)
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	fs.AddGoFlagSet(klogFlags)
 
-	fs.AddGoFlagSet(goflags)
+	zapFlags := flag.NewFlagSet("zap", flag.ExitOnError)
+	config.zapOpts.BindFlags(zapFlags)
+	fs.AddGoFlagSet(zapFlags)
 }


### PR DESCRIPTION
The current implementation of lvmd fails to configure command-line options for klog and zap. This PR fixes this problem and allows users to use their options like `-zap-devel`.