### PR TITLE
Pin unpinned-action references across 10 workflows

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -40,11 +40,11 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
           df -h
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login registry
         if: ${{ inputs.push == 'true' }}
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/create-chart-update-pr.yaml
+++ b/.github/workflows/create-chart-update-pr.yaml
@@ -22,7 +22,7 @@ jobs:
           # The exit code will be 1 if the pattern is not found by grep.
           echo ${{ inputs.app-version }} | grep -E "^[0-9]+.[0-9]+.[0-9]+$"
           echo ${{ inputs.chart-version }} | grep -E "^[0-9]+.[0-9]+.[0-9]+$"
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
       - name: Configure Git
@@ -44,7 +44,7 @@ jobs:
           sed -r -i "s/ghcr.io\/topolvm\/topolvm:[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/ghcr.io\/topolvm\/topolvm:${{ inputs.app-version }}/g" charts/topolvm/Chart.yaml
           make install-helm-docs && make generate-helm-docs
       - name: Issue an access token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         id: app-token
         with:
           app-id: ${{ secrets.PROJECT_APP_ID }}

--- a/.github/workflows/e2e-k8s-incluster-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-incluster-lvmd.yaml
@@ -28,14 +28,14 @@ jobs:
       TEST_LVMD_TYPE: ${{ matrix.test_lvmd_type }}
       TEST_SCHEDULER_EXTENDER_TYPE: "none"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: cache e2e sidecar binaries
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             test/e2e/tmpbin

--- a/.github/workflows/e2e-k8s-workflow.yaml
+++ b/.github/workflows/e2e-k8s-workflow.yaml
@@ -22,11 +22,11 @@ jobs:
       TEST_SCHEDULER_EXTENDER_TYPE: ${{ inputs.test_scheduler_extender_type }}
       TEST_LEGACY: ${{ inputs.test_legacy }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
-      - uses: actions/cache/restore@v5.0.5
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             bin

--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -18,14 +18,14 @@ jobs:
   build:
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: cache e2e sidecar binaries
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             test/e2e/tmpbin
@@ -34,7 +34,7 @@ jobs:
             e2e-sidecars-
       - run: make -C test/e2e setup
       - run: make -C test/e2e topolvm.img
-      - uses: actions/cache/save@v5.0.5
+      - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             bin

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
       # This version is written in `charts/topolvm/README.md`,
       # so do not update it if not necessary.
       - name: "Install Helm"
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: "v3.5.0"
 
@@ -34,7 +34,7 @@ jobs:
           helm repo add cert-manager https://charts.jetstack.io
 
       - name: "Run chart-releaser"
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f
         with:
           config: .cr.yaml
         env:

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: "Setup Go"
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
 
@@ -32,7 +32,7 @@ jobs:
         run: ./bin/helm-docs && git diff --no-patch --exit-code
 
       - name: "Set up chart-testing"
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
 
       - name: "Run chart-testing (lint)"
         run: ct lint --config ct.yaml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,12 +13,12 @@ jobs:
     name: "build"
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - run: make setup
       - run: make check-uncommitted
       - run: make build-topolvm GOARCH=s390x
@@ -42,9 +42,9 @@ jobs:
           - "normal"
           - "with-sidecar"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - run: make install-container-structure-test
       - run: make image-${{ matrix.image }}
       - run: make container-structure-test STRUCTURE_TEST_TARGET=${{ matrix.image }}
@@ -57,11 +57,11 @@ jobs:
       run:
         working-directory: "example"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - run: make setup
       - run: make run

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,12 +49,12 @@ jobs:
     needs: [prepare, build-images]
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - run: make build/lvmd TOPOLVM_VERSION=${{ needs.prepare.outputs.version }}
       - run: tar czf lvmd-${{ needs.prepare.outputs.version }}.tar.gz -C ./build lvmd
       - name: "Push branch tag"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v10.2.0
+    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 30


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/build-images.yaml`

- 🟠 MED `docker/setup-qemu-action` (job `build-images`)
- 🟠 MED `docker/setup-buildx-action` (job `build-images`)
- ⚪ LOW `actions/checkout` (job `build-images`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -40,11 +40,11 @@
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
           df -h
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Login registry
         if: ${{ inputs.push == 'true' }}
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
```

</details>

### `.github/workflows/create-chart-update-pr.yaml`

- ⚪ LOW `actions/checkout` (job `create-chart-update-pr`)
- ⚪ LOW `actions/create-github-app-token` (job `create-chart-update-pr`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/create-chart-update-pr.yaml
+++ b/.github/workflows/create-chart-update-pr.yaml
@@ -22,7 +22,7 @@
           # The exit code will be 1 if the pattern is not found by grep.
           echo ${{ inputs.app-version }} | grep -E "^[0-9]+.[0-9]+.[0-9]+$"
           echo ${{ inputs.chart-version }} | grep -E "^[0-9]+.[0-9]+.[0-9]+$"
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
       - name: Configure Git
@@ -44,7 +44,7 @@
           sed -r -i "s/ghcr.io\/topolvm\/topolvm:[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/ghcr.io\/topolvm\/topolvm:${{ inputs.app-version }}/g" charts/topolvm/Chart.yaml
           make install-helm-docs && make generate-helm-docs
       - name: Issue an access token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         id: app-token
         with:
           app-id: ${{ secrets.PROJECT_APP_ID }}
```

</details>

### `.github/workflows/e2e-k8s-incluster-lvmd.yaml`

- 🟠 MED `docker/setup-buildx-action` (job `e2e-k8s-incluster-lvmd`)
- ⚪ LOW `actions/checkout` (job `e2e-k8s-incluster-lvmd`)
- ⚪ LOW `actions/setup-go` (job `e2e-k8s-incluster-lvmd`)
- ⚪ LOW `actions/cache` (job `e2e-k8s-incluster-lvmd`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/e2e-k8s-incluster-lvmd.yaml
+++ b/.github/workflows/e2e-k8s-incluster-lvmd.yaml
@@ -28,14 +28,14 @@
       TEST_LVMD_TYPE: ${{ matrix.test_lvmd_type }}
       TEST_SCHEDULER_EXTENDER_TYPE: "none"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: cache e2e sidecar binaries
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             test/e2e/tmpbin
```

</details>

### `.github/workflows/e2e-k8s-workflow.yaml`

- ⚪ LOW `actions/checkout` (job `e2e-k8s`)
- ⚪ LOW `actions/setup-go` (job `e2e-k8s`)
- ⚪ LOW `actions/cache/restore` (job `e2e-k8s`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/e2e-k8s-workflow.yaml
+++ b/.github/workflows/e2e-k8s-workflow.yaml
@@ -22,11 +22,11 @@
       TEST_SCHEDULER_EXTENDER_TYPE: ${{ inputs.test_scheduler_extender_type }}
       TEST_LEGACY: ${{ inputs.test_legacy }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
-      - uses: actions/cache/restore@v5.0.5
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             bin
```

</details>

### `.github/workflows/e2e-k8s.yaml`

- 🟠 MED `docker/setup-buildx-action` (job `build`)
- ⚪ LOW `actions/checkout` (job `build`)
- ⚪ LOW `actions/setup-go` (job `build`)
- ⚪ LOW `actions/cache` (job `build`)
- ⚪ LOW `actions/cache/save` (job `build`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/e2e-k8s.yaml
+++ b/.github/workflows/e2e-k8s.yaml
@@ -18,14 +18,14 @@
   build:
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: cache e2e sidecar binaries
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             test/e2e/tmpbin
@@ -34,7 +34,7 @@
             e2e-sidecars-
       - run: make -C test/e2e setup
       - run: make -C test/e2e topolvm.img
-      - uses: actions/cache/save@v5.0.5
+      - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             bin
```

</details>

### `.github/workflows/helm-release.yaml`

- 🟠 MED `azure/setup-helm` (job `release`)
- 🟠 MED `helm/chart-releaser-action` (job `release`)
- ⚪ LOW `actions/checkout` (job `release`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -10,7 +10,7 @@
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@
       # This version is written in `charts/topolvm/README.md`,
       # so do not update it if not necessary.
       - name: "Install Helm"
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: "v3.5.0"
 
@@ -34,7 +34,7 @@
           helm repo add cert-manager https://charts.jetstack.io
 
       - name: "Run chart-releaser"
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f
         with:
           config: .cr.yaml
         env:
```

</details>

### `.github/workflows/helm.yaml`

- 🟠 MED `helm/chart-testing-action` (job `lint`)
- ⚪ LOW `actions/checkout` (job `lint`)
- ⚪ LOW `actions/setup-go` (job `lint`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -15,12 +15,12 @@
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: "Setup Go"
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
 
@@ -32,7 +32,7 @@
         run: ./bin/helm-docs && git diff --no-patch --exit-code
 
       - name: "Set up chart-testing"
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
 
       - name: "Run chart-testing (lint)"
         run: ct lint --config ct.yaml
```

</details>

### `.github/workflows/main.yaml`

- 🟠 MED `docker/setup-buildx-action` (job `build`)
- 🟠 MED `docker/setup-buildx-action` (job `container-structure-test`)
- 🟠 MED `docker/setup-buildx-action` (job `example`)
- ⚪ LOW `actions/checkout` (job `build`)
- ⚪ LOW `actions/setup-go` (job `build`)
- ⚪ LOW `actions/checkout` (job `container-structure-test`)
- ⚪ LOW `actions/checkout` (job `example`)
- ⚪ LOW `actions/setup-go` (job `example`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,12 +13,12 @@
     name: "build"
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - run: make setup
       - run: make check-uncommitted
       - run: make build-topolvm GOARCH=s390x
@@ -42,9 +42,9 @@
           - "normal"
           - "with-sidecar"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - run: make install-container-structure-test
       - run: make image-${{ matrix.image }}
       - run: make container-structure-test STRUCTURE_TEST_TARGET=${{ matrix.image }}
@@ -57,11 +57,11 @@
       run:
         working-directory: "example"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
... (5 more diff lines — see Files changed)
```

</details>

### `.github/workflows/release.yaml`

- 🟠 MED `docker/setup-buildx-action` (job `release`)
- ⚪ LOW `actions/checkout` (job `release`)
- ⚪ LOW `actions/setup-go` (job `release`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,12 +49,12 @@
     needs: [prepare, build-images]
     runs-on: "ubuntu-22.04"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - run: make build/lvmd TOPOLVM_VERSION=${{ needs.prepare.outputs.version }}
       - run: tar czf lvmd-${{ needs.prepare.outputs.version }}.tar.gz -C ./build lvmd
       - name: "Push branch tag"
```

</details>

### `.github/workflows/stale.yaml`

- ⚪ LOW `actions/stale` (job `stale`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,7 +18,7 @@
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v10.2.0
+    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 30
```

</details>

---

This commit is signed off per the repository's DCO (Developer Certificate of Origin) policy.

---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
