### PR TITLE
Fix duplicate port name warning

### DIFF
--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -142,11 +142,11 @@ spec:
             - --http-endpoint=:9809
           ports:
             - containerPort: 9809
-              name: healthz
+              name: reg-healthz
           livenessProbe:
             httpGet:
               path: /healthz
-              port: healthz
+              port: reg-healthz
             {{- with .Values.livenessProbe.csi_registrar.failureThreshold }}
             failureThreshold: {{ . }}
             {{- end }}


### PR DESCRIPTION
topolvm-node uses a same name for two ports, the second usage was introduced by 6e4b2100 (improve livenessProbe get
csi-node-driver-registrar healthz by httpGet), it seems not to be intentional. This duplication causes the warning: "Warning: spec.template.spec.containers[1].ports[0]: duplicate port name \"healthz\" with spec.template.spec.containers[0].ports[0], services and probes that select ports by name will use
spec.template.spec.containers[0].ports[0]", and should be fixed.