### PR TITLE
Making overprovisioning parameter optional

### DIFF
--- a/internal/lvmd/command/lvm.go
+++ b/internal/lvmd/command/lvm.go
@@ -302,12 +302,7 @@ func (t ThinPoolUsage) FreeBytes(overprovisionRatio *float64) (uint64, error) {
 		}
 		return virtualPoolSize - t.VirtualBytes, nil
 	} else {
-		// but this check is useless as we don't care about free bytes...
-		free := uint64((1.0 - t.DataPercent/100.0) * float64(t.SizeBytes))
-		fmt.Printf("DataPercent: %v SizeBytes: %v\n, free: %v\n", t.DataPercent, t.SizeBytes, free)
-		//TODO inspect exactly the DataPercent format and adjust this
-		return free, nil
-		//return uint64(t.DataPercent * t.SizeBytes), nil
+		return uint64(((100.0 - t.DataPercent) / 100.0) * float64(t.SizeBytes)), nil
 	}
 }
 

--- a/internal/lvmd/command/lvm.go
+++ b/internal/lvmd/command/lvm.go
@@ -302,8 +302,11 @@ func (t ThinPoolUsage) FreeBytes(overprovisionRatio *float64) (uint64, error) {
 		}
 		return virtualPoolSize - t.VirtualBytes, nil
 	} else {
+		// but this check is useless as we don't care about free bytes...
+		free := uint64((1.0 - t.DataPercent/100.0) * float64(t.SizeBytes))
+		fmt.Printf("DataPercent: %v SizeBytes: %v\n, free: %v\n", t.DataPercent, t.SizeBytes, free)
 		//TODO inspect exactly the DataPercent format and adjust this
-		return uint64((1.0 - t.DataPercent/100.0) * float64(t.SizeBytes)), nil
+		return free, nil
 		//return uint64(t.DataPercent * t.SizeBytes), nil
 	}
 }
@@ -436,6 +439,14 @@ func (t *ThinPool) Usage(ctx context.Context) (*ThinPoolUsage, error) {
 		tpu.VirtualBytes += l.size
 	}
 	return tpu, nil
+}
+
+func AllowCreate(requestedBytes uint64, freeBytes uint64, useOverprovisioning bool) bool {
+	if useOverprovisioning {
+		return requestedBytes <= freeBytes
+	} else {
+		return freeBytes > 0
+	}
 }
 
 // LogicalVolume represents a logical volume.

--- a/internal/lvmd/command/lvm.go
+++ b/internal/lvmd/command/lvm.go
@@ -288,8 +288,9 @@ type ThinPoolUsage struct {
 	SizeBytes       uint64
 }
 
-// FreeBytes if using overprovisioning return overprovisioning-based calculations
-// otherwise return pool's current data% usage
+// FreeBytes Depending on overprovisioning returns either
+// overprovisioning-based calculations or
+// pool's current data% usage
 func (t ThinPoolUsage) FreeBytes(overprovisionRatio *float64) (uint64, error) {
 	if overprovisionRatio != nil {
 		opr := *overprovisionRatio
@@ -436,8 +437,8 @@ func (t *ThinPool) Usage(ctx context.Context) (*ThinPoolUsage, error) {
 	return tpu, nil
 }
 
-func AllowCreate(requestedBytes uint64, freeBytes uint64, useOverprovisioning bool) bool {
-	if useOverprovisioning {
+func CheckCapacity(requestedBytes uint64, freeBytes uint64, usesOverprovisioning bool) bool {
+	if usesOverprovisioning {
 		return requestedBytes <= freeBytes
 	} else {
 		return freeBytes > 0

--- a/internal/lvmd/device_class_manager.go
+++ b/internal/lvmd/device_class_manager.go
@@ -79,7 +79,7 @@ func ValidateDeviceClasses(deviceClasses []*lvmdTypes.DeviceClass) error {
 				return fmt.Errorf("thinpool name should not be empty: %s", dc.Name)
 			}
 
-			if dc.ThinPoolConfig.OverprovisionRatio != nil && *dc.ThinPoolConfig.OverprovisionRatio < 1.0 {
+			if !dc.ThinPoolConfig.SkipOverprovisioningRatio && dc.ThinPoolConfig.OverprovisionRatio < 1.0 {
 				return fmt.Errorf("given overprovision ratio is provided for thin pool %s in device class %s, then it should be 1.0 or more", dc.ThinPoolConfig.Name, dc.Name)
 			}
 			// combination of volumegroup and thinpool should be unique across device classes

--- a/internal/lvmd/device_class_manager.go
+++ b/internal/lvmd/device_class_manager.go
@@ -79,8 +79,8 @@ func ValidateDeviceClasses(deviceClasses []*lvmdTypes.DeviceClass) error {
 				return fmt.Errorf("thinpool name should not be empty: %s", dc.Name)
 			}
 
-			if dc.ThinPoolConfig.OverprovisionRatio < 1.0 {
-				return fmt.Errorf("overprovision ratio for thin pool %s in device class %s should be 1.0 or more", dc.ThinPoolConfig.Name, dc.Name)
+			if dc.ThinPoolConfig.OverprovisionRatio != nil && *dc.ThinPoolConfig.OverprovisionRatio < 1.0 {
+				return fmt.Errorf("given overprovision ratio is provided for thin pool %s in device class %s, then it should be 1.0 or more", dc.ThinPoolConfig.Name, dc.Name)
 			}
 			// combination of volumegroup and thinpool should be unique across device classes
 			// so the key 'name' shouldn't appear twice to verify it's uniqueness

--- a/internal/lvmd/device_class_manager_test.go
+++ b/internal/lvmd/device_class_manager_test.go
@@ -88,7 +88,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: opRatio,
+						OverprovisionRatio: &opRatio,
 					},
 				},
 				{
@@ -99,7 +99,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool1",
-						OverprovisionRatio: opRatio,
+						OverprovisionRatio: &opRatio,
 					},
 				},
 				{
@@ -111,7 +111,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: opRatio,
+						OverprovisionRatio: &opRatio,
 					},
 				},
 			},
@@ -127,7 +127,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: opRatio,
+						OverprovisionRatio: &opRatio,
 					},
 				},
 				{
@@ -145,7 +145,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool1",
-						OverprovisionRatio: opRatio,
+						OverprovisionRatio: &opRatio,
 					},
 				},
 				{
@@ -260,7 +260,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Name:        "dev1",
 					VolumeGroup: "vg0",
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
-						OverprovisionRatio: opRatio,
+						OverprovisionRatio: &opRatio,
 					},
 				},
 			},
@@ -290,7 +290,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Default:     true,
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
-						OverprovisionRatio: opRatio,
+						OverprovisionRatio: &opRatio,
 					},
 				},
 			},
@@ -318,7 +318,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: wrongOpRatio,
+						OverprovisionRatio: &wrongOpRatio,
 					},
 				},
 			},
@@ -334,7 +334,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.DeviceType("dummy"),
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: wrongOpRatio,
+						OverprovisionRatio: &wrongOpRatio,
 					},
 				},
 			},
@@ -356,7 +356,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: opRatio,
+						OverprovisionRatio: &opRatio,
 					},
 				},
 				{
@@ -366,7 +366,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: opRatio,
+						OverprovisionRatio: &opRatio,
 					},
 				},
 			},
@@ -418,7 +418,7 @@ func TestDeviceClassManager(t *testing.T) {
 			Type:        lvmdTypes.TypeThin,
 			ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 				Name:               "pool0",
-				OverprovisionRatio: opRatio,
+				OverprovisionRatio: &opRatio,
 			},
 		},
 	}

--- a/internal/lvmd/device_class_manager_test.go
+++ b/internal/lvmd/device_class_manager_test.go
@@ -268,7 +268,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 		},
 		{
 			deviceClasses: []*lvmdTypes.DeviceClass{
-				// incomplete thinpool info, no OverprovisionRatio
+				// thinpool info without OverprovisionRatio
 				{
 					Name:        "dev0",
 					VolumeGroup: "vg0",
@@ -279,7 +279,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					},
 				},
 			},
-			valid: false,
+			valid: true,
 		},
 		{
 			deviceClasses: []*lvmdTypes.DeviceClass{

--- a/internal/lvmd/device_class_manager_test.go
+++ b/internal/lvmd/device_class_manager_test.go
@@ -88,7 +88,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: &opRatio,
+						OverprovisionRatio: opRatio,
 					},
 				},
 				{
@@ -99,7 +99,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool1",
-						OverprovisionRatio: &opRatio,
+						OverprovisionRatio: opRatio,
 					},
 				},
 				{
@@ -111,7 +111,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: &opRatio,
+						OverprovisionRatio: opRatio,
 					},
 				},
 			},
@@ -127,7 +127,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: &opRatio,
+						OverprovisionRatio: opRatio,
 					},
 				},
 				{
@@ -145,7 +145,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool1",
-						OverprovisionRatio: &opRatio,
+						OverprovisionRatio: opRatio,
 					},
 				},
 				{
@@ -260,7 +260,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Name:        "dev1",
 					VolumeGroup: "vg0",
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
-						OverprovisionRatio: &opRatio,
+						OverprovisionRatio: opRatio,
 					},
 				},
 			},
@@ -290,7 +290,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Default:     true,
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
-						OverprovisionRatio: &opRatio,
+						OverprovisionRatio: opRatio,
 					},
 				},
 			},
@@ -318,7 +318,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: &wrongOpRatio,
+						OverprovisionRatio: wrongOpRatio,
 					},
 				},
 			},
@@ -334,7 +334,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.DeviceType("dummy"),
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: &wrongOpRatio,
+						OverprovisionRatio: wrongOpRatio,
 					},
 				},
 			},
@@ -356,7 +356,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: &opRatio,
+						OverprovisionRatio: opRatio,
 					},
 				},
 				{
@@ -366,7 +366,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               "pool0",
-						OverprovisionRatio: &opRatio,
+						OverprovisionRatio: opRatio,
 					},
 				},
 			},
@@ -418,7 +418,7 @@ func TestDeviceClassManager(t *testing.T) {
 			Type:        lvmdTypes.TypeThin,
 			ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 				Name:               "pool0",
-				OverprovisionRatio: &opRatio,
+				OverprovisionRatio: opRatio,
 			},
 		},
 	}

--- a/internal/lvmd/embed_test.go
+++ b/internal/lvmd/embed_test.go
@@ -28,7 +28,7 @@ func TestNewEmbeddedServiceClients(t *testing.T) {
 				Type:        lvmdTypes.TypeThin,
 				ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 					Name:               "test_pool",
-					OverprovisionRatio: overprovisionRatio,
+					OverprovisionRatio: &overprovisionRatio,
 				},
 			}},
 		},

--- a/internal/lvmd/embed_test.go
+++ b/internal/lvmd/embed_test.go
@@ -28,7 +28,7 @@ func TestNewEmbeddedServiceClients(t *testing.T) {
 				Type:        lvmdTypes.TypeThin,
 				ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 					Name:               "test_pool",
-					OverprovisionRatio: &overprovisionRatio,
+					OverprovisionRatio: overprovisionRatio,
 				},
 			}},
 		},

--- a/internal/lvmd/lvservice.go
+++ b/internal/lvmd/lvservice.go
@@ -53,7 +53,7 @@ func (s *lvService) CreateLV(ctx context.Context, req *proto.CreateLVRequest) (*
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get free bytes: %v", err)
 	}
-	if !pool.AllowCreate(requested, free) {
+	if !CheckCapacity(pool, requested, free) {
 		logger.Error(err, "not enough space left on VG", "free", free, "requested", requested)
 		return nil, status.Errorf(codes.ResourceExhausted, "not enough space left on VG: free=%d, requested=%d", free, requested)
 	}
@@ -202,7 +202,7 @@ func (s *lvService) CreateLVSnapshot(ctx context.Context, req *proto.CreateLVSna
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get free bytes: %v", err)
 	}
-	if !command.AllowCreate(desiredSize, free, dc.ThinPoolConfig.OverprovisionRatio != nil) {
+	if !command.CheckCapacity(desiredSize, free, dc.ThinPoolConfig.OverprovisionRatio != nil) {
 		logger.Error(err, "not enough space left on VG", "free", free, "desiredSize", desiredSize)
 		return nil, status.Errorf(codes.ResourceExhausted, "not enough space left on VG: free=%d, desiredSize=%d", free, desiredSize)
 	}
@@ -307,7 +307,7 @@ func (s *lvService) ResizeLV(ctx context.Context, req *proto.ResizeLVRequest) (*
 		"free", free,
 	)
 
-	if !pool.AllowCreate(requested-current, free) {
+	if !CheckCapacity(pool, requested-current, free) {
 		logger.Error(err, "not enough space left on VG",
 			"requested", requested,
 			"current", current,

--- a/internal/lvmd/lvservice.go
+++ b/internal/lvmd/lvservice.go
@@ -53,7 +53,6 @@ func (s *lvService) CreateLV(ctx context.Context, req *proto.CreateLVRequest) (*
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get free bytes: %v", err)
 	}
-
 	if !pool.AllowCreate(requested, free) {
 		logger.Error(err, "not enough space left on VG", "free", free, "requested", requested)
 		return nil, status.Errorf(codes.ResourceExhausted, "not enough space left on VG: free=%d, requested=%d", free, requested)
@@ -203,7 +202,6 @@ func (s *lvService) CreateLVSnapshot(ctx context.Context, req *proto.CreateLVSna
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get free bytes: %v", err)
 	}
-
 	if !command.AllowCreate(desiredSize, free, dc.ThinPoolConfig.OverprovisionRatio != nil) {
 		logger.Error(err, "not enough space left on VG", "free", free, "desiredSize", desiredSize)
 		return nil, status.Errorf(codes.ResourceExhausted, "not enough space left on VG: free=%d, desiredSize=%d", free, desiredSize)

--- a/internal/lvmd/lvservice_test.go
+++ b/internal/lvmd/lvservice_test.go
@@ -409,7 +409,7 @@ func TestLVService_ThinLV_WithoutOverprovisioning(t *testing.T) {
 		t.Errorf(`does not match size 2: %d`, lv.Size()>>30)
 	}
 
-	//should just be created as actually used data is below the pool size
+	//should just be created as actually used data (0%) is below the pool size
 	_, err = lvService.CreateLV(context.Background(), &proto.CreateLVRequest{
 		Name:        "testp3",
 		DeviceClass: deviceClassInTest,

--- a/internal/lvmd/lvservice_test.go
+++ b/internal/lvmd/lvservice_test.go
@@ -84,8 +84,9 @@ func setupLVService(ctx context.Context, t *testing.T) (
 					VolumeGroup: vg.Name(),
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
-						Name:               poolName,
-						OverprovisionRatio: &overprovisionRatio,
+						Name:                      poolName,
+						SkipOverprovisioningRatio: false,
+						OverprovisionRatio:        overprovisionRatio,
 					},
 				},
 				{
@@ -94,7 +95,8 @@ func setupLVService(ctx context.Context, t *testing.T) (
 					VolumeGroup: vg.Name(),
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
-						Name: poolName,
+						Name:                      poolName,
+						SkipOverprovisioningRatio: true,
 					},
 				},
 			},

--- a/internal/lvmd/lvservice_test.go
+++ b/internal/lvmd/lvservice_test.go
@@ -84,7 +84,7 @@ func setupLVService(ctx context.Context, t *testing.T) (
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               poolName,
-						OverprovisionRatio: overprovisionRatio,
+						OverprovisionRatio: &overprovisionRatio,
 					},
 				},
 			},

--- a/internal/lvmd/lvservice_test.go
+++ b/internal/lvmd/lvservice_test.go
@@ -18,12 +18,13 @@ import (
 )
 
 const (
-	lvServiceTestVGName   = "test_lvservice"
-	lvServiceTestPoolName = "test_lvservice_pool"
-	lvServiceTestThickDC  = lvServiceTestVGName
-	lvServiceTestThinDC   = lvServiceTestPoolName
-	lvServiceTestTag1     = "testtag1"
-	lvServiceTestTag2     = "testtag2"
+	lvServiceTestVGName     = "test_lvservice"
+	lvServiceTestPoolName   = "test_lvservice_pool"
+	lvServiceTestThickDC    = lvServiceTestVGName
+	lvServiceTestThinDC     = lvServiceTestPoolName
+	lvServiceTestThinDCNoOp = "test_lvservice_pool_noop"
+	lvServiceTestTag1       = "testtag1"
+	lvServiceTestTag2       = "testtag2"
 )
 
 func setupLVService(ctx context.Context, t *testing.T) (
@@ -78,13 +79,22 @@ func setupLVService(ctx context.Context, t *testing.T) (
 					VolumeGroup: vg.Name(),
 				},
 				{
-					// thinpool target
+					// thinpool target with overprovisioning
 					Name:        lvServiceTestThinDC,
 					VolumeGroup: vg.Name(),
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               poolName,
 						OverprovisionRatio: &overprovisionRatio,
+					},
+				},
+				{
+					// thinpool target without overprovisioning
+					Name:        lvServiceTestThinDCNoOp,
+					VolumeGroup: vg.Name(),
+					Type:        lvmdTypes.TypeThin,
+					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
+						Name: poolName,
 					},
 				},
 			},
@@ -208,7 +218,7 @@ func TestLVService_ThickLV(t *testing.T) {
 	}
 }
 
-func TestLVService_ThinLV(t *testing.T) {
+func TestLVService_ThinLV_Overprovisioning(t *testing.T) {
 	ctx := ctrl.LoggerInto(context.Background(), testr.New(t))
 	lvService, count, vg, pool := setupLVService(ctx, t)
 
@@ -287,9 +297,134 @@ func TestLVService_ThinLV(t *testing.T) {
 		t.Errorf(`does not match size 2: %d`, lv.Size()>>30)
 	}
 
+	//should exceed the overprovisioned limit
+	_, err = lvService.CreateLV(context.Background(), &proto.CreateLVRequest{
+		Name:        "testp3",
+		DeviceClass: lvServiceTestThinDC,
+		SizeBytes:   10 << 30, // 10 GiB
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *count != 4 {
+		t.Errorf("unexpected count: %d", count)
+	}
+
 	_, err = lvService.RemoveLV(context.Background(), &proto.RemoveLVRequest{
 		Name:        "testp1",
 		DeviceClass: lvServiceTestThinDC,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if *count != 5 {
+		t.Errorf("unexpected count: %d", count)
+	}
+
+	if err := vg.Update(ctx); err != nil {
+		t.Fatal(err)
+	}
+	_, err = pool.FindVolume(ctx, "test1")
+	if !errors.Is(err, command.ErrNotFound) {
+		t.Error("unexpected error: ", err)
+	}
+}
+
+func TestLVService_ThinLV_WithoutOverprovisioning(t *testing.T) {
+	ctx := ctrl.LoggerInto(context.Background(), testr.New(t))
+	deviceClassInTest := lvServiceTestThinDCNoOp
+	lvService, count, vg, pool := setupLVService(ctx, t)
+
+	res, err := lvService.CreateLV(context.Background(), &proto.CreateLVRequest{
+		Name:        "testp1",
+		DeviceClass: deviceClassInTest,
+		SizeBytes:   1 << 30, // 1 GiB
+		Tags:        []string{lvServiceTestTag1, lvServiceTestTag2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *count != 1 {
+		t.Errorf("is not notified: %d", count)
+	}
+	if res.GetVolume().GetName() != "testp1" {
+		t.Errorf(`res.Volume.Name != "testp1": %s`, res.GetVolume().GetName())
+	}
+	if res.GetVolume().GetSizeBytes() != 1<<30 {
+		t.Errorf(`res.Volume.SizeBytes != %d: %d`, 1<<30, res.GetVolume().GetSizeBytes())
+	}
+	err = exec.Command("lvs", vg.Name()+"/testp1").Run()
+	if err != nil {
+		t.Error("failed to create logical volume")
+	}
+
+	if err := vg.Update(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	lv, err := pool.FindVolume(ctx, "testp1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lv.Tags()[0] != lvServiceTestTag1 {
+		t.Errorf(`testtag1 not present on volume`)
+	}
+	if lv.Tags()[1] != lvServiceTestTag2 {
+		t.Errorf(`testtag1 not present on volume`)
+	}
+
+	_, err = lvService.CreateLV(context.Background(), &proto.CreateLVRequest{
+		Name:        "testp2",
+		DeviceClass: deviceClassInTest,
+		SizeBytes:   3 << 30, // 3 GiB
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *count != 2 {
+		t.Errorf("unexpected count: %d", count)
+	}
+
+	_, err = lvService.ResizeLV(context.Background(), &proto.ResizeLVRequest{
+		Name:        "testp1",
+		DeviceClass: deviceClassInTest,
+		SizeBytes:   2 << 30, // 2 GiB
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *count != 3 {
+		t.Errorf("unexpected count: %d", count)
+	}
+
+	if err := vg.Update(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	lv, err = pool.FindVolume(ctx, "testp1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lv.Size() != (2 << 30) {
+		t.Errorf(`does not match size 2: %d`, lv.Size()>>30)
+	}
+
+	//should just be created
+	_, err = lvService.CreateLV(context.Background(), &proto.CreateLVRequest{
+		Name:        "testp3",
+		DeviceClass: deviceClassInTest,
+		SizeBytes:   10 << 30, // 10 GiB
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *count != 4 {
+		t.Errorf("unexpected count: %d", count)
+	}
+
+	_, err = lvService.RemoveLV(context.Background(), &proto.RemoveLVRequest{
+		Name:        "testp1",
+		DeviceClass: deviceClassInTest,
 	})
 	if err != nil {
 		t.Error(err)
@@ -305,7 +440,6 @@ func TestLVService_ThinLV(t *testing.T) {
 	if !errors.Is(err, command.ErrNotFound) {
 		t.Error("unexpected error: ", err)
 	}
-
 }
 
 func TestLVService_ThinSnapshots(t *testing.T) {

--- a/internal/lvmd/pool.go
+++ b/internal/lvmd/pool.go
@@ -36,7 +36,7 @@ func storagePoolForDeviceClass(ctx context.Context, dc *lvmdTypes.DeviceClass) (
 
 type thinPoolAdapter struct {
 	*command.ThinPool
-	overprovisionRatio float64
+	overprovisionRatio *float64
 }
 
 func (p *thinPoolAdapter) Free(ctx context.Context) (uint64, error) {

--- a/internal/lvmd/pool.go
+++ b/internal/lvmd/pool.go
@@ -10,7 +10,6 @@ import (
 
 type storagePool interface {
 	Free(ctx context.Context) (uint64, error)
-	AllowCreate(requestedBytes uint64, freeBytes uint64) bool
 	ListVolumes(ctx context.Context) (map[string]*command.LogicalVolume, error)
 	FindVolume(ctx context.Context, name string) (*command.LogicalVolume, error)
 	CreateVolume(ctx context.Context, name string, size uint64, tags []string, stripe uint, stripeSize string, lvcreateOptions []string) error
@@ -49,16 +48,17 @@ func (p *thinPoolAdapter) Free(ctx context.Context) (uint64, error) {
 	return usage.FreeBytes(p.overprovisionRatio)
 }
 
-func (p *thinPoolAdapter) AllowCreate(requestedBytes uint64, freeBytes uint64) bool {
-	return command.AllowCreate(requestedBytes, freeBytes, p.overprovisionRatio != nil)
+func CheckCapacity(pool storagePool, requestedBytes uint64, freeBytes uint64) bool {
+	switch p := pool.(type) {
+	case *thinPoolAdapter:
+		return command.CheckCapacity(requestedBytes, freeBytes, p.overprovisionRatio != nil)
+	default:
+		return requestedBytes <= freeBytes
+	}
 }
 
 type volumeGroupAdapter struct {
 	*command.VolumeGroup
-}
-
-func (vg *volumeGroupAdapter) AllowCreate(requestedBytes uint64, freeBytes uint64) bool {
-	return requestedBytes <= freeBytes
 }
 
 func (vg *volumeGroupAdapter) Free(_ context.Context) (uint64, error) {

--- a/internal/lvmd/vgservice.go
+++ b/internal/lvmd/vgservice.go
@@ -137,7 +137,7 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 			tpi.MetadataPercent = tpu.MetadataPercent
 
 			// used for annotating the node for capacity aware scheduling
-			opb, err := tpu.FreeBytes(dc.ThinPoolConfig.OverprovisionRatio)
+			opb, err := tpu.FreeBytes(dc.ThinPoolConfig.OverprovisionRatio) // adjust
 			if err != nil {
 				return status.Errorf(codes.Internal, "failed to get pool usage: %v", err)
 			}

--- a/internal/lvmd/vgservice.go
+++ b/internal/lvmd/vgservice.go
@@ -137,7 +137,7 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 			tpi.MetadataPercent = tpu.MetadataPercent
 
 			// used for annotating the node for capacity aware scheduling
-			opb, err := tpu.FreeBytes(dc.ThinPoolConfig.OverprovisionRatio) // adjust
+			opb, err := tpu.FreeBytes(dc.ThinPoolConfig.OverprovisionRatio)
 			if err != nil {
 				return status.Errorf(codes.Internal, "failed to get pool usage: %v", err)
 			}

--- a/internal/lvmd/vgservice_test.go
+++ b/internal/lvmd/vgservice_test.go
@@ -18,11 +18,14 @@ import (
 )
 
 const (
+	vgServiceTestVGName   = "test_vgservice"
+	vgServiceTestPoolName = "test_vgservice_pool"
+	vgServiceTestThickDC  = vgServiceTestVGName
+	vgServiceTestThinDC   = vgServiceTestPoolName
+)
+
+var (
 	vgServiceTestOverprovisionRatio = float64(10.0)
-	vgServiceTestVGName             = "test_vgservice"
-	vgServiceTestPoolName           = "test_vgservice_pool"
-	vgServiceTestThickDC            = vgServiceTestVGName
-	vgServiceTestThinDC             = vgServiceTestPoolName
 )
 
 type mockWatchServer struct {
@@ -317,7 +320,7 @@ func setupVGService(ctx context.Context, t *testing.T) (
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               vgServiceTestPoolName,
-						OverprovisionRatio: vgServiceTestOverprovisionRatio,
+						OverprovisionRatio: &vgServiceTestOverprovisionRatio,
 					},
 				},
 			},

--- a/internal/lvmd/vgservice_test.go
+++ b/internal/lvmd/vgservice_test.go
@@ -338,7 +338,7 @@ func setupVGService(ctx context.Context, t *testing.T) (
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
 						Name:               vgServiceTestPoolName,
-						OverprovisionRatio: &vgServiceTestOverprovisionRatio,
+						OverprovisionRatio: vgServiceTestOverprovisionRatio,
 					},
 				},
 				{
@@ -348,7 +348,8 @@ func setupVGService(ctx context.Context, t *testing.T) (
 					SpareGB:     &spareGB,
 					Type:        lvmdTypes.TypeThin,
 					ThinPoolConfig: &lvmdTypes.ThinPoolConfig{
-						Name: vgServiceTestPoolName,
+						Name:                      vgServiceTestPoolName,
+						SkipOverprovisioningRatio: true,
 					},
 				},
 			},

--- a/pkg/lvmd/types/types.go
+++ b/pkg/lvmd/types/types.go
@@ -11,8 +11,10 @@ const (
 type ThinPoolConfig struct {
 	// Name of thinpool
 	Name string `json:"name"`
+	// SkipOverprovisioningRatio indicates whether overprovision ratio is used for space calculation
+	SkipOverprovisioningRatio bool `json:"skip-overprovisioning-ratio"`
 	// OverprovisionRatio signifies the upper bound multiplier for allowing logical volume creation in this pool
-	OverprovisionRatio *float64 `json:"overprovision-ratio"`
+	OverprovisionRatio float64 `json:"overprovision-ratio"`
 }
 
 // DeviceClass maps between device-classes and target for logical volume creation

--- a/pkg/lvmd/types/types.go
+++ b/pkg/lvmd/types/types.go
@@ -12,7 +12,7 @@ type ThinPoolConfig struct {
 	// Name of thinpool
 	Name string `json:"name"`
 	// OverprovisionRatio signifies the upper bound multiplier for allowing logical volume creation in this pool
-	OverprovisionRatio float64 `json:"overprovision-ratio"`
+	OverprovisionRatio *float64 `json:"overprovision-ratio"`
 }
 
 // DeviceClass maps between device-classes and target for logical volume creation


### PR DESCRIPTION
[Context](https://github.com/topolvm/topolvm/issues/1101)

Decided to start with simple change: 
- make the overprovisioning parameter optional
- adjust the free space calculation to take into account lack of overprovisioning
- added test-case, aligned existing ones

Please let me know if this is the acceptable direction, I'll update the docs then