### PR TITLE
Add option to specify extraArgs for the csi-resizer in the Helm chart

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -17,6 +17,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v16.
 | controller.additionalContainers | list | `[]` | Define extra containers to add to the Deployment. Please ensure not to use any existing container names. |
 | controller.affinity | string | `"podAntiAffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n    - labelSelector:\n        matchExpressions:\n          - key: app.kubernetes.io/component\n            operator: In\n            values:\n              - controller\n          - key: app.kubernetes.io/name\n            operator: In\n            values:\n              - {{ include \"topolvm.name\" . }}\n      topologyKey: kubernetes.io/hostname\n"` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | controller.args | list | `[]` | Arguments to be passed to the command. |
+| controller.csiResizer.handleVolumeInUseError | bool | `true` | Specify `--handle-volume-inuse-error` for csi-resizer. |
 | controller.initContainers | list | `[]` | Additional initContainers for the controller service. |
 | controller.labels | object | `{}` | Additional labels to be added to the Deployment. |
 | controller.leaderElection.enabled | bool | `true` | Enable leader election for controller and all sidecars. |

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -17,6 +17,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v16.
 | controller.additionalContainers | list | `[]` | Define extra containers to add to the Deployment. Please ensure not to use any existing container names. |
 | controller.affinity | string | `"podAntiAffinity:\n  requiredDuringSchedulingIgnoredDuringExecution:\n    - labelSelector:\n        matchExpressions:\n          - key: app.kubernetes.io/component\n            operator: In\n            values:\n              - controller\n          - key: app.kubernetes.io/name\n            operator: In\n            values:\n              - {{ include \"topolvm.name\" . }}\n      topologyKey: kubernetes.io/hostname\n"` | Specify affinity. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity |
 | controller.args | list | `[]` | Arguments to be passed to the command. |
+| controller.csiResizer.args | list | `[]` | Arguments to be passed to the csi-resizer. |
 | controller.initContainers | list | `[]` | Additional initContainers for the controller service. |
 | controller.labels | object | `{}` | Additional labels to be added to the Deployment. |
 | controller.leaderElection.enabled | bool | `true` | Enable leader election for controller and all sidecars. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -212,6 +212,10 @@ spec:
             - --leader-election-namespace={{ .Release.Namespace }}
             {{- end }}
             - --http-endpoint=:9810
+          {{- $csiResizerArgs := default (list) .Values.controller.csiResizer.args }}
+          {{- if gt (len $csiResizerArgs) 0 }}
+          args: {{ toYaml $csiResizerArgs | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 9810
               name: csi-resizer

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -207,6 +207,7 @@ spec:
           command:
             - /csi-resizer
             - --csi-address=/run/topolvm/csi-topolvm.sock
+            - --handle-volume-inuse-error={{ .Values.controller.csiResizer.handleVolumeInUseError }}
             {{- if .Values.controller.leaderElection.enabled }}
             - --leader-election
             - --leader-election-namespace={{ .Release.Namespace }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -432,6 +432,10 @@ controller:
   # controller.args -- Arguments to be passed to the command.
   args: []
 
+  csiResizer:
+    # controller.csiResizer.args -- Arguments to be passed to the csi-resizer.
+    args: []
+
   storageCapacityTracking:
     # controller.storageCapacityTracking.enabled -- Enable Storage Capacity Tracking for csi-provisioner.
     enabled: true

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -432,6 +432,10 @@ controller:
   # controller.args -- Arguments to be passed to the command.
   args: []
 
+  csiResizer:
+    # controller.csiResizer.handleVolumeInUseError -- Specify `--handle-volume-inuse-error` for csi-resizer.
+    handleVolumeInUseError: true
+
   storageCapacityTracking:
     # controller.storageCapacityTracking.enabled -- Enable Storage Capacity Tracking for csi-provisioner.
     enabled: true


### PR DESCRIPTION
Add option to specify extraArgs for the csi-resizer in the Helm chart

to be able to customize args that are not set or exposed by the Helm chart