### PR TITLE
Remove k8s.io/mount-utils from update supporting kubernetes check list

### DIFF
--- a/.github/ISSUE_TEMPLATE/update_supporting_kubernetes.md
+++ b/.github/ISSUE_TEMPLATE/update_supporting_kubernetes.md
@@ -19,9 +19,6 @@ There is a check list to confirm depending libraries or tools are released. The 
 
 Must update Kubernetes with each new version of Kubernetes.
 
-- [ ] k8s.io/mount-utils
-  - https://github.com/kubernetes/mount-utils/tags
-    - The supported Kubernetes version is written in the description of each tag.
 - [ ] sigs.k8s.io/controller-runtime
   - https://github.com/kubernetes-sigs/controller-runtime/releases
 - [ ] sigs.k8s.io/controller-tools


### PR DESCRIPTION
The package is automatically published when the corresponding kubernetes is released[1]. So, it is unnecessary to check it explicitly.

[1]: https://github.com/kubernetes/mount-utils/blob/master/README.md