### PR TITLE
lvmd/command: use exec.CommandContext so cancelled RPCs kill their LVM child

### DIFF
--- a/internal/lvmd/command/lvm_command.go
+++ b/internal/lvmd/command/lvm_command.go
@@ -73,7 +73,11 @@ func callLVMInto(ctx context.Context, into any, logVerbosity int, args ...string
 func callLVMStreamed(ctx context.Context, logVerbosity int, args ...string) (io.ReadCloser, error) {
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithCallDepth(1))
 	wholeCommand := slices.Concat(lvmCommandPrefix, args)
-	cmd := exec.Command(wholeCommand[0], wholeCommand[1:]...)
+	// Use CommandContext so kubelet timing out on an RPC (default 2 min
+	// csiTimeout) cancels the underlying vgs/lvs/... subprocess instead
+	// of leaving it running on the node. exec.Command ignores ctx and
+	// accumulates orphans under repeated timeout scenarios (#1163).
+	cmd := exec.CommandContext(ctx, wholeCommand[0], wholeCommand[1:]...)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "LC_ALL=C")
 	return runCommand(ctx, logVerbosity, cmd)


### PR DESCRIPTION
Fixes #1163.

`callLVMStreamed` threads `ctx` through its signature but hands it to `exec.Command`, which ignores context cancellation. When kubelet's `csiTimeout` (default 2 minutes) expires mid-RPC, the gRPC handler returns with `context canceled` but the underlying `vgs` / `lvs` / etc. process keeps running on the node. Every subsequent timeout adds another orphan, and under high LVM activity the accumulation is visible as unreaped processes consuming resources.

This switches to `exec.CommandContext(ctx, ...)` so a cancelled context triggers the usual Kill-on-cancel path. No behaviour change on the happy path; only the RPC-timeout path now cleans up the child.