### PR TITLE
Expose extraArgs for the csi-provisioner in the Helm chart

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -17,6 +17,11 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v16.
 | controller.additionalContainers | list | `[]` | Define extra containers to add to the Deployment. Please ensure not to use any existing container names. |
 | controller.affinity | string | `"podAntiAffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n    - labelSelector:\n        matchExpressions:\n          - key: app.kubernetes.io/component\n            operator: In\n            values:\n              - controller\n          - key: app.kubernetes.io/name\n            operator: In\n            values:\n              - {{ include \"topolvm.name\" . }}\n      topologyKey: kubernetes.io/hostname\n"` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | controller.args | list | `[]` | Arguments to be passed to the command. |
+| controller.csiProvisioner.kubeAPIBurst | int | `0` | Specify `--kube-api-burst` for csi-provisioner. Set to 0 to use csi-provisioner defaults. |
+| controller.csiProvisioner.kubeAPICapacityBurst | int | `0` | Specify `--kube-api-capacity-burst` for csi-provisioner. Set to 0 to use csi-provisioner defaults. |
+| controller.csiProvisioner.kubeAPICapacityQPS | float | `0` | Specify `--kube-api-capacity-qps` for csi-provisioner. Set to 0 to use csi-provisioner defaults. |
+| controller.csiProvisioner.kubeAPIQPS | int | `0` | Specify `--kube-api-qps` for csi-provisioner. Set to 0 to use csi-provisioner defaults. |
+| controller.csiProvisioner.workerThreads | int | `0` | Specify `--worker-threads` for csi-provisioner. Set to 0 to use csi-provisioner defaults. |
 | controller.initContainers | list | `[]` | Additional initContainers for the controller service. |
 | controller.labels | object | `{}` | Additional labels to be added to the Deployment. |
 | controller.leaderElection.enabled | bool | `true` | Enable leader election for controller and all sidecars. |

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -17,6 +17,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v16.
 | controller.additionalContainers | list | `[]` | Define extra containers to add to the Deployment. Please ensure not to use any existing container names. |
 | controller.affinity | string | `"podAntiAffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n    - labelSelector:\n        matchExpressions:\n          - key: app.kubernetes.io/component\n            operator: In\n            values:\n              - controller\n          - key: app.kubernetes.io/name\n            operator: In\n            values:\n              - {{ include \"topolvm.name\" . }}\n      topologyKey: kubernetes.io/hostname\n"` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | controller.args | list | `[]` | Arguments to be passed to the command. |
+| controller.csiProvisioner.args | list | `[]` | Arguments to be passed to the csi-provisioner. |
 | controller.initContainers | list | `[]` | Additional initContainers for the controller service. |
 | controller.labels | object | `{}` | Additional labels to be added to the Deployment. |
 | controller.leaderElection.enabled | bool | `true` | Enable leader election for controller and all sidecars. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -166,6 +166,10 @@ spec:
             - --enable-capacity
             - --capacity-ownerref-level=2
             {{- end }}
+          {{- $csiProvisionerArgs := default (list) .Values.controller.csiProvisioner.args }}
+          {{- if gt (len $csiProvisionerArgs) 0 }}
+          args: {{ toYaml $csiProvisionerArgs | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 9809
               name: csi-provisioner

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -157,6 +157,21 @@ spec:
             - /csi-provisioner
             - --csi-address=/run/topolvm/csi-topolvm.sock
             - --feature-gates=Topology=true
+            {{- if gt (int .Values.controller.csiProvisioner.workerThreads) 0 }}
+            - --worker-threads={{ .Values.controller.csiProvisioner.workerThreads }}
+            {{- end }}
+            {{- if gt (int .Values.controller.csiProvisioner.kubeAPIBurst) 0 }}
+            - --kube-api-burst={{ .Values.controller.csiProvisioner.kubeAPIBurst }}
+            {{- end }}
+            {{- if gt (int .Values.controller.csiProvisioner.kubeAPICapacityBurst) 0 }}
+            - --kube-api-capacity-burst={{ .Values.controller.csiProvisioner.kubeAPICapacityBurst }}
+            {{- end }}
+            {{- if gt (float64 .Values.controller.csiProvisioner.kubeAPICapacityQPS) 0.0 }}
+            - --kube-api-capacity-qps={{ .Values.controller.csiProvisioner.kubeAPICapacityQPS }}
+            {{- end }}
+            {{- if gt (int .Values.controller.csiProvisioner.kubeAPIQPS) 0 }}
+            - --kube-api-qps={{ .Values.controller.csiProvisioner.kubeAPIQPS }}
+            {{- end }}
             {{- if .Values.controller.leaderElection.enabled }}
             - --leader-election
             - --leader-election-namespace={{ .Release.Namespace }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -432,6 +432,22 @@ controller:
   # controller.args -- Arguments to be passed to the command.
   args: []
 
+  csiProvisioner:
+    # controller.csiProvisioner.workerThreads -- Specify `--worker-threads` for csi-provisioner. Set to 0 to use csi-provisioner defaults.
+    workerThreads: 0
+
+    # controller.csiProvisioner.kubeAPIBurst -- Specify `--kube-api-burst` for csi-provisioner. Set to 0 to use csi-provisioner defaults.
+    kubeAPIBurst: 0
+
+    # controller.csiProvisioner.kubeAPICapacityBurst -- Specify `--kube-api-capacity-burst` for csi-provisioner. Set to 0 to use csi-provisioner defaults.
+    kubeAPICapacityBurst: 0
+
+    # controller.csiProvisioner.kubeAPICapacityQPS -- Specify `--kube-api-capacity-qps` for csi-provisioner. Set to 0 to use csi-provisioner defaults.
+    kubeAPICapacityQPS: 0.0
+
+    # controller.csiProvisioner.kubeAPIQPS -- Specify `--kube-api-qps` for csi-provisioner. Set to 0 to use csi-provisioner defaults.
+    kubeAPIQPS: 0
+
   storageCapacityTracking:
     # controller.storageCapacityTracking.enabled -- Enable Storage Capacity Tracking for csi-provisioner.
     enabled: true

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -432,6 +432,10 @@ controller:
   # controller.args -- Arguments to be passed to the command.
   args: []
 
+  csiProvisioner:
+    # controller.csiProvisioner.args -- Arguments to be passed to the csi-provisioner.
+    args: []
+
   storageCapacityTracking:
     # controller.storageCapacityTracking.enabled -- Enable Storage Capacity Tracking for csi-provisioner.
     enabled: true


### PR DESCRIPTION
Expose extraArgs for the csi-provisioner in the Helm chart

To be able to pass custome cli args that are not exposed via the values or set in the chart currently.