### PR TITLE
feat(chart): option to preserve CRDs when uninstalling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ define LEGACY_CRD_TEMPLATE
 endef
 export LEGACY_CRD_TEMPLATE
 
+INJECT_CRD_ANNOTATIONS := awk '/controller-gen\.kubebuilder\.io\/version:/{print; print "    {{- with .Values.crd.annotations }}"; print "    {{- toYaml . | nindent 4 }}"; print "    {{- end }}"; next}1'
+
 CONTAINER_STRUCTURE_TEST_IMAGE=$(IMAGE_PREFIX)topolvm:$(IMAGE_TAG)
 ifeq ($(STRUCTURE_TEST_TARGET),with-sidecar)
 CONTAINER_STRUCTURE_TEST_IMAGE=$(IMAGE_PREFIX)topolvm-with-sidecar:$(IMAGE_TAG)
@@ -95,8 +97,8 @@ manifests: generate-legacy-api ## Generate WebhookConfiguration, ClusterRole and
 		webhook \
 		paths="./api/...;./internal/...;./cmd/..." \
 		output:crd:artifacts:config=config/crd/bases
-	cat config/crd/bases/topolvm.io_logicalvolumes.yaml | xargs -d"	" printf "$$CRD_TEMPLATE" > charts/topolvm/templates/crds/topolvm.io_logicalvolumes.yaml
-	cat config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml | xargs -d"	" printf "$$LEGACY_CRD_TEMPLATE" > charts/topolvm/templates/crds/topolvm.cybozu.com_logicalvolumes.yaml
+	cat config/crd/bases/topolvm.io_logicalvolumes.yaml | $(INJECT_CRD_ANNOTATIONS) | xargs -d"	" printf "$$CRD_TEMPLATE" > charts/topolvm/templates/crds/topolvm.io_logicalvolumes.yaml
+	cat config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml | $(INJECT_CRD_ANNOTATIONS) | xargs -d"	" printf "$$LEGACY_CRD_TEMPLATE" > charts/topolvm/templates/crds/topolvm.cybozu.com_logicalvolumes.yaml
 
 .PHONY: generate-api ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 generate-api: 

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -41,6 +41,8 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v17.
 | controller.tolerations | list | `[]` | Specify tolerations. # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | controller.updateStrategy | object | `{}` | Specify updateStrategy. |
 | controller.volumes | list | `[{"emptyDir":{},"name":"socket-dir"}]` | Specify volumes. |
+| crd | object | `{"annotations":{}}` | CRD configuration. |
+| crd.annotations | object | `{}` | Additional annotations to add to CRDs (e.g. {"helm.sh/resource-policy": "keep"}). |
 | env.csi_provisioner | list | `[]` | Specify environment variables for csi_provisioner container. |
 | env.csi_registrar | list | `[]` | Specify environment variables for csi_registrar container. |
 | env.csi_resizer | list | `[]` | Specify environment variables for csi_resizer container. |

--- a/charts/topolvm/templates/crds/topolvm.cybozu.com_logicalvolumes.yaml
+++ b/charts/topolvm/templates/crds/topolvm.cybozu.com_logicalvolumes.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    {{- with .Values.crd.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: logicalvolumes.topolvm.cybozu.com
 spec:
   group: topolvm.cybozu.com

--- a/charts/topolvm/templates/crds/topolvm.io_logicalvolumes.yaml
+++ b/charts/topolvm/templates/crds/topolvm.io_logicalvolumes.yaml
@@ -5,6 +5,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    {{- with .Values.crd.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: logicalvolumes.topolvm.io
 spec:
   group: topolvm.io

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -1,6 +1,11 @@
 # useLegacy -- If true, the legacy plugin name and legacy custom resource group is used(topolvm.cybozu.com).
 useLegacy: false
 
+# crd -- CRD configuration.
+crd:
+  # crd.annotations -- Additional annotations to add to CRDs (e.g. {"helm.sh/resource-policy": "keep"}).
+  annotations: {}
+
 image:
   # image.repository -- TopoLVM image repository to use.
   repository: ghcr.io/topolvm/topolvm-with-sidecar


### PR DESCRIPTION
Currently, uninstalling the Helm chart unconditionally deletes the CRDs. Since deleting the LogicalVolume CRD also deletes all existing LogicalVolume resources, this can lead to catastrophic data loss. I propose adding a values-controlled option to annotate the CRDs with helm.sh/resource-policy: keep, allowing users to preserve CRDs across chart uninstalls.

Cheers, Alexey