### PR TITLE
Too late call of SetLVMCommandPrefix

### DIFF
--- a/cmd/lvmd/app/root.go
+++ b/cmd/lvmd/app/root.go
@@ -73,6 +73,13 @@ func subMain(parentCtx context.Context) error {
 		return err
 	}
 
+	if config.LVMCommandPrefix != nil {
+		if lvmPath != "" {
+			return fmt.Errorf("cannot set both --lvm-path and lvm-command-prefix")
+		}
+		command.SetLVMCommandPrefix(config.LVMCommandPrefix)
+	}
+
 	vgs, err := command.ListVolumeGroups(parentCtx)
 	if err != nil {
 		logger.Error(err, "error while retrieving volume groups")
@@ -93,13 +100,6 @@ func subMain(parentCtx context.Context) error {
 				return err
 			}
 		}
-	}
-
-	if config.LVMCommandPrefix != nil {
-		if lvmPath != "" {
-			return fmt.Errorf("cannot set both --lvm-path and lvm-command-prefix")
-		}
-		command.SetLVMCommandPrefix(config.LVMCommandPrefix)
 	}
 
 	// UNIX domain socket file should be removed before listening.


### PR DESCRIPTION
Custom lvm-command-prefix must be set via SetLVMCommandPrefix before the lvmd.NewEmbeddedServiceClients is called, as it can already use LVM CLI.

Fixes #1106 

NOTE: I haven't tested the change.