### PR TITLE
Replace manual disk cleanup with quick-cleanup

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -30,16 +30,9 @@ jobs:
           - "with-sidecar"
     steps:
       - name: Disk cleanup
-        run: |
-          # These code are copied from the following code:
-          # https://github.com/shiguredo-webrtc-build/webrtc-build/blob/5a821e430b496bbff74cf45bab058ab4ac340c2c/.github/workflows/build.yml#L138-L147
-          #    LICENSE: http://www.apache.org/licenses/LICENSE-2.0
-          #    Copyright 2019-2025, Shiguredo Inc.
-          df -h
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          df -h
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
       - uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Summary

Replace manual disk cleanup scripts with the shared [`palmsoftware/quick-cleanup`](https://github.com/palmsoftware/quick-cleanup) GitHub Action.

This consolidates the manual cleanup (rm -rf swift, dotnet, android) into a single maintained action. It also provides automatic Docker storage relocation to the larger `/mnt` partition — a feature none of the manual scripts currently implement.

## Already in use

`quick-cleanup` is already adopted in production workflows across multiple projects:

- [`crc-org/crc`](https://github.com/crc-org/crc/blob/main/.github/workflows/make-rpm.yml#L19) — OpenShift Local (CRC)
- [`palmsoftware/quick-ocp`](https://github.com/palmsoftware/quick-ocp/blob/main/action.yml#L94) — OpenShift cluster deployment action
- [`palmsoftware/quick-k8s`](https://github.com/palmsoftware/quick-k8s/blob/main/action.yml#L509) — Kubernetes cluster deployment action (KinD/Minikube)

## Tracking

- [palmsoftware/quick-cleanup#3](https://github.com/palmsoftware/quick-cleanup/issues/3) — Tracking issue



## Related PRs

- https://github.com/crc-org/crc/pull/5145
- https://github.com/openshift-kni/openperouter/pull/159
- https://github.com/metallb/metallb-operator/pull/537
- https://github.com/prometheus-operator/prometheus-operator/pull/8389
- https://github.com/topolvm/topolvm/pull/1151
- https://github.com/vmware-tanzu/velero/pull/9550

## Changes

- Updated `.github/workflows/build-images.yaml` — replaced "Disk cleanup" step (10 lines of shell commands)

## Benefits

- **Less boilerplate** — replaces 10 lines of shell commands
- **Docker relocation** — automatically moves Docker storage to `/mnt` (larger partition)
- **Adaptive cleanup** — adjusts intensity based on available space
- **Disk reporting** — built-in before/after `df -h` output
- **Maintained upstream** — cleanup targets updated as runner images change
- **Apache 2.0 licensed**