### PR TITLE
Avoid unnecessary VG scan by adding Status.Path

### DIFF
--- a/api/legacy/v1/logicalvolume_types.go
+++ b/api/legacy/v1/logicalvolume_types.go
@@ -40,6 +40,7 @@ type LogicalVolumeStatus struct {
 	Code        codes.Code         `json:"code,omitempty"`
 	Message     string             `json:"message,omitempty"`
 	CurrentSize *resource.Quantity `json:"currentSize,omitempty"`
+	Path        string             `json:"path,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1/logicalvolume_types.go
+++ b/api/v1/logicalvolume_types.go
@@ -40,6 +40,7 @@ type LogicalVolumeStatus struct {
 	Code        codes.Code         `json:"code,omitempty"`
 	Message     string             `json:"message,omitempty"`
 	CurrentSize *resource.Quantity `json:"currentSize,omitempty"`
+	Path        string             `json:"path,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/charts/topolvm/templates/crds/topolvm.cybozu.com_logicalvolumes.yaml
+++ b/charts/topolvm/templates/crds/topolvm.cybozu.com_logicalvolumes.yaml
@@ -92,6 +92,8 @@ spec:
                 x-kubernetes-int-or-string: true
               message:
                 type: string
+              path:
+                type: string
               volumeID:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster

--- a/charts/topolvm/templates/crds/topolvm.io_logicalvolumes.yaml
+++ b/charts/topolvm/templates/crds/topolvm.io_logicalvolumes.yaml
@@ -92,6 +92,8 @@ spec:
                 x-kubernetes-int-or-string: true
               message:
                 type: string
+              path:
+                type: string
               volumeID:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster

--- a/config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml
+++ b/config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml
@@ -91,6 +91,8 @@ spec:
                 x-kubernetes-int-or-string: true
               message:
                 type: string
+              path:
+                type: string
               volumeID:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster

--- a/config/crd/bases/topolvm.io_logicalvolumes.yaml
+++ b/config/crd/bases/topolvm.io_logicalvolumes.yaml
@@ -91,6 +91,8 @@ spec:
                 x-kubernetes-int-or-string: true
               message:
                 type: string
+              path:
+                type: string
               volumeID:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster

--- a/internal/controller/logicalvolume_controller.go
+++ b/internal/controller/logicalvolume_controller.go
@@ -257,6 +257,7 @@ func (r *LogicalVolumeReconciler) createLV(ctx context.Context, log logr.Logger,
 
 		lv.Status.VolumeID = volume.Name
 		lv.Status.CurrentSize = resource.NewQuantity(volume.SizeBytes, resource.BinarySI)
+		lv.Status.Path = volume.Path
 		lv.Status.Code = codes.OK
 		lv.Status.Message = ""
 		return nil

--- a/internal/lvmd/lvservice.go
+++ b/internal/lvmd/lvservice.go
@@ -101,6 +101,7 @@ func (s *lvService) CreateLV(ctx context.Context, req *proto.CreateLVRequest) (*
 			// convert to int64 because lvmd internals and lvm use uint64 but CSI uses int64.
 			// For most conventional lvm use cases overflow here will never occur (9223372 TB or above cause overflow)
 			SizeBytes: int64(lv.Size()),
+			Path:      lv.Path(),
 			DevMajor:  lv.MajorNumber(),
 			DevMinor:  lv.MinorNumber(),
 		},


### PR DESCRIPTION
Avoid unnecessary VG scan by adding Status.Path

A problem has been noticed to appear with a high number of PVC/mounts. NodePublishVolume calls take a long time to complete because of a scan for the volume.

In node.go NodePublishVolume uses getLvFromContext, which does an unnecessary volume group scan. This can be avoided by simply reading the path from lvr.Status.Path. If it has not gotten a value, the old way is used. Doing this meant adding a new Status value "Path" which gets its value already when it is available in CreateLV. To keep code cohesion, also NodeExpandVolume was edited to match.

Feel free to suggest how this could be made more efficient.