### PR TITLE
Add overhead-factor to device class for RAID capacity reporting

### DIFF
--- a/internal/lvmd/device_class_manager.go
+++ b/internal/lvmd/device_class_manager.go
@@ -32,6 +32,15 @@ func GetSpare(dc *lvmdTypes.DeviceClass) uint64 {
 	return *dc.SpareGB << 30
 }
 
+// GetOverheadFactor returns the overhead factor for the device-class.
+// Returns 1.0 (no overhead) when not set.
+func GetOverheadFactor(dc *lvmdTypes.DeviceClass) float64 {
+	if dc.OverheadFactor == nil {
+		return 1.0
+	}
+	return *dc.OverheadFactor
+}
+
 // ValidateDeviceClasses validates device-classes
 func ValidateDeviceClasses(deviceClasses []*lvmdTypes.DeviceClass) error {
 	if len(deviceClasses) < 1 {
@@ -95,6 +104,9 @@ func ValidateDeviceClasses(deviceClasses []*lvmdTypes.DeviceClass) error {
 		vgNames[name] = true
 		if dc.StripeSize != "" && !stripeSizeRegexp.MatchString(dc.StripeSize) {
 			return fmt.Errorf("stripe-size format is \"Size[k|UNIT]\": %s", dc.Name)
+		}
+		if dc.OverheadFactor != nil && *dc.OverheadFactor < 1.0 {
+			return fmt.Errorf("overhead-factor for device class %s must be 1.0 or more", dc.Name)
 		}
 	}
 	if countDefault > 1 {

--- a/internal/lvmd/device_class_manager_test.go
+++ b/internal/lvmd/device_class_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	lvmdTypes "github.com/topolvm/topolvm/pkg/lvmd/types"
+	"k8s.io/utils/ptr"
 )
 
 func TestValidateDeviceClasses(t *testing.T) {
@@ -172,6 +173,28 @@ func TestValidateDeviceClasses(t *testing.T) {
 				},
 			},
 			valid: true,
+		},
+		{
+			deviceClasses: []*lvmdTypes.DeviceClass{
+				{
+					Name:           "overhead-valid",
+					VolumeGroup:    "node1-myvg1",
+					Default:        true,
+					OverheadFactor: ptr.To(2.0),
+				},
+			},
+			valid: true,
+		},
+		{
+			deviceClasses: []*lvmdTypes.DeviceClass{
+				{
+					Name:           "overhead-invalid",
+					VolumeGroup:    "node1-myvg1",
+					Default:        true,
+					OverheadFactor: ptr.To(0.5),
+				},
+			},
+			valid: false,
 		},
 		{
 			deviceClasses: []*lvmdTypes.DeviceClass{
@@ -477,5 +500,43 @@ func TestDeviceClassManager(t *testing.T) {
 	_, err = manager.DeviceClass("dev0")
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGetOverheadFactor(t *testing.T) {
+	cases := []struct {
+		name     string
+		dc       *lvmdTypes.DeviceClass
+		expected float64
+	}{
+		{
+			name:     "nil returns 1.0",
+			dc:       &lvmdTypes.DeviceClass{Name: "dc1"},
+			expected: 1.0,
+		},
+		{
+			name:     "set to 2.0",
+			dc:       &lvmdTypes.DeviceClass{Name: "dc2", OverheadFactor: ptr.To(2.0)},
+			expected: 2.0,
+		},
+		{
+			name:     "set to 1.0",
+			dc:       &lvmdTypes.DeviceClass{Name: "dc3", OverheadFactor: ptr.To(1.0)},
+			expected: 1.0,
+		},
+		{
+			name:     "fractional",
+			dc:       &lvmdTypes.DeviceClass{Name: "dc4", OverheadFactor: ptr.To(1.5)},
+			expected: 1.5,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := GetOverheadFactor(c.dc)
+			if got != c.expected {
+				t.Errorf("GetOverheadFactor() = %v, want %v", got, c.expected)
+			}
+		})
 	}
 }

--- a/internal/lvmd/pool.go
+++ b/internal/lvmd/pool.go
@@ -3,6 +3,7 @@ package lvmd
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/topolvm/topolvm/internal/lvmd/command"
 	lvmdTypes "github.com/topolvm/topolvm/pkg/lvmd/types"
@@ -22,7 +23,7 @@ func storagePoolForDeviceClass(ctx context.Context, dc *lvmdTypes.DeviceClass) (
 	}
 	switch dc.Type {
 	case lvmdTypes.TypeThick:
-		return &volumeGroupAdapter{vg}, nil
+		return &volumeGroupAdapter{vg, GetOverheadFactor(dc)}, nil
 	case lvmdTypes.TypeThin:
 		pool, err := vg.FindPool(ctx, dc.ThinPoolConfig.Name)
 		if err != nil {
@@ -50,8 +51,16 @@ func (p *thinPoolAdapter) Free(ctx context.Context) (uint64, error) {
 
 type volumeGroupAdapter struct {
 	*command.VolumeGroup
+	overheadFactor float64
 }
 
 func (vg *volumeGroupAdapter) Free(_ context.Context) (uint64, error) {
-	return vg.VolumeGroup.Free()
+	free, err := vg.VolumeGroup.Free()
+	if err != nil {
+		return 0, err
+	}
+	if vg.overheadFactor > 1.0 {
+		free = uint64(math.Floor(float64(free) / vg.overheadFactor))
+	}
+	return free, nil
 }

--- a/internal/lvmd/vgservice.go
+++ b/internal/lvmd/vgservice.go
@@ -3,6 +3,7 @@ package lvmd
 import (
 	"context"
 	"errors"
+	"math"
 	"sync"
 
 	"github.com/topolvm/topolvm/internal/lvmd/command"
@@ -161,6 +162,11 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 		dc, err := s.dcManager.FindDeviceClassByVGName(vg.Name())
 		if errors.Is(err, ErrDeviceClassNotFound) {
 			continue
+		}
+
+		overheadFactor := GetOverheadFactor(dc)
+		if overheadFactor > 1.0 {
+			vgFree = uint64(math.Floor(float64(vgFree) / overheadFactor))
 		}
 
 		spare := GetSpare(dc)

--- a/pkg/lvmd/types/types.go
+++ b/pkg/lvmd/types/types.go
@@ -34,6 +34,10 @@ type DeviceClass struct {
 	LVCreateOptions []string `json:"lvcreate-options"`
 	// Type is the name of logical volume target, supports 'thick' (default) or 'thin' currently
 	Type DeviceType `json:"type"`
+	// OverheadFactor is a multiplier that accounts for RAID overhead when reporting
+	// available capacity. Reported free space is divided by this factor.
+	// Must be >= 1.0 when set. Defaults to 1.0 (no overhead).
+	OverheadFactor *float64 `json:"overhead-factor,omitempty"`
 	// ThinPoolConfig holds the configuration for thinpool in this volume group corresponding to the device-class
 	ThinPoolConfig *ThinPoolConfig `json:"thin-pool"`
 }


### PR DESCRIPTION
RAID logical volumes consume more raw space than their usable size (e.g., raid1 doubles every write). Without RAID awareness, TopoLVM reports raw VG free space, overstating usable capacity and causing provisioning failures when the scheduler places pods on nodes that cannot actually fulfill the request.

Add an overhead-factor field to the lvmd.yaml device class config. When set, reported available capacity is divided by this factor (available = vg_free / overhead_factor), giving the scheduler an accurate view of usable space. Defaults to 1.0 for backward compatibility.