### PR TITLE
Bump CSI sidecars to clear CVE-2026-33186 (grpc < 1.79.3)

### DIFF
--- a/charts/topolvm/templates/controller/clusterroles.yaml
+++ b/charts/topolvm/templates/controller/clusterroles.yaml
@@ -90,11 +90,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  # The "watch" and "update" verbs for volumesnapshots are optional but recommended.
-  # They enable finalizer-based protection to prevent snapshots from being deleted
-  # during provisioning. Without these permissions, the provisioner will still function
-  # but snapshot protection will be unavailable. This makes the provisioner backwards
-  # compatible with older RBAC configurations.
+  # The "watch", "update", and "list" verbs for volumesnapshots are optional but
+  # recommended. They enable finalizer-based protection to prevent snapshots from
+  # being deleted during provisioning, and allow periodic sweeps to clean up
+  # orphaned finalizers. Without these permissions, the provisioner will still
+  # function but snapshot protection will be unavailable. This makes the
+  # provisioner backwards compatible with older RBAC configurations.
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list", "watch", "update"]

--- a/versions.mk
+++ b/versions.mk
@@ -54,15 +54,15 @@ ENVTEST_KUBERNETES_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f
 
 # CSI sidecar versions
 # https://github.com/kubernetes-csi/external-provisioner/releases
-EXTERNAL_PROVISIONER_VERSION := 6.2.0
+EXTERNAL_PROVISIONER_VERSION := 6.3.0
 # https://github.com/kubernetes-csi/external-resizer/releases
-EXTERNAL_RESIZER_VERSION := 2.1.0
+EXTERNAL_RESIZER_VERSION := 2.2.1
 # https://github.com/kubernetes-csi/external-snapshotter/releases
-EXTERNAL_SNAPSHOTTER_VERSION := 8.5.0
+EXTERNAL_SNAPSHOTTER_VERSION := 8.6.0
 # https://github.com/kubernetes-csi/livenessprobe/releases
-LIVENESSPROBE_VERSION := 2.18.0
+LIVENESSPROBE_VERSION := 2.19.0
 # https://github.com/kubernetes-csi/node-driver-registrar/releases
-NODE_DRIVER_REGISTRAR_VERSION := 2.16.0
+NODE_DRIVER_REGISTRAR_VERSION := 2.17.0
 
 # The container version of kind must be with the digest.
 # ref. https://github.com/kubernetes-sigs/kind/releases


### PR DESCRIPTION
:wave: team, our CI is flagging **CVE-2026-33186** (Critical) in the CSI sidecars baked into `topolvm-with-sidecar`. It’s `google.golang.org/grpc` < 1.79.3; `/hypertopolvm` is already fine on main, but the sidecar pins in `versions.mk` are still on older releases.

This PR bumps those sidecars to current upstream versions that ship a fixed grpc 🙇 

## Summary

| Sidecar | From | To | grpc |
|---|---|---|---|
| external-provisioner | 6.2.0 | 6.3.0 | 1.81.1 |
| external-resizer | 2.1.0 | 2.2.1 | 1.79.3 |
| external-snapshotter | 8.5.0 | 8.6.0 | 1.81.1 |
| livenessprobe | 2.18.0 | 2.19.0 | 1.81.1 |
| node-driver-registrar | 2.16.0 | 2.17.0 | 1.81.1 |

RBAC: provisioner v6.3.0 only updates the volumesnapshots comment (verbs already include `list`). Chart comment aligned accordingly.

`external-snapshotter/client` left at `v8.4.0`. Bumping to `v8.6.0` pulls Go 1.26 / k8s 0.36; same lag as when the sidecar was 8.5.0 with client 8.4.0.