### PR TITLE
Add a policy to update Ubuntu and Debian, and revert versions to conform to it

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   build-images:
     name: "build-images"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/e2e-k8s-incluster-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-incluster-lvmd.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   e2e-k8s-incluster-lvmd:
     name: "e2e-k8s-incluster-lvmd"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-k8s-workflow.yaml
+++ b/.github/workflows/e2e-k8s-workflow.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   e2e-k8s:
     name: "e2e-k8s"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-22.04"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: "build"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
@@ -30,7 +30,7 @@ jobs:
   container-structure-test:
     name: "container-structure-test"
     needs: build
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-22.04"
     strategy:
       fail-fast: true
       matrix:
@@ -48,7 +48,7 @@ jobs:
   example:
     if:  startsWith(github.head_ref, 'bump-chart-')
     name: "example"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-22.04"
     defaults:
       run:
         working-directory: "example"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
   release:
     name: "release"
     needs: [prepare, build-images]
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ And if there is no activity for another 7 days, it will be closed.
 
 ## Development Environment Setup
 
-Our recommended environment is Ubuntu 24.04. Because following steps modify your system globally,
+Our recommended environment is Ubuntu 22.04. Because following steps modify your system globally,
 we suggest preparing a dedicated physical or virtual machine.
 
 1. Download the repository.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build topolvm
-FROM --platform=$BUILDPLATFORM golang:1.24-bookworm AS build-topolvm
+FROM --platform=$BUILDPLATFORM golang:1.24-bullseye AS build-topolvm
 
 # Get argument
 ARG TOPOLVM_VERSION
@@ -12,7 +12,7 @@ RUN touch pkg/lvmd/proto/*.go
 RUN make build-topolvm TOPOLVM_VERSION=${TOPOLVM_VERSION} GOARCH=${TARGETARCH}
 
 # TopoLVM container
-FROM ubuntu:24.04 AS topolvm
+FROM ubuntu:22.04 AS topolvm
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build topolvm
-FROM --platform=$BUILDPLATFORM golang:1.24-bullseye AS build-topolvm
+FROM --platform=$BUILDPLATFORM golang:1.24-bookworm AS build-topolvm
 
 # Get argument
 ARG TOPOLVM_VERSION

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -90,7 +90,7 @@ When you use TopoLVM on old Linux kernel hosts with official docker image, you m
 - [mkfs.xfs incompatibility whith RHEL/Centos7.X #257](https://github.com/topolvm/topolvm/issues/257)
 - [xfs mount failed #283](https://github.com/topolvm/topolvm/issues/283)
 
-This is because the official docker image is based on Ubuntu 24.04 and [xfsprogs v5.13 or later](https://packages.ubuntu.com/search?keywords=xfsprogs). It is possible to use incompatible filesystem options on older Linux kernels. Also, we don't know which kernel version exactly causes the problem, because the official xfs Q&A does not provide compatible kernel versions.
+This is because the official docker image is based on Ubuntu 22.04 and [xfsprogs v5.13 or later](https://packages.ubuntu.com/search?keywords=xfsprogs). It is possible to use incompatible filesystem options on older Linux kernels. Also, we don't know which kernel version exactly causes the problem, because the official xfs Q&A does not provide compatible kernel versions.
 In the past, we used Ubuntu 18.04 as a base image and used older xfsprogs whenever possible, but Ubuntu 18.04 became the end of support and we have upgraded the base image version.
 
 ## Restoring Snapshots or creating Clones with differing StorageClass from their source can fail

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -139,6 +139,12 @@ Read [kubernetes go.mod](https://github.com/kubernetes/kubernetes/blob/master/go
 
 Visit [the upstream web page](https://kubernetes-csi.github.io/docs/drivers.html) to check current TopoLVM information. If some information is old, create PR to update the information
 
+#### Update Ubuntu and Debian
+
+If the support term for using Ubuntu is about to expire, update the versions. The Debian version in the `Dockerfile` should also be updated. The target version can be found in the updated Ubuntu image at `/etc/debian_version`.
+
+Note that we use the oldest supported Ubuntu LTS version for as long as possible to ensure compatibility between the host kernel and the mkfs tools in the image. See also `docs/limitations.md`.
+
 #### Final Check
 
 `git grep <dropped kubernetes version e.g. 1.18>`, `git grep image:`, `git grep -i VERSION` and looking `versions.mk` might help us avoid overlooking necessary changes.

--- a/docs/snapshot-and-restore.md
+++ b/docs/snapshot-and-restore.md
@@ -75,7 +75,7 @@ metadata:
 spec:
   containers:
   - name: pause
-    image: ubuntu:24.04
+    image: ubuntu:22.04
     command:
     - bash
     - -c
@@ -160,7 +160,7 @@ metadata:
 spec:
   containers:
   - name: pause
-    image: ubuntu:24.04
+    image: ubuntu:22.04
     command:
     - bash
     - -c

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/test/e2e/testdata/cloning/clone-pod-template.yaml
+++ b/test/e2e/testdata/cloning/clone-pod-template.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu
-      image: ubuntu:24.04
+      image: ubuntu:22.04
       command:
         - bash
         - -c

--- a/test/e2e/testdata/e2e/pod-volume-device-template.yaml
+++ b/test/e2e/testdata/e2e/pod-volume-device-template.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu
-      image: ubuntu:24.04
+      image: ubuntu:22.04
       command:
         - bash
         - -c

--- a/test/e2e/testdata/e2e/pod-volume-mount-template.yaml
+++ b/test/e2e/testdata/e2e/pod-volume-mount-template.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu
-      image: ubuntu:24.04
+      image: ubuntu:22.04
       command: ["/usr/bin/sleep", "infinity"]
       volumeMounts:
         - mountPath: /test1

--- a/test/e2e/testdata/empty_storageclass/manifest.yaml
+++ b/test/e2e/testdata/empty_storageclass/manifest.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu
-      image: ubuntu:24.04
+      image: ubuntu:22.04
       command:
         - bash
         - -c

--- a/test/e2e/testdata/snapshot_restore/restore-pod-template.yaml
+++ b/test/e2e/testdata/snapshot_restore/restore-pod-template.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu
-      image: ubuntu:24.04
+      image: ubuntu:22.04
       command:
         - bash
         - -c

--- a/test/e2e/testdata/thin_provisioning/pod-template.yaml
+++ b/test/e2e/testdata/thin_provisioning/pod-template.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: ubuntu
-      image: ubuntu:24.04
+      image: ubuntu:22.04
       command:
         - bash
         - -c


### PR DESCRIPTION
To ensure compatibility between the host kernel and the mkfs in containers, use an old Ubuntu LTS.