### PR TITLE
inject fake jmicron signature to reproduce mount failure

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -127,6 +128,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ShouldNot(HaveOccurred())
 })
 
+var _ = AfterEach(func() {
+	if CurrentSpecReport().Failed() {
+		dumpGlobalDebug()
+	}
+})
+
 var _ = Describe("TopoLVM", func() {
 	Context("scheduling", testScheduling)
 	Context("metrics", testMetrics)
@@ -143,3 +150,16 @@ var _ = Describe("TopoLVM", func() {
 	Context("empty storageclass", testEmptyStorageClass)
 	Context("CSI sanity", testSanity)
 })
+
+func dumpGlobalDebug() {
+	cmds := [][]string{
+		{"get", "pods", "-A", "-o", "wide"},
+		{"describe", "pods", "-A"},
+		{"get", "events", "-A", "--sort-by=.lastTimestamp"},
+		{"logs", "-n", "topolvm-system", "-l", "app.kubernetes.io/name=topolvm-node", "--tail=200"},
+	}
+	for _, args := range cmds {
+		out, err := kubectl(args...)
+		_, _ = fmt.Fprintf(GinkgoWriter, "# kubectl %s\n%s\nerr=%v\n", strings.Join(args, " "), out, err)
+	}
+}


### PR DESCRIPTION
This commit injects a fake jmicron signature into the last sector of an “unformatted” device to reproduce the mount failure described in https: //github.com/topolvm/topolvm/issues/1126. Once the failure is confirmed and the subsequent fix is added and validated, this instrumentation will be commented out/removed.