### PR TITLE
Fix permissions-missing in helm-release.yaml

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -8,6 +8,9 @@ permissions:
 jobs:
   release:
     runs-on: "ubuntu-latest"
+    permissions:
+      pages: write
+      contents: write
     steps:
       - name: "Checkout"
         uses: actions/checkout@v6


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

### 🟠 `permissions-missing` · `release`

**Scopes the `release` job uses but never declares.**

`pages: write` — required by "Run chart-releaser" (L36): github_pages_deploy via helm/chart-releaser-action

Reference: CWE-862 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -8,6 +8,9 @@
 jobs:
   release:
     runs-on: "ubuntu-latest"
+    permissions:
+      pages: write
+      contents: write
     steps:
       - name: "Checkout"
         uses: actions/checkout@v6
```

</details>

---

This commit is signed off per the repository's DCO (Developer Certificate of Origin) policy.

---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
