### PR TITLE
lvmd/command: drain stdout before returning from parseFullReportResult

### DIFF
--- a/internal/lvmd/command/lvm_command.go
+++ b/internal/lvmd/command/lvm_command.go
@@ -113,15 +113,9 @@ type commandReadCloser struct {
 
 // Close drains any unread stdout, reads stderr, and waits for the command to exit.
 func (p commandReadCloser) Close() error {
-	// Drain stdout before Wait() to prevent blocking when the caller
-	// stopped reading early and the child has more output than the
-	// pipe buffer (#1161).
-	if _, err := io.Copy(io.Discard, p.ReadCloser); err != nil {
-		// Caller may have already closed the reader; only that case is expected.
-		if !errors.Is(err, os.ErrClosed) {
-			return err
-		}
-	}
+	// Drain stdout before Wait() to prevent blocking when the caller stopped
+	// reading early and the child has more output than the pipe buffer.
+	_, _ = io.Copy(io.Discard, p.ReadCloser)
 
 	// Read the stderr output after the read has finished since we are sure by then the command must have run.
 	stderr, err := io.ReadAll(p.stderr)

--- a/internal/lvmd/command/lvm_command.go
+++ b/internal/lvmd/command/lvm_command.go
@@ -111,9 +111,18 @@ type commandReadCloser struct {
 	stderr io.ReadCloser
 }
 
-// Close closes stdout and stderr and waits for the command to exit. Close
-// should not be called before all reads from stdout have completed.
+// Close drains any unread stdout, reads stderr, and waits for the command to exit.
 func (p commandReadCloser) Close() error {
+	// Drain stdout before Wait() to prevent blocking when the caller
+	// stopped reading early and the child has more output than the
+	// pipe buffer (#1161).
+	if _, err := io.Copy(io.Discard, p.ReadCloser); err != nil {
+		// Caller may have already closed the reader; only that case is expected.
+		if !errors.Is(err, os.ErrClosed) {
+			return err
+		}
+	}
+
 	// Read the stderr output after the read has finished since we are sure by then the command must have run.
 	stderr, err := io.ReadAll(p.stderr)
 	if err != nil {

--- a/internal/lvmd/command/lvm_command_test.go
+++ b/internal/lvmd/command/lvm_command_test.go
@@ -157,9 +157,10 @@ func TestCallLVM(t *testing.T) {
 
 func TestCommandReadCloserClose(t *testing.T) {
 	t.Run("Close returns even when the caller stops reading early", func(t *testing.T) {
-		// Produce ~256 KiB of output, safely larger than the pipe buffer
-		// so cmd.Wait would deadlock on an undrained stdout (#1161).
-		ctx := log.IntoContext(context.Background(), testr.New(t))
+		// Regression for #1161.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		ctx = log.IntoContext(ctx, testr.New(t))
 		cmd := exec.CommandContext(ctx, "dd", "if=/dev/zero", "bs=1024", "count=256", "status=none")
 
 		rc, err := runCommand(ctx, verbosityLVMStateNoUpdate, cmd)
@@ -167,23 +168,13 @@ func TestCommandReadCloserClose(t *testing.T) {
 			t.Fatalf("runCommand: %v", err)
 		}
 
-		// Read only a handful of bytes, simulating a parser that bails
-		// out on the first value it decodes.
 		buf := make([]byte, 4)
 		if _, err := io.ReadFull(rc, buf); err != nil {
 			t.Fatalf("read prefix: %v", err)
 		}
 
-		done := make(chan error, 1)
-		go func() { done <- rc.Close() }()
-		select {
-		case err := <-done:
-			if err != nil {
-				t.Fatalf("close returned error: %v", err)
-			}
-		case <-time.After(5 * time.Second):
-			_ = cmd.Process.Kill()
-			t.Fatal("commandReadCloser.Close deadlocked with unread stdout")
+		if err := rc.Close(); err != nil {
+			t.Fatalf("close returned error: %v", err)
 		}
 	})
 }

--- a/internal/lvmd/command/lvm_command_test.go
+++ b/internal/lvmd/command/lvm_command_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/funcr"
 	"github.com/go-logr/logr/testr"
@@ -149,6 +151,39 @@ func TestCallLVM(t *testing.T) {
 		}
 		if !stdoutExistsInLogs {
 			t.Fatalf("version from stdout was not logged, existing logs: %v", messages)
+		}
+	})
+}
+
+func TestCommandReadCloserClose(t *testing.T) {
+	t.Run("Close returns even when the caller stops reading early", func(t *testing.T) {
+		// Produce ~256 KiB of output, safely larger than the pipe buffer
+		// so cmd.Wait would deadlock on an undrained stdout (#1161).
+		ctx := log.IntoContext(context.Background(), testr.New(t))
+		cmd := exec.CommandContext(ctx, "dd", "if=/dev/zero", "bs=1024", "count=256", "status=none")
+
+		rc, err := runCommand(ctx, verbosityLVMStateNoUpdate, cmd)
+		if err != nil {
+			t.Fatalf("runCommand: %v", err)
+		}
+
+		// Read only a handful of bytes, simulating a parser that bails
+		// out on the first value it decodes.
+		buf := make([]byte, 4)
+		if _, err := io.ReadFull(rc, buf); err != nil {
+			t.Fatalf("read prefix: %v", err)
+		}
+
+		done := make(chan error, 1)
+		go func() { done <- rc.Close() }()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("close returned error: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			_ = cmd.Process.Kill()
+			t.Fatal("commandReadCloser.Close deadlocked with unread stdout")
 		}
 	})
 }


### PR DESCRIPTION
Fixes #1161.

`getLVMState` streams the `lvm fullreport` output through an `os/exec.StdoutPipe`-backed `ReadCloser` and defers `streamed.Close()`, which internally calls `cmd.Wait()`. The Go documentation explicitly forbids calling `Wait` before all reads from the pipe complete, because an unread tail keeps the child process blocked on a full pipe buffer.

`parseFullReportResult` does not honour that contract. `json.Decoder` reads only up to the end of the top-level value and always leaves at least the trailing newline in the pipe; on the error path it typically leaves a much larger unread tail. For fullreports above ~64 KB (multi-VG or many-LV clusters) this deadlocks lvmd — the child cannot flush stdout, `cmd.Wait()` never returns, and the operator's lvmd loop hangs indefinitely.

This captures the decode error, drains the rest of the stream with `io.Copy(io.Discard, data)`, then returns. Decode errors still propagate; the drain just guarantees the pipe is fully consumed so the subsequent `Close` → `Wait` path completes cleanly.