### PR TITLE
Fix volume expansion timeout for LVM extent-aligned sizes

### DIFF
--- a/internal/driver/internal/k8s/logicalvolume_service.go
+++ b/internal/driver/internal/k8s/logicalvolume_service.go
@@ -295,8 +295,8 @@ func (s *LogicalVolumeService) ExpandVolume(ctx context.Context, volumeID string
 			return false, nil
 		}
 
-		if changedLV.Status.CurrentSize.Cmp(*request) != 0 {
-			logger.Info("waiting for update of 'status.currentSize' to be updated to signal successful expansion",
+		if changedLV.Status.CurrentSize.Cmp(*request) < 0 {
+			logger.Info("waiting for update of 'status.currentSize' to be at least the requested size",
 				"name", lv.Name,
 				"status.currentSize", changedLV.Status.CurrentSize,
 				"spec.size", changedLV.Spec.Size,


### PR DESCRIPTION
Volume expansion was timing out when the requested size didn't align to LVM extent boundaries (typically 4MB). The expansion succeeded at the LVM level, but the CSI driver waited indefinitely because it expected an exact size match.

LVM rounds up volume sizes to extent boundaries. For example, a request for 203Mi becomes 204Mi (51 extents × 4MB). The previous comparison
 would never return true when LVM rounded up.

Changed the comparison from  (exact match) to  (at least as large as requested) to correctly handle LVM extent rounding.

Fixes topolvm#1144