### PR TITLE
add csi-provisoner metric scraping and extraArgs to containers

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -49,6 +49,9 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v17.
 | env.topolvm_controller | list | `[]` | Specify environment variables for topolvm_controller container. |
 | env.topolvm_node | list | `[]` | Specify environment variables for topolvm_node container. |
 | env.topolvm_scheduler | list | `[]` | Specify environment variables for topolvm_scheduler container. |
+| extraArgs.csi_provisioner | list | `[]` | Specify extra arguments for csi_provisioner container. |
+| extraArgs.csi_resizer | list | `[]` | Specify extra arguments for csi_resizer container. |
+| extraArgs.csi_snapshotter | list | `[]` | Specify extra arguments for csi_snapshotter container. |
 | image.csi.csiProvisioner | string | `nil` | Specify csi-provisioner image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.reference }}` will be used. |
 | image.csi.csiResizer | string | `nil` | Specify csi-resizer image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.reference }}` will be used. |
 | image.csi.csiSnapshotter | string | `nil` | Specify csi-snapshot image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.reference }}` will be used. |

--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -49,9 +49,9 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v17.
 | env.topolvm_controller | list | `[]` | Specify environment variables for topolvm_controller container. |
 | env.topolvm_node | list | `[]` | Specify environment variables for topolvm_node container. |
 | env.topolvm_scheduler | list | `[]` | Specify environment variables for topolvm_scheduler container. |
-| extraArgs.csi_provisioner | list | `[]` | Specify extra arguments for csi_provisioner container. |
-| extraArgs.csi_resizer | list | `[]` | Specify extra arguments for csi_resizer container. |
-| extraArgs.csi_snapshotter | list | `[]` | Specify extra arguments for csi_snapshotter container. |
+| extraArgs.csi_provisioner | list | `[]` | Additional arguments for the csi-provisioner container. |
+| extraArgs.csi_resizer | list | `[]` | Additional arguments for the csi-resizer container. |
+| extraArgs.csi_snapshotter | list | `[]` | Additional arguments for the csi-snapshotter container. |
 | image.csi.csiProvisioner | string | `nil` | Specify csi-provisioner image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.reference }}` will be used. |
 | image.csi.csiResizer | string | `nil` | Specify csi-resizer image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.reference }}` will be used. |
 | image.csi.csiSnapshotter | string | `nil` | Specify csi-snapshot image. If not specified, `ghcr.io/topolvm/topolvm-with-sidecar:{{ .Values.image.reference }}` will be used. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -166,6 +166,9 @@ spec:
             - --enable-capacity
             - --capacity-ownerref-level=2
             {{- end }}
+            {{- with .Values.extraArgs.csi_provisioner }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 9809
               name: csi-provisioner
@@ -212,6 +215,9 @@ spec:
             - --leader-election-namespace={{ .Release.Namespace }}
             {{- end }}
             - --http-endpoint=:9810
+            {{- with .Values.extraArgs.csi_resizer }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 9810
               name: csi-resizer
@@ -248,6 +254,9 @@ spec:
             - --leader-election-namespace={{ .Release.Namespace }}
             {{- end }}
             - --http-endpoint=:9811
+            {{- with .Values.extraArgs.csi_snapshotter }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 9811
               name: csi-snapshotter

--- a/charts/topolvm/templates/controller/podmonitor.yaml
+++ b/charts/topolvm/templates/controller/podmonitor.yaml
@@ -34,4 +34,20 @@ spec:
     metricRelabelings:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  - path: /metrics
+    port: csi-provisioner
+    {{- with .Values.controller.prometheus.podMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.controller.prometheus.podMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.controller.prometheus.podMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.controller.prometheus.podMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -653,6 +653,14 @@ env:
   # env.topolvm_scheduler -- Specify environment variables for topolvm_scheduler container.
   topolvm_scheduler: []
 
+extraArgs:
+  # extraArgs.csi_provisioner -- Additional arguments for the csi-provisioner container.
+  csi_provisioner: []
+  # extraArgs.csi_resizer -- Additional arguments for the csi-resizer container.
+  csi_resizer: []
+  # extraArgs.csi_snapshotter -- Additional arguments for the csi-snapshotter container.
+  csi_snapshotter: []
+
 livenessProbe:
   # livenessProbe.topolvm_node -- Specify resources.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/


### PR DESCRIPTION
This PR adds additional csi-provisioner metric to the PodMonitor, as well as exposing `extraArgs` to the csi containers to allow configuration.  This helps resolve the issue with large k8s clusters here: https://github.com/topolvm/topolvm/issues/1201