### PR TITLE
Update the release procedure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,9 +45,11 @@ Bump version
     VERSION=1.2.3
     ```
 
-2. Go to [the rule setting page](https://github.com/topolvm/topolvm/settings/rules/2151135) and change the value of "Enforcement status" to `Active`.
+2. Go to the rule [prevent changes to the main branch][] and change the value of "Enforcement status" to `Active`.
 
-3. Add a new tag and push it.
+3. Go to the rule [block tag creation][] and change the value of "Enforcement status" to `Disabled`.
+
+4. Add a new tag and push it.
 
     ```console
     git switch main
@@ -56,7 +58,7 @@ Bump version
     git push origin v$VERSION
     ```
 
-4. Once a new tag is pushed, [GitHub Actions][] automatically
+5. Once a new tag is pushed, [GitHub Actions][] automatically
    creates a draft release note for the tagged version,
    builds a tar archive for the new release,
    and attaches it to the release note.
@@ -64,7 +66,7 @@ Bump version
    Visit https://github.com/topolvm/topolvm/releases to check
    the result. 
 
-5. Edit the auto-generated release note
+6. Edit the auto-generated release note
    and remove PRs which contain changes only to the helm chart.
    Then, publish it.
 
@@ -74,7 +76,7 @@ Bump Chart Version
 TopoLVM Helm Chart will be released independently.
 This will prevent the TopoLVM version from going up just by modifying the Helm Chart.
 
-1. If necessary, go to [the rule setting page](https://github.com/topolvm/topolvm/settings/rules/2151135) and change the value of "Enforcement status" to `Active`.
+1. If necessary, go to the rule [prevent changes to the main branch][] and change the value of "Enforcement status" to `Active`.
    - If you are here after releasing the app, you should already have this setting changed.
 
 2. Determine a new version number by [checking the differences](https://github.com/topolvm/topolvm/compare/topolvm-chart-vX.Y.Z...main) since the last release. Then, manually run the workflow to create a PR to update the Helm Chart.
@@ -82,9 +84,11 @@ This will prevent the TopoLVM version from going up just by modifying the Helm C
    https://github.com/topolvm/topolvm/actions/workflows/create-chart-update-pr.yaml
 
 3. Review and merge the auto-created PR.
-   - Before merging, go to [the rule setting page](https://github.com/topolvm/topolvm/settings/rules/2151135) and change the value of "Enforcement status" to `Disabled`.
+   - Before merging, go to the rule [prevent changes to the main branch][] and change the value of "Enforcement status" to `Disabled`.
 
 4. Manually run the GitHub Actions workflow for the release.
+
+   Before running the workflow, go to the rule [block tag creation][] and change the value of "Enforcement status" to `Disabled`.
 
    https://github.com/topolvm/topolvm/actions/workflows/helm-release.yaml
 
@@ -95,6 +99,9 @@ This will prevent the TopoLVM version from going up just by modifying the Helm C
    2. Clear the textbox, and click "Generate release notes" button.
    3. Remove PRs which do not contain changes to the helm chart.
 
+6. Go to the rule [block tag creation][] and change the value of "Enforcement status" to `Active`.
+
 [semver]: https://semver.org/spec/v2.0.0.html
-[example]: https://github.com/cybozu-go/etcdpasswd/commit/77d95384ac6c97e7f48281eaf23cb94f68867f79
 [GitHub Actions]: https://github.com/topolvm/topolvm/actions
+[prevent changes to the main branch]: https://github.com/topolvm/topolvm/settings/rules/2151135
+[block tag creation]: https://github.com/topolvm/topolvm/settings/rules/17382112


### PR DESCRIPTION
Since we've updated the tag protection rule to harden it, updated the release procedure to reflect this.