### PR TITLE
chart: align node lvmd-socket-dir hostPath type with lvmd daemonset

### DIFF
--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -243,7 +243,7 @@ spec:
         - name: lvmd-socket-dir
           hostPath:
             path: {{ dir .Values.node.lvmdSocket }}
-            type: Directory
+            type: DirectoryOrCreate
         {{- end }}
         {{- end }}
         {{- with .Values.node.additionalVolumes }}


### PR DESCRIPTION
  ## Summary

  Changes the `topolvm-node` DaemonSet's `lvmd-socket-dir` hostPath volume from `type: Directory` to `type: DirectoryOrCreate`, matching the equivalent volume in the `topolvm-lvmd` DaemonSet.

  I'm not sure whether there is a reason why the ordering of who creates the directory matters?

  ## Why

  The two DaemonSets currently declare the same host path (default `/run/topolvm`) with mismatched `hostPath.type`:

  | DaemonSet | Template | Type |
  |---|---|---|
  | `topolvm-lvmd-0` | `charts/topolvm/templates/lvmd/daemonset.yaml` | `DirectoryOrCreate` |
  | `topolvm-node`   | `charts/topolvm/templates/node/daemonset.yaml` | `Directory` (strict) |

  On a fresh node where `/run/topolvm` doesn't yet exist, both DaemonSets schedule simultaneously. If kubelet starts the `topolvm-node` pod first (or in parallel before lvmd has run), it fails with:

  MountVolume.SetUp failed for volume "lvmd-socket-dir": hostPath type check failed: /run/topolvm is not a directory

  The pod CrashLoopBackOffs until the lvmd pod's `DirectoryOrCreate` mount creates the path. The race self-heals in 60-90s but produces several `topolvm-node` restarts and a downstream `csi-registrar` liveness probe failure (its healthz depends on the CSI socket that
  `topolvm-node` exposes).

  ## Reproduction

  Reproduced on three freshly-provisioned EKS nodes in the same cluster, same chart, same image:

  | Node OS | First-boot `topolvm-node` restarts |
  |---|---|
  | Bottlerocket OS 1.60.0 (k8s 1.35) | 4 |
  | Amazon Linux 2023 (current chart, 222 MB image) | 3 |
  | Amazon Linux 2023 (older chart, 177 MB image) | 1 (observed historically) |

  The race fires on every fresh node; the number of restart cycles scales with how long the lvmd pod takes to start (image pull duration + initContainer time). Bottlerocket isn't a special case — it's just where the slack between lvmd's start and node's start is largest,
  because there's no host-side pre-bootstrap to warm caches.

  ## Fix

  ```diff
           - name: lvmd-socket-dir
             hostPath:
               path: {{ dir .Values.node.lvmdSocket }}
  -            type: Directory
  +            type: DirectoryOrCreate

  Whichever DaemonSet wins the schedule race now creates the directory and the other mounts cleanly. No behavior change once /run/topolvm exists, which is the steady state.