### PR TITLE
feat(chart): add podAnnotations for controller and node pods

### DIFF
--- a/charts/topolvm/README.md
+++ b/charts/topolvm/README.md
@@ -23,6 +23,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v17.
 | controller.minReadySeconds | int | `nil` | Specify minReadySeconds. |
 | controller.nodeFinalize.skipped | bool | `false` | Skip automatic cleanup of PhysicalVolumeClaims when a Node is deleted. |
 | controller.nodeSelector | object | `{}` | Specify nodeSelector. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| controller.podAnnotations | object | `{}` | Annotations to be set on the controller pod. |
 | controller.podDisruptionBudget.enabled | bool | `true` | Specify podDisruptionBudget enabled. |
 | controller.podLabels | object | `{}` | Additional labels to be set on the controller pod. |
 | controller.priorityClassName | string | `nil` | Specify priorityClassName. |
@@ -106,6 +107,7 @@ See [Getting Started](https://github.com/topolvm/topolvm/blob/topolvm-chart-v17.
 | node.metrics.annotations | object | `{"prometheus.io/port":"metrics"}` | Annotations for Scrape used by Prometheus. |
 | node.metrics.enabled | bool | `true` | If true, enable scraping of metrics by Prometheus. |
 | node.nodeSelector | object | `{}` | Specify nodeSelector. # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| node.podAnnotations | object | `{}` | Annotations to be set on the node pods, merged with `node.metrics.annotations` and takes precedence over it. |
 | node.podLabels | object | `{}` | Additional labels to be set on the node pods. |
 | node.podSecurityContext | object | `{}` | Pod securityContext. # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | node.priorityClassName | string | `nil` | Specify priorityClassName. |

--- a/charts/topolvm/templates/controller/deployment.yaml
+++ b/charts/topolvm/templates/controller/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         {{- with .Values.controller.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.controller.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}

--- a/charts/topolvm/templates/node/daemonset.yaml
+++ b/charts/topolvm/templates/node/daemonset.yaml
@@ -24,8 +24,13 @@ spec:
         {{- with .Values.node.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- $annotations := merge (dict) (.Values.node.podAnnotations | default dict) }}
       {{- if and .Values.node.metrics.enabled .Values.node.metrics.annotations }}
-      annotations: {{ toYaml .Values.node.metrics.annotations | nindent 8 }}
+      {{- $annotations = merge $annotations .Values.node.metrics.annotations }}
+      {{- end }}
+      {{- with $annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       {{- with .Values.node.priorityClassName }}

--- a/charts/topolvm/values.yaml
+++ b/charts/topolvm/values.yaml
@@ -407,6 +407,9 @@ node:
   #    maxSurge: 50%
   #    maxUnavailable: 50%
 
+  # node.podAnnotations -- Annotations to be set on the node pods, merged with `node.metrics.annotations` and takes precedence over it.
+  podAnnotations: {}
+
   # node.podLabels -- Additional labels to be set on the node pods.
   podLabels: {}
   # node.labels -- Additional labels to be added to the Daemonset.
@@ -533,6 +536,9 @@ controller:
   podDisruptionBudget:
     # controller.podDisruptionBudget.enabled -- Specify podDisruptionBudget enabled.
     enabled: true
+
+  # controller.podAnnotations -- Annotations to be set on the controller pod.
+  podAnnotations: {}
 
   # controller.podLabels -- Additional labels to be set on the controller pod.
   podLabels: {}


### PR DESCRIPTION
The controller and node pod templates only exposed podLabels, so there was no way to set pod annotations such as fluentbit.io/parser_<container> to select a log parser. The topolvm-controller and topolvm-node containers log JSON, but the CSI sidecars (csi-provisioner, csi-resizer, csi-snapshotter, csi-registrar, liveness-probe) emit klog, which a log collector cannot structure without a per-container parser annotation.

Add controller.podAnnotations and node.podAnnotations. On the node DaemonSet they merge with the existing metrics annotations rather than replacing them. Both default to {} and render no annotations block when unset.