### PR TITLE
docs: refresh TOC of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing Guide
 
-- [Contributing Guide](#contributing-guide)
-  - [Ways to Contribute](#ways-to-contribute)
-  - [Find an Issue](#find-an-issue)
-  - [Ask for Help](#ask-for-help)
-  - [Pull Request Lifecycle](#pull-request-lifecycle)
-  - [Development Environment Setup](#development-environment-setup)
-  - [Sign Your Commits](#sign-your-commits)
-    - [DCO](#dco)
-  - [Pull Request Checklist](#pull-request-checklist)
+<!-- Created by VSCode Markdown All in One command: Create Table of Contents -->
+- [Ways to Contribute](#ways-to-contribute)
+- [Find an Issue](#find-an-issue)
+- [Ask for Help](#ask-for-help)
+- [Pull Request Lifecycle](#pull-request-lifecycle)
+- [Development Environment Setup](#development-environment-setup)
+- [Sign Your Commits](#sign-your-commits)
+  - [DCO](#dco)
+- [Pull Request Checklist](#pull-request-checklist)
 
 Welcome! We are glad that you want to contribute to our project!
 


### PR DESCRIPTION
The current table of contents of CONTRIBUTING.md is hand-crafted, but other documents use VSCode Markdown All in One command to make their TOC ([example](https://github.com/topolvm/topolvm/blob/bf1fc85672a2525753496d3f9f387e05be99956a/docs/faq.md?plain=1#L3)). This commit fixes this issue.